### PR TITLE
Move markdown processing from runtime to build-time

### DIFF
--- a/About.md
+++ b/About.md
@@ -115,8 +115,9 @@ Third-party names, logos, and descriptions are used with permission from their o
 
 This application uses the following open-source libraries and fonts:
 
-- [Marked](https://github.com/markedjs/marked) (MIT License)—Markdown parser
-- [DOMPurify](https://github.com/cure53/DOMPurify) (Apache 2.0 / MPL 2.0)—HTML sanitizer
+- [Marked](https://github.com/markedjs/marked) (MIT License)—Markdown parser for build-time content processing
+- [jsdom](https://github.com/jsdom/jsdom) (MIT License)—DOM implementation for build-time HTML manipulation
+- [DOMPurify](https://github.com/cure53/DOMPurify) (Apache 2.0 / MPL 2.0)—Runtime HTML sanitizer
 - [Vite](https://vitejs.dev) (MIT License)—Build tool
 - [vite-plugin-pwa](https://vite-pwa-org.netlify.app) (MIT License)—Progressive Web App capability
 - [mimetext](https://github.com/muratgozel/MIMEText) (MIT License)—Email message builder

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -7,13 +7,14 @@ This document contains the full license texts for all third-party open-source li
 ## Table of Contents
 
 1. [Marked](#marked) - MIT License
-2. [DOMPurify](#dompurify) - Apache 2.0 / MPL 2.0 (dual-licensed)
-3. [Vite](#vite) - MIT License
-4. [vite-plugin-pwa](#vite-plugin-pwa) - MIT License
-5. [mimetext](#mimetext) - MIT License
-6. [Montserrat Alternates Font](#montserrat-alternates-font) - SIL Open Font License 1.1
-7. [OpenDyslexic Font](#opendyslexic-font) - SIL Open Font License 1.1
-8. [Poison Oak Images](#poison-oak-images) - CC BY 2.0, CC BY-SA 4.0, CC0 1.0
+2. [jsdom](#jsdom) - MIT License
+3. [DOMPurify](#dompurify) - Apache 2.0 / MPL 2.0 (dual-licensed)
+4. [Vite](#vite) - MIT License
+5. [vite-plugin-pwa](#vite-plugin-pwa) - MIT License
+6. [mimetext](#mimetext) - MIT License
+7. [Montserrat Alternates Font](#montserrat-alternates-font) - SIL Open Font License 1.1
+8. [OpenDyslexic Font](#opendyslexic-font) - SIL Open Font License 1.1
+9. [Poison Oak Images](#poison-oak-images) - CC BY 2.0, CC BY-SA 4.0, CC0 1.0
 
 ---
 
@@ -45,6 +46,38 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+---
+
+## jsdom
+
+**Homepage:** [https://github.com/jsdom/jsdom](https://github.com/jsdom/jsdom)
+**Repository:** [https://github.com/jsdom/jsdom](https://github.com/jsdom/jsdom)
+**License:** MIT
+
+```plaintext
+MIT License
+
+Copyright (c) 2010-2024 Elijah Insua and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ---

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "html-validate": "^10.4.0",
+        "jsdom": "^25.0.1",
         "sharp": "^0.34.5",
         "vite": "^6.0.5",
         "vite-plugin-pwa": "^0.21.1"
@@ -36,6 +37,27 @@
       "peerDependencies": {
         "ajv": ">=8"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1561,6 +1583,121 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
@@ -3049,6 +3186,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -3147,6 +3294,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -3375,6 +3529,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3436,6 +3603,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3510,6 +3712,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3554,6 +3763,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -3626,6 +3845,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -3937,6 +4169,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -4235,6 +4484,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-validate": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-10.4.0.tgz",
@@ -4295,6 +4557,47 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/idb": {
@@ -4560,6 +4863,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4783,6 +5093,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4922,6 +5273,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4988,6 +5362,13 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5059,6 +5440,19 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -5191,6 +5585,16 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5382,6 +5786,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -5456,6 +5867,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -5993,6 +6424,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6056,6 +6494,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -6389,6 +6873,66 @@
         "@vite-pwa/assets-generator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6912,6 +7456,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -6,22 +6,24 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run lint:markdown && npm run extract-map-data && vite build && npm run validate:all",
-    "build:novalidate": "npm run extract-map-data && vite build",
+    "build": "npm run lint:markdown && npm run extract-map-data && npm run preprocess && vite build && npm run validate:all",
+    "build:novalidate": "npm run extract-map-data && npm run preprocess && vite build",
     "preview": "vite preview",
     "validate": "html-validate index.html",
     "validate:dist": "html-validate dist/index.html",
     "validate:all": "node scripts/validate-html.js",
     "generate-icons": "node create-maskable-icons.js",
     "extract-map-data": "node scripts/extract-map-data.js",
+    "preprocess": "node scripts/preprocess-content.js",
     "lint:markdown": "cd .. && npm install --silent && npm run lint:sources"
   },
   "dependencies": {
-    "dompurify": "^3.2.2",
-    "marked": "^14.1.3"
+    "dompurify": "^3.2.2"
   },
   "devDependencies": {
     "html-validate": "^10.4.0",
+    "jsdom": "^25.0.1",
+    "marked": "^14.1.3",
     "sharp": "^0.34.5",
     "vite": "^6.0.5",
     "vite-plugin-pwa": "^0.21.1"

--- a/web-app/public/processed/about.html
+++ b/web-app/public/processed/about.html
@@ -1,0 +1,172 @@
+<h1><span>About This Guide</span></h1>
+<p>This resource guide helps people experiencing homelessness in San Luis Obispo County find services and support.
+It uses colors and icons to help you quickly know what kind of link or button you’re seeing:</p>
+<h2><span>Link Types</span></h2>
+<table>
+<thead>
+<tr>
+<th>Link Type</th>
+<th>What It Looks Like</th>
+<th>What It Does When You Click</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Link Type"><strong>Directory Link</strong></td>
+<td data-label="What It Looks Like"><a href="#" data-directory-link="example">Agency Name</a></td>
+<td data-label="What It Does When You Click">Opens detailed information about an agency in a popup window</td>
+</tr>
+<tr>
+<td data-label="Link Type"><strong>Map Link</strong></td>
+<td data-label="What It Looks Like"><a href="" class="map-link">123 Main St.</a></td>
+<td data-label="What It Does When You Click">Opens the location in your map app</td>
+</tr>
+<tr>
+<td data-label="Link Type"><strong>Phone Link</strong></td>
+<td data-label="What It Looks Like"><a href="tel:+1-805-555-0123" aria-label="Call 805-555-0123">805-555-0123</a></td>
+<td data-label="What It Does When You Click">Calls the phone number</td>
+</tr>
+<tr>
+<td data-label="Link Type"><strong>Email Link</strong></td>
+<td data-label="What It Looks Like"><a href="mailto:contact@example.org" aria-label="Email contact@example.org">contact@example.org</a></td>
+<td data-label="What It Does When You Click">Opens your email to send a message</td>
+</tr>
+<tr>
+<td data-label="Link Type"><strong>SMS/Text Link</strong></td>
+<td data-label="What It Looks Like"><a href="sms:+1-805-555-0123">805-555-0123</a></td>
+<td data-label="What It Does When You Click">Opens your text messaging app</td>
+</tr>
+<tr>
+<td data-label="Link Type"><strong>External Link</strong></td>
+<td data-label="What It Looks Like"><a href="https://example.com" data-external-link="true">Example Website</a></td>
+<td data-label="What It Does When You Click">Opens a website in a new tab</td>
+</tr>
+</tbody></table>
+<h2><span>Buttons and Features</span></h2>
+<table>
+<thead>
+<tr>
+<th>Feature</th>
+<th>What It Looks Like</th>
+<th>What It Does When You Click</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Feature"><strong>Navigation</strong></td>
+<td data-label="What It Looks Like"><span style="font-family: 'Montserrat Alternates', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"><span style="color: var(--primary-color);"><strong>Resources</strong></span> / <span style="color: var(--primary-color);"><strong>Directory</strong></span> / <span style="color: var(--primary-color);"><strong>About</strong></span></span></td>
+<td data-label="What It Does When You Click">Switches between the main sections of this guide</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Search</strong></td>
+<td data-label="What It Looks Like"><span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif; border: 1px solid var(--primary-color); border-radius: 5px; padding: 0.25rem;">Search…   </span></td>
+<td data-label="What It Does When You Click">Searches for specific topics, agencies, or services</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Table of Contents</strong></td>
+<td data-label="What It Looks Like"><span style="display:inline-flex;align-items:center;justify-content:center;width:50px;height:50px;border-radius:50%;background-color:#1a62ff;color:white;font-size:24px;text-shadow:0 0 3px rgba(255, 255, 255, 0.9), 0 0 6px rgba(255, 255, 255, 0.7), 0 0 9px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.8), 1px 1px 2px rgba(0, 0, 0, 0.6);">📖</span></td>
+<td data-label="What It Does When You Click">Returns to the Table of Contents when browsing the Resource Guide</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Feedback</strong></td>
+<td data-label="What It Looks Like"><span style="display:inline-flex;align-items:center;justify-content:center;width:50px;height:50px;border-radius:50%;background-color:#5a93ff;color:white;font-size:24px;">💬</span></td>
+<td data-label="What It Does When You Click">Sends feedback about errors or suggestions for improvement</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Share</strong></td>
+<td data-label="What It Looks Like"><span style="display:inline-flex;align-items:center;justify-content:center;width:50px;height:50px;border-radius:50%;background-color:#c65010;color:white;font-size:24px;text-shadow:0 0 4px rgba(0, 0, 0, 0.5), 0 0 8px rgba(0, 0, 0, 0.4), 0 0 12px rgba(0, 0, 0, 0.3), 1px 1px 3px rgba(0, 0, 0, 0.4), -1px -1px 3px rgba(0, 0, 0, 0.4);">🔗</span></td>
+<td data-label="What It Does When You Click">Shares a link to this resource guide</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Section Share</strong></td>
+<td data-label="What It Looks Like"><span style="display:inline-flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:50%;background-color:rgba(198,80,16,0.1);border:1px solid #c65010;font-size:14px;">🔗</span> <b>Section Heading</b></td>
+<td data-label="What It Does When You Click">Shares a link to a specific section or subsection</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Text Size</strong></td>
+<td data-label="What It Looks Like"><span style="display:inline-flex;align-items:center;justify-content:center;width:50px;height:50px;border-radius:50%;background-color:#1a62ff;color:white;font-weight:bold;font-family:serif;"><span style="font-size:20px;">A</span><span style="font-size:14px;">A</span></span></td>
+<td data-label="What It Does When You Click">Allows you to adjust text size or to select a dyslexia-friendly font, for easier reading.</td>
+</tr>
+<tr>
+<td data-label="Feature"><strong>Install App</strong></td>
+<td data-label="What It Looks Like"><span style="display:inline-flex;align-items:center;justify-content:center;width:50px;height:50px;border-radius:50%;background-color:#1a62ff;color:white;"><svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M12 16L12 4M12 16L8 12M12 16L16 12" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M4 17V19C4 20 5 21 6 21H18C19 21 20 20 20 19V17" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span></td>
+<td data-label="What It Does When You Click">Installs this guide as an app on your device for quick access (appears only if installation is available)</td>
+</tr>
+</tbody></table>
+<hr>
+<h2><span>About This Project</span></h2>
+<p>This guide is a project of <a href="https://showerthepeopleslo.org/" data-external-link="true">Shower the People</a>, a nonprofit organization serving people experiencing homelessness in San Luis Obispo County.</p>
+<p><em>Special thanks to Laurel Woodson &amp; Mark Grayson for the funding that kick-started this project.</em></p>
+<hr>
+<h2><span>How to Install This App on Your Device</span></h2>
+<p>You can install this resource guide as an app on your phone, tablet, or computer for quick access—even when you’re offline.</p>
+<h3><span>If You See the Install Button</span></h3>
+<p>If you see an “Install App” button (as shown in the table above) in the bottom-right corner of the screen, just tap it!
+The button appears when your browser supports direct installation.</p>
+<h3><span>iPhone or iPad (Safari)</span></h3>
+<ol>
+<li>Open this page in Safari (the default web browser)</li>
+<li>Tap the share button (the square with an up arrow) at the bottom of the screen</li>
+<li>Scroll down and tap <strong>Add to Home Screen</strong></li>
+<li>Tap <strong>Add</strong> in the top right corner</li>
+</ol>
+<p><em>Note: On iPhone/iPad you must use Safari for this feature to work. Other browsers like Chrome or Firefox do not support installing web apps on iOS.</em></p>
+<h3><span>Android (Chrome)</span></h3>
+<ol>
+<li>Tap the menu button (<strong>⋮</strong>) in the top right corner</li>
+<li>Tap <strong>Add to Home screen</strong> or <strong>Install app</strong></li>
+<li>Tap <strong>Install</strong> to confirm</li>
+</ol>
+<h3><span>Android (Firefox)</span></h3>
+<ol>
+<li>Tap the menu button (<strong>⋮</strong>)</li>
+<li>Tap <strong>Install</strong> or <strong>Add to Home screen</strong></li>
+</ol>
+<h3><span>Android (Samsung Internet)</span></h3>
+<ol>
+<li>Tap the menu button (<strong>☰</strong>) at the bottom</li>
+<li>Tap <strong>Add page to</strong> then <strong>Home screen</strong></li>
+</ol>
+<h3><span>Windows, Mac, or Linux (Chrome, Edge, or Brave)</span></h3>
+<ol>
+<li>Look for an install icon in the address bar (a monitor with a down arrow), or</li>
+<li>Click the browser menu (<strong>⋮</strong> in Chrome/Brave, or <strong>⋯</strong> in Edge) and look for <strong>Install…</strong></li>
+<li>Click <strong>Install</strong> to confirm</li>
+</ol>
+<h3><span>Firefox on Desktop</span></h3>
+<p>Firefox on desktop computers does not currently support installing web apps.
+You can bookmark this page for quick access: press <kbd>Ctrl</kbd>+<kbd>D</kbd> (Windows/Linux) or <kbd>Cmd</kbd>+<kbd>D</kbd> / <kbd>⌘</kbd>+<kbd>D</kbd> (Mac).</p>
+<h3><span>Mac (Safari)</span></h3>
+<p>From the menu bar, select <strong>File → Add to Dock</strong>, or bookmark this page with <kbd>Cmd</kbd>+<kbd>D</kbd> or <kbd>⌘</kbd>+<kbd>D</kbd>.</p>
+<hr>
+<h2><span>How to Report Errors or Suggest Improvements</span></h2>
+<p>VivaSLO tries to be as accurate and helpful as possible.
+If you find outdated information, errors, or want to suggest improvements:</p>
+<ul>
+<li>Click the feedback button (💬) in the bottom-right corner of the screen</li>
+<li>Complete the feedback form with details about the issue or suggestion</li>
+<li>Click “Send Feedback” to submit your message</li>
+</ul>
+<p>Your feedback helps keep this resource current and useful for everyone.</p>
+<hr>
+<h2><span>Disclaimer</span></h2>
+<p>Information is provided for reference only.
+Shower the People does not endorse or guarantee any organization or service listed.
+Details may change at any time.
+You should confirm current information directly with each provider.
+Third-party names, logos, and descriptions are used with permission from their owners.</p>
+<hr>
+<h2><span>Open-Source Libraries and Fonts</span></h2>
+<p>This application uses the following open-source libraries and fonts:</p>
+<ul>
+<li><a href="https://github.com/markedjs/marked" data-external-link="true">Marked</a> (MIT License)—Markdown parser</li>
+<li><a href="https://github.com/cure53/DOMPurify" data-external-link="true">DOMPurify</a> (Apache 2.0 / MPL 2.0)—HTML sanitizer</li>
+<li><a href="https://vitejs.dev" data-external-link="true">Vite</a> (MIT License)—Build tool</li>
+<li><a href="https://vite-pwa-org.netlify.app" data-external-link="true">vite-plugin-pwa</a> (MIT License)—Progressive Web App capability</li>
+<li><a href="https://github.com/muratgozel/MIMEText" data-external-link="true">mimetext</a> (MIT License)—Email message builder</li>
+<li><a href="https://fonts.google.com/specimen/Montserrat+Alternates" data-external-link="true">Montserrat Alternates</a> (SIL Open Font License 1.1)—Display font</li>
+<li><a href="https://opendyslexic.org/" data-external-link="true">OpenDyslexic</a> (SIL Open Font License 1.1)—Accessibility font option</li>
+</ul>
+<p>Full license texts available in <a href="https://github.com/davgross/homeless-in-slo-resource-guide/blob/main/THIRD_PARTY_LICENSES.md" data-external-link="true">THIRD_PARTY_LICENSES.md</a>.</p>
+<hr>
+<h2><span>Copyright</span></h2>
+<p>© 2025 Shower the People. All rights reserved.</p>
+<p class="last-updated">Last updated: <span id="last-update-date"></span></p>

--- a/web-app/public/processed/directory-entries.json
+++ b/web-app/public/processed/directory-entries.json
@@ -1,0 +1,2255 @@
+{
+  "40-Prado": {
+    "title": "40 Prado Homeless Services Center",
+    "content": "<h2><span>40 Prado Homeless Services Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/40-prado/\" data-external-link=\"true\">capslo.org/40-prado</a></li>\n<li><strong>Location:</strong> 40 Prado Road, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.256218\" data-lon=\"-120.672031\" data-zoom=\"17\" data-label=\"40 Prado Homeless Services Center\">Map</a></li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-544-4004;ext=2\" aria-label=\"Call 805-544-4004 x2\">805-544-4004 x2</a> (general services) </li>\n<li><a href=\"tel:+1-805-544-4004;ext=100\" aria-label=\"Call 805-544-4004 x100\">805-544-4004 x100</a> (more information)</li>\n<li><a href=\"tel:+1-805-459-1073\" aria-label=\"Call 805-459-1073\">805-459-1073</a> (questions about on-site safe parking)</li>\n</ul>\n</li>\n<li><strong>Hours:</strong> every day, 8am–2:30pm and 4:30pm–7am (closed 2:30pm–4:30pm and 7–8am) <ul>\n<li>Overnight shelter intake: M–Th 9am–2pm, Fridays by appointment only  (Intake is a one-time registration process where you provide personal information, complete paperwork, and get added to the shelter system)</li>\n<li>Laundry services: 8am–2:30pm</li>\n<li>Day services: 8am–4pm </li>\n<li>Breakfast: before 9am </li>\n<li>Lunch: Noon–12:30pm (open to all) </li>\n<li>Overnight shelter check-in: daily, 4:30–6pm (Check-in is done each day you want a bed; you must arrive during check-in hours to secure a spot for that night)</li>\n<li>Dinner: 5–5:30pm (overnight shelter and cooling center residents only)</li>\n<li>Warming Center: 7pm–8am (only when warming center is in operation) </li>\n<li>Cooling Center: 8am–6pm (only when cooling center is in operation) </li>\n<li>Safe Parking: 6pm–7pm </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> come to the shelter during intake hours<ul>\n<li>To use the shelter, you must be homeless, you must have a valid photo ID, and you must not have a P.C. 290 sex offender criminal record. You must be able to care for yourself independently (bathing, feeding, dressing, etc.). There are a limited number of beds; priority is given to SLO county residents.</li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>operates <a href=\"#\" data-directory-link=\"Rotating-Overnight-Safe-Parking-Program\" aria-label=\"View directory entry for Rotating Overnight Safe Parking Program\"><strong>Rotating Overnight Safe Parking Program</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"SLO-Hub\" aria-label=\"View directory entry for SLO Hub\"><strong>SLO Hub</strong></a> </li>\n<li>operates the “Mid County Warming and Cooling Center” </li>\n<li>operates the “40 Prado Safe Parking Program” </li>\n<li><a href=\"#\" data-directory-link=\"HCHP\" aria-label=\"View directory entry for Healthcare for the Homeless Program\"><strong>Healthcare for the Homeless Program</strong></a> takes place at 40 Prado</li>\n<li><a href=\"#\" data-directory-link=\"Peoples-Kitchen-SLO\" aria-label=\"View directory entry for People’s Kitchen\"><strong>People’s Kitchen</strong></a> takes place at 43 Prado </li>\n<li><a href=\"#\" data-directory-link=\"Recuperative-Care-Program\" aria-label=\"View directory entry for Recuperative Care Program\"><strong>Recuperative Care Program</strong></a> takes place at 40 Prado </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "40 Prado Homeless Services Center"
+    ]
+  },
+  "5CHC": {
+    "title": "5Cities Homeless Coalition (5CHC)",
+    "content": "<h2><span>5Cities Homeless Coalition (5CHC)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://5chc.org/\" data-external-link=\"true\">5chc.org</a></li>\n<li><strong>Location:</strong> 100 South 4th St., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.1212032\" data-lon=\"-120.6267386\" data-zoom=\"17\" data-label=\"5Cities Homeless Coalition\">Map</a> <ul>\n<li>Warming Center: 1023 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.118597\" data-lon=\"-120.594462\" data-zoom=\"17\" data-label=\"5Cities Homeless Coalition Warming Center\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-574-1638\" aria-label=\"Call 805-574-1638\">805-574-1638</a> </li>\n<li><a href=\"tel:+1-805-202-3615\" aria-label=\"Call 805-202-3615\">805-202-3615</a> (warming center hotline) </li>\n<li><a href=\"tel:+1-805-295-1501\" aria-label=\"Call 805-295-1501\">805-295-1501</a> (warming center) </li>\n<li><a href=\"sms:+1-805-295-1501?&amp;body=Add%20Me\">805-295-1501</a> (warming center automatic text updates) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@5chc.org\" aria-label=\"Email info@5chc.org\">info@5chc.org</a> <ul>\n<li><a href=\"mailto:shelter@5chc.org\" aria-label=\"Email shelter@5chc.org\">shelter@5chc.org</a> (warming center) </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>operates <a href=\"#\" data-directory-link=\"Cabins-for-Change\" aria-label=\"View directory entry for Cabins for Change\"><strong>Cabins for Change</strong></a> and “Balay Ko on Barka” a.k.a. “My Home for Hope”</li>\n<li>operates <a href=\"#\" data-directory-link=\"Supportive-Services-for-Veteran-Families\" aria-label=\"View directory entry for Supportive Services for Veteran Families\"><strong>Supportive Services for Veteran Families</strong></a></li>\n<li>operates “Homeless Youth Outreach”</li>\n<li>hosts the “Pet Resource Center” of <a href=\"#\" data-directory-link=\"C.A.R.E.4Paws\" aria-label=\"View directory entry for C.A.R.E.4Paws\"><strong>C.A.R.E.4Paws</strong></a> </li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "5Cities Homeless Coalition (5CHC)",
+      "“My Home for Hope”"
+    ]
+  },
+  "805-Street-Outreach": {
+    "title": "805 Street Outreach",
+    "content": "<h2><span>805 Street Outreach</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://805streetoutreach.org/\" data-external-link=\"true\">805streetoutreach.org</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:izzy@805streetoutreach.org\" aria-label=\"Email izzy@805streetoutreach.org\">izzy@805streetoutreach.org</a> </li>\n<li>Shower program:<ul>\n<li><strong>Location:</strong> Morro Bay Public Library parking lot, 625 Harbor St., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.3671654\" data-lon=\"-120.8462354\" data-zoom=\"17\" data-label=\"Morro Bay Public Library (805 Street Outreach)\">Map</a> </li>\n<li><strong>Hours:</strong> Every Monday, 12pm–3pm </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "805 Street Outreach"
+    ]
+  },
+  "Abundance-Shop": {
+    "title": "Abundance Shop",
+    "content": "<h2><span>Abundance Shop</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.stbenslososos.org/abundance-shop/\" data-external-link=\"true\">stbenslososos.org/abundance-shop</a></li>\n<li><strong>Location:</strong> 2025 9th St., Los Osos <a href=\"#\" class=\"map-link\" data-lat=\"35.3144169\" data-lon=\"-120.8335942\" data-zoom=\"17\" data-label=\"Abundance Shop\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-528-1370\" aria-label=\"Call 805-528-1370\">805-528-1370</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:office@stbenslososos.org\" aria-label=\"Email office@stbenslososos.org\">office@stbenslososos.org</a></li>\n<li><strong>Hours:</strong> Th–Sa 11am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Abundance Shop"
+    ]
+  },
+  "AARP-Tax-Aide": {
+    "title": "AARP Tax-Aide Program (Central Coast Tax-Aide)",
+    "content": "<h2><span>AARP Tax-Aide Program (Central Coast Tax-Aide)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ccfreetax.org/\" data-external-link=\"true\">ccfreetax.org</a></li>\n<li><strong>Location:</strong> Various locations, see <a href=\"https://www.ccfreetax.org/appointment.html\" data-external-link=\"true\">Appointments</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-931-6308\" aria-label=\"Call 805-931-6308\">805-931-6308</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@ccfreetax.org\" aria-label=\"Email info@ccfreetax.org\">info@ccfreetax.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "AARP Tax-Aide Program (Central Coast Tax-Aide)"
+    ]
+  },
+  "Access-Central-Coast": {
+    "title": "Access Central Coast",
+    "content": "<h2><span>Access Central Coast</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"CCADRC\" aria-label=\"View directory entry for Central Coast Aging &amp; Disability Resource Center\"><strong>Central Coast Aging &amp; Disability Resource Center</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://accesscentralcoast.org/\" data-external-link=\"true\">accesscentralcoast.org</a></li>\n<li><strong>Location:</strong> 51 Zaca Ln. #140, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.2508747\" data-lon=\"-120.6726201\" data-zoom=\"17\" data-label=\"Access Central Coast\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-462-1162\" aria-label=\"Call 805-462-1162\">805-462-1162</a> (videophone: <a href=\"tel:+1-805-464-3203\" aria-label=\"Call 805-464-3203\">805-464-3203</a>) </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@accesscentralcoast.org\" aria-label=\"Email info@accesscentralcoast.org\">info@accesscentralcoast.org</a> </li>\n<li><strong>Hours:</strong> M–F: 9am–noon &amp; 1–5pm (but closed every other Friday)</li>\n<li>Note: Formerly known as the “Independent Living Resource Center”</li>\n</ul>\n",
+    "aliases": [
+      "Access Central Coast",
+      "the “Independent Living Resource Center”",
+      "**Central Coast Aging & Disability Resource Center**"
+    ]
+  },
+  "ASN": {
+    "title": "Access Support Network (ASN)",
+    "content": "<h2><span>Access Support Network (ASN)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://accesssupportnetwork.org/san-luis-obispo/\" data-external-link=\"true\">accesssupportnetwork.org/san-luis-obispo</a></li>\n<li><strong>Location:</strong> 1320 Nipomo St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.2764744\" data-lon=\"-120.6639145\" data-zoom=\"17\" data-label=\"Access Support Network\">Map</a> <ul>\n<li>Also has a mobile outreach van:<ul>\n<li>Every other Monday, 1:30–4pm at <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado\"><strong>40 Prado</strong></a> in SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.256495\" data-lon=\"-120.672000\" data-zoom=\"17\" data-label=\"Access Support Network\">Map</a> </li>\n<li>Tuesdays 9:30–11:30am at 1320 Nipomo St. in SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.013497\" data-lon=\"-120.488581\" data-zoom=\"17\" data-label=\"Access Support Network\">Map</a> </li>\n<li>Wednesdays 11:30am–1:30pm at Paso Robles <a href=\"#\" data-directory-link=\"ECHO\" aria-label=\"View directory entry for ECHO\"><strong>ECHO</strong></a> Shelter (1134 Black Oak Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.645387\" data-lon=\"-120.687569\" data-zoom=\"17\" data-label=\"El Camino Homeless Organization\">Map</a>) </li>\n<li>Wednesdays 3–6pm at Atascadero <a href=\"#\" data-directory-link=\"ECHO\" aria-label=\"View directory entry for ECHO\"><strong>ECHO</strong></a> Shelter (6370 Atascadero Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.486312\" data-lon=\"-120.670295\" data-zoom=\"17\" data-label=\"El Camino Homeless Organization\">Map</a>)  </li>\n<li>Second Sunday of the Month at the SLO library on Palm St. <a href=\"#\" class=\"map-link\" data-lat=\"35.282806\" data-lon=\"-120.661426\" data-zoom=\"17\" data-label=\"Access Support Network\">Map</a> </li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-3660\" aria-label=\"Call 805-781-3660\">805-781-3660</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:theasnsupp@gmail.com\" aria-label=\"Email theasnsupp@gmail.com\">theasnsupp@gmail.com</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "Access Support Network (ASN)"
+    ]
+  },
+  "Achievement-House-Thrift-Store": {
+    "title": "Achievement House Thrift Stores",
+    "content": "<h2><span>Achievement House Thrift Stores</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.achievementhouse.org/pages/thrift-stores\" data-external-link=\"true\">achievementhouse.org/pages/thrift-stores</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1446 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.1208561\" data-lon=\"-120.6056542\" data-zoom=\"17\" data-label=\"Achievement House Thrift Store (Arroyo Grande)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-202-3068\" aria-label=\"Call 805-202-3068\">805-202-3068</a></td>\n<td data-label=\"Hours\">Daily 9:30am–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">730 Morro Bay Blvd., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.3657373\" data-lon=\"-120.8447987\" data-zoom=\"17\" data-label=\"Achievement House Thrift Store (Morro Bay)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-772-6744\" aria-label=\"Call 805-772-6744\">805-772-6744</a></td>\n<td data-label=\"Hours\">Daily 9:30am–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">553 Higuera St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.277251\" data-lon=\"-120.667015\" data-zoom=\"17\" data-label=\"Bargain Botique\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-543-0412\" aria-label=\"Call 805-543-0412\">805-543-0412</a></td>\n<td data-label=\"Hours\">Daily 9:30am–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">3003 Cuesta College Rd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.3243286\" data-lon=\"-120.7449265\" data-zoom=\"17\" data-label=\"Achievement House Thrift Store (SLO)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-543-9383\" aria-label=\"Call 805-543-9383\">805-543-9383</a></td>\n<td data-label=\"Hours\">M–Sa 9am–4pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:info@achievementhouse.org\" aria-label=\"Email info@achievementhouse.org\">info@achievementhouse.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Achievement House Thrift Stores"
+    ]
+  },
+  "ACLU": {
+    "title": "ACLU of Southern California",
+    "content": "<h2><span>ACLU of Southern California</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.aclusocal.org/\" data-external-link=\"true\">aclusocal.org</a></li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-213-977-9500\" aria-label=\"Call 213-977-9500\">213-977-9500</a> (main) </li>\n<li><a href=\"tel:+1-213-977-5253\" aria-label=\"Call 213-977-5253\">213-977-5253</a> (legal intake)</li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 10am–7pm</li>\n</ul>\n",
+    "aliases": [
+      "ACLU of Southern California"
+    ]
+  },
+  "Adult-Protective-Services": {
+    "title": "Adult Protective Services",
+    "content": "<h2><span>Adult Protective Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/social-services/adult-services/services/adult-protective-services-program-%28aps%29\" data-external-link=\"true\">Slocounty.ca.gov/APS</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">Arroyo Grande: 1086 E. Grand Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.1197593\" data-lon=\"-120.5956380\" data-zoom=\"17\" data-label=\"Adult Protective Services (Arroyo Grande)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-2000\" aria-label=\"Call 805-474-2000\">805-474-2000</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Atascadero: 9630 El Camino Real <a href=\"#\" class=\"map-link\" data-lat=\"35.4657747\" data-lon=\"-120.6485702\" data-zoom=\"17\" data-label=\"Adult Protective Services (Atascadero)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-461-6000\" aria-label=\"Call 805-461-6000\">805-461-6000</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Morro Bay: 600 Quintana Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.3692734\" data-lon=\"-120.8447261\" data-zoom=\"17\" data-label=\"Adult Protective Services (Morro Bay)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-772-6405\" aria-label=\"Call 805-772-6405\">805-772-6405</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Nipomo: 681 W. Tefft St. #1 <a href=\"#\" class=\"map-link\" data-lat=\"35.0336188\" data-lon=\"-120.4879843\" data-zoom=\"17\" data-label=\"Adult Protective Services (Nipomo)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-931-1800\" aria-label=\"Call 805-931-1800\">805-931-1800</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Paso Robles: 406 Spring St. <a href=\"#\" class=\"map-link\" data-lat=\"35.6185648\" data-lon=\"-120.6903449\" data-zoom=\"17\" data-label=\"Adult Protective Services (Paso Robles)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-237-3110\" aria-label=\"Call 805-237-3110\">805-237-3110</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">SLO: 3433 S. Higuera St. <a href=\"#\" class=\"map-link\" data-lat=\"35.2536551\" data-lon=\"-120.6687249\" data-zoom=\"17\" data-label=\"Adult Protective Services (SLO)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-1600\" aria-label=\"Call 805-781-1600\">805-781-1600</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-1790\" aria-label=\"Call 805-781-1790\">805-781-1790</a> (M–F 8am–5pm); <a href=\"tel:+1-844-729-8011\" aria-label=\"Call 844-729-8011\">844-729-8011</a> (after hours); <a href=\"tel:+1-911\" aria-label=\"Call 911\">911</a> (emergency) </li>\n<li><strong>Hours:</strong> M–F 8am–4pm (and by appointment only 4–5pm) </li>\n<li>Notes:<ul>\n<li>Can make referrals to <a href=\"#\" data-directory-link=\"Medically-Fragile-Homeless-Program\" aria-label=\"View directory entry for Medically Fragile Homeless Program\"><strong>Medically Fragile Homeless Program</strong></a></li>\n<li>Can make referrals to <a href=\"#\" data-directory-link=\"CFS\" aria-label=\"View directory entry for Center for Family Strengthening (CFS)\"><strong>Center for Family Strengthening (CFS)</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Adult Protective Services"
+    ]
+  },
+  "Adventist-Health-Sierra-Vista": {
+    "title": "Adventist Health Sierra Vista",
+    "content": "<h2><span>Adventist Health Sierra Vista</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.adventisthealth.org/central-coast/locations/sierra-vista-regional-medical-center\" data-external-link=\"true\">adventisthealth.org/central-coast/locations/sierra-vista-regional-medical-center</a></li>\n<li><strong>Location:</strong> 1010 Murray Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.2924045\" data-lon=\"-120.6659071\" data-zoom=\"17\" data-label=\"Adventist Health Sierra Vista\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-546-7600\" aria-label=\"Call 805-546-7600\">805-546-7600</a> </li>\n<li><strong>Hours:</strong> 24/7 </li>\n<li>Note: hosts <a href=\"#\" data-directory-link=\"Liberty-Tattoo-Removal-Program\" aria-label=\"View directory entry for Liberty Tattoo Removal Program\"><strong>Liberty Tattoo Removal Program</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Adventist Health Sierra Vista"
+    ]
+  },
+  "Adventist-Health-Twin-Cities": {
+    "title": "Adventist Health Twin Cities",
+    "content": "<h2><span>Adventist Health Twin Cities</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.adventisthealth.org/central-coast/locations/twin-cities-community-hospital\" data-external-link=\"true\">adventisthealth.org/central-coast/locations/twin-cities-community-hospital</a></li>\n<li><strong>Location:</strong> 1100 Las Tablas Rd., Templeton <a href=\"#\" class=\"map-link\" data-lat=\"35.5551414\" data-lon=\"-120.7200585\" data-zoom=\"17\" data-label=\"Adventist Health Twin Cities\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-434-3500\" aria-label=\"Call 805-434-3500\">805-434-3500</a> </li>\n<li><strong>Hours:</strong> 24/7 </li>\n</ul>\n",
+    "aliases": [
+      "Adventist Health Twin Cities"
+    ]
+  },
+  "Aegis-Treatment-Centers": {
+    "title": "Aegis Treatment Centers",
+    "content": "<h2><span>Aegis Treatment Centers</span></h2>\n<h3><span>Atascadero</span></h3>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://pinnacletreatment.com/location/california/atascadero/aegis-treatment-centers-atascadero/\" data-external-link=\"true\">pinnacletreatment.com/location/california/atascadero/aegis-treatment-centers-atascadero</a></li>\n<li><strong>Location:</strong> 6500 Morro Rd. Suites C &amp; D, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.4472115\" data-lon=\"-120.7045496\" data-zoom=\"17\" data-label=\"Aegis Treatment Centers (Atascadero)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-461-5212\" aria-label=\"Call 805-461-5212\">805-461-5212</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Medication services:<ul>\n<li>M–Th: 6am–10am, 11am–3:30pm </li>\n<li>F: 6am–10am, 11am–1:30pm </li>\n<li>Sa/Su/Holidays: 7am–11am </li>\n</ul>\n</li>\n<li>Administrative:<ul>\n<li>M–Th: 6am–4pm </li>\n<li>F: 6am–2:30pm </li>\n<li>Sa/Su/Holidays: 7am–11am </li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>How to access:</strong> Walk-ins welcome; same-day admissions available </li>\n</ul>\n<h3><span>SLO city</span></h3>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://pinnacletreatment.com/location/california/san-luis-obispo/aegis-san-luis-obispo-med-unit/\" data-external-link=\"true\">pinnacletreatment.com/location/california/san-luis-obispo/aegis-san-luis-obispo-med-unit</a></li>\n<li><strong>Location:</strong> 1551 Bishop St. #520, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.2740882\" data-lon=\"-120.6464189\" data-zoom=\"17\" data-label=\"Aegis Treatment Centers (SLO)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-461-5212\" aria-label=\"Call 805-461-5212\">805-461-5212</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Medication services:<ul>\n<li>M–F: 6am–10am, 11am–1:30pm </li>\n<li>Sa/Su/Holidays: 6am–10am </li>\n</ul>\n</li>\n<li>Administrative:<ul>\n<li>M–F: 6am–2:30pm </li>\n<li>Sa/Su/Holidays: 6am–10am </li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>How to access:</strong> Schedule a visit <a href=\"https://book.ptc.care/CA-SANLUISOBISPO-OTP\" data-external-link=\"true\">here</a></li>\n</ul>\n",
+    "aliases": [
+      "Aegis Treatment Centers"
+    ]
+  },
+  "Aevum": {
+    "title": "Aevum Home Health and Aevum Hospice Care",
+    "content": "<h2><span>Aevum Home Health and Aevum Hospice Care</span></h2>\n<ul>\n<li><strong>Websites:</strong><ul>\n<li>Home Health: <a href=\"https://www.aevumhomehealth.com/\" data-external-link=\"true\">aevumhomehealth.com</a></li>\n<li>Hospice Care: <a href=\"https://aevumhospice.com/\" data-external-link=\"true\">aevumhospice.com</a></li>\n</ul>\n</li>\n<li><strong>Location:</strong> 1302 Marsh St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.283249\" data-lon=\"-120.655908\" data-zoom=\"17\" data-label=\"Aevum Home Health\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li>Home Health: <a href=\"tel:+1-805-586-2033\" aria-label=\"Call 805-586-2033\">805-586-2033</a> </li>\n<li>Hospice Care: <a href=\"tel:+1-805-465-2492\" aria-label=\"Call 805-465-2492\">805-465-2492</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong><ul>\n<li>Home Health: <a href=\"mailto:info@aevumhomehealth.com\" aria-label=\"Email info@aevumhomehealth.com\">info@aevumhomehealth.com</a> </li>\n<li>Hospice Care: <a href=\"mailto:info@aevumhospice.com\" aria-label=\"Email info@aevumhospice.com\">info@aevumhospice.com</a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Aevum Home Health and Aevum Hospice Care"
+    ]
+  },
+  "Agape-Church": {
+    "title": "Agape Church",
+    "content": "<h2><span>Agape Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://agapeslo.church/\" data-external-link=\"true\">agapeslo.church</a></li>\n<li><strong>Location:</strong> 950 Laureate Lane, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.2857149\" data-lon=\"-120.7097524\" data-zoom=\"17\" data-label=\"Agape Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-0777\" aria-label=\"Call 805-541-0777\">805-541-0777</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:adminslo@agape.church\" aria-label=\"Email adminslo@agape.church\">adminslo@agape.church</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Office: M–Th 9am–4pm </li>\n<li>Food pantry: Tu 10–10:30am, Su Noon–12:30pm</li>\n</ul>\n</li>\n<li>Note: “Men of Agape” serve a free meal at Meadow Park, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.269063\" data-lon=\"-120.658325\" data-zoom=\"17\" data-label=\"Men of Agape\">Map</a>, Thursdays at 11am</li>\n</ul>\n",
+    "aliases": [
+      "Agape Church"
+    ]
+  },
+  "AGS-Recycling": {
+    "title": "AGS Recycling",
+    "content": "<h2><span>AGS Recycling</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://agsreciclyng.com/\" data-external-link=\"true\">agsreciclyng.com</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Arroyo Grande: 564 Mesa View Dr., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.0814297\" data-lon=\"-120.5863837\" data-zoom=\"17\" data-label=\"AGS Recycling (Arroyo Grande)\">Map</a> </li>\n<li>Morro Bay: 2650 Main Street, Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.3899509\" data-lon=\"-120.8572476\" data-zoom=\"17\" data-label=\"AGS Recycling (Morro Bay)\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-598-6285\" aria-label=\"Call 805-598-6285\">805-598-6285</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Arroyo Grande: Tu–Sa 9am–5pm (closed Noon–12:30pm) </li>\n<li>Morro Bay: Tu–Sa 9am–5pm (closed Noon–12:30pm) </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "AGS Recycling"
+    ]
+  },
+  "Alano-Club": {
+    "title": "Alano Club",
+    "content": "<h2><span>Alano Club</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://sloalanoclub.org\" data-external-link=\"true\">sloalanoclub.org</a></li>\n<li><strong>Location:</strong> 3075 Broad Street, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.2619723\" data-lon=\"-120.6505945\" data-zoom=\"17\" data-label=\"Alano Club\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-9817\" aria-label=\"Call 805-543-9817\">805-543-9817</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:sloalanoclub@gmail.com\" aria-label=\"Email sloalanoclub@gmail.com\">sloalanoclub@gmail.com</a> </li>\n<li><strong>Hours:</strong> Open 7 days/week (see <a href=\"https://sloalanoclub.org/meeting-schedule\" data-external-link=\"true\">meeting schedule</a> for specific meeting times)</li>\n</ul>\n",
+    "aliases": [
+      "Alano Club"
+    ]
+  },
+  "AA": {
+    "title": "Alcoholics Anonymous",
+    "content": "<h2><span>Alcoholics Anonymous</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://sloaa.org/\" data-external-link=\"true\">sloaa.org</a></li>\n<li><strong>Location:</strong> 1333 Van Beurden Dr. #102, Los Osos </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-3211\" aria-label=\"Call 805-541-3211\">805-541-3211</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@sloaa.org\" aria-label=\"Email info@sloaa.org\">info@sloaa.org</a></li>\n<li><strong>Hours:</strong><ul>\n<li>Central Coast Intergroup office: M–F Noon–6pm, Sa 1–4pm </li>\n<li>Individual meetings: <a href=\"https://www.sloaa.org/meetings/\" data-external-link=\"true\">many hours and locations</a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Alcoholics Anonymous"
+    ]
+  },
+  "APA": {
+    "title": "Alliance for Pharmaceutical Access",
+    "content": "<h2><span>Alliance for Pharmaceutical Access</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://apameds.org/for-clients/\" data-external-link=\"true\">apameds.org/for-clients</a></li>\n</ul>\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">345 S. Halcyon Rd. (Arroyo Grande) <a class=\"map-link\" data-lat=\"35.113326\" data-lon=\"-120.590433\" data-zoom=\"17\" data-label=\"Alliance for Pharmaceutical Access\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-489-4261;ext=4267\" aria-label=\"Call 805-489-4261 x4267\">805-489-4261 x4267</a></td>\n<td data-label=\"Hours\">Mo. 1pm–7pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1428 Phillips Lane #B4 (SLO, inside Noor Clinic) <a href=\"#\" class=\"map-link\" data-lat=\"35.288103\" data-lon=\"-120.657544\" data-zoom=\"17\" data-label=\"Alliance for Pharmaceutical Access\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-548-0894\" aria-label=\"Call 805-548-0894\">805-548-0894</a></td>\n<td data-label=\"Hours\">Tu. 1pm–5pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:Advocates@apameds.org\" aria-label=\"Email Advocates@apameds.org\">Advocates@apameds.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Alliance for Pharmaceutical Access"
+    ]
+  },
+  "American-Cancer-Society": {
+    "title": "American Cancer Society",
+    "content": "<h2><span>American Cancer Society</span></h2>\n<ul>\n<li>Patient Lodging Programs: <a href=\"https://www.cancer.org/support-programs-and-services/patient-lodging.html\" data-external-link=\"true\">cancer.org/support-programs-and-services/patient-lodging.html</a></li>\n<li>Road to Recovery (transportation to medical appointments): <a href=\"https://www.cancer.org/support-programs-and-services/road-to-recovery.html\" data-external-link=\"true\">cancer.org/support-programs-and-services/road-to-recovery.html</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-227-2345\" aria-label=\"Call 800-227-2345\">800-227-2345</a> </li>\n</ul>\n",
+    "aliases": [
+      "American Cancer Society"
+    ]
+  },
+  "American-Legion-Post-66": {
+    "title": "American Legion Post 66",
+    "content": "<h2><span>American Legion Post 66</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://post66slo.org/\" data-external-link=\"true\">post66slo.org</a></li>\n<li><strong>Location:</strong> 1661 Mill St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.288680\" data-lon=\"-120.653533\" data-zoom=\"17\" data-label=\"American Legion Post 66\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-6445\" aria-label=\"Call 805-543-6445\">805-543-6445</a> </li>\n<li>Notes: For <a href=\"#\" data-directory-link=\"Boyd-Bristol-Medical-Equipment-Program\" aria-label=\"View directory entry for Boyd Bristol Medical Equipment Program\"><strong>Boyd Bristol Medical Equipment Program</strong></a> hours, call to make an appointment</li>\n</ul>\n",
+    "aliases": [
+      "American Legion Post 66"
+    ]
+  },
+  "Arise-Central-Coast": {
+    "title": "Arise Central Coast",
+    "content": "<h2><span>Arise Central Coast</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://arisevineyard.com/\" data-external-link=\"true\">arisevineyard.com</a></li>\n<li><strong>Location:</strong> 1775 Calle Joaquin, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.241754\" data-lon=\"-120.688113\" data-zoom=\"15\" data-label=\"Arise Central Coast\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-3162\" aria-label=\"Call 805-543-3162\">805-543-3162</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Office: M–Th 9am–4pm </li>\n<li>Food pantry: M 2:30–4:30pm</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Arise Central Coast"
+    ]
+  },
+  "Arroyo-Grande-Community-Hospital": {
+    "title": "Arroyo Grande Community Hospital",
+    "content": "<h2><span>Arroyo Grande Community Hospital</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"Dignity-Health\" aria-label=\"View directory entry for Dignity Health\"><strong>Dignity Health</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.dignityhealth.org/central-coast/locations/arroyo-grande\" data-external-link=\"true\">dignityhealth.org/central-coast/locations/arroyo-grande</a></li>\n<li><strong>Location:</strong> 345 S. Halcyon Rd., Arroyo Grande <a class=\"map-link\" data-lat=\"35.113326\" data-lon=\"-120.590433\" data-zoom=\"17\" data-label=\"Arroyo Grande Community Hospital\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li>Front desk: <a href=\"tel:+1-805-489-4261\" aria-label=\"Call 805-489-4261\">805-489-4261</a> </li>\n<li>ER: <a href=\"tel:+1-805-473-7626\" aria-label=\"Call 805-473-7626\">805-473-7626</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong> 24/7 </li>\n</ul>\n",
+    "aliases": [
+      "Arroyo Grande Community Hospital",
+      "**Dignity Health**"
+    ]
+  },
+  "Arroyo-Grande-Recreation-Services": {
+    "title": "Arroyo Grande Recreation Services",
+    "content": "<h2><span>Arroyo Grande Recreation Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://arroyogrande.org/168/Recreation-Services\" data-external-link=\"true\">arroyogrande.org/168/Recreation-Services</a></li>\n<li><strong>Location:</strong> 1221 Ash St., Arroyo Grande <a class=\"map-link\" data-lat=\"35.114628\" data-lon=\"-120.600829\" data-zoom=\"17\" data-label=\"Arroyo Grande Recreation Services\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-473-5474\" aria-label=\"Call 805-473-5474\">805-473-5474</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:agrec@arroyogrande.org\" aria-label=\"Email agrec@arroyogrande.org\">agrec@arroyogrande.org</a></li>\n<li><strong>Hours:</strong> M–Th 9am–5pm, F 9am–1pm  (walk-in registration available)</li>\n</ul>\n",
+    "aliases": [
+      "Arroyo Grande Recreation Services"
+    ]
+  },
+  "Aspire-Counseling-Service": {
+    "title": "Aspire Counseling Service",
+    "content": "<h2><span>Aspire Counseling Service</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://aspirecounselingservice.com/san-luis-obispo/\" data-external-link=\"true\">aspirecounselingservice.com/san-luis-obispo</a></li>\n<li><strong>Location:</strong> 865 Aerovista Pl. #130, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.242312\" data-lon=\"-120.640925\" data-zoom=\"17\" data-label=\"Aspire Counseling Service\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-329-5595\" aria-label=\"Call 805-329-5595\">805-329-5595</a> (main) </li>\n<li><a href=\"tel:+1-888-585-7373\" aria-label=\"Call 888-585-7373\">888-585-7373</a> (24/7 call or text) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@aspirecounselingservice.com\" aria-label=\"Email info@aspirecounselingservice.com\">info@aspirecounselingservice.com</a> </li>\n<li><strong>Hours:</strong> M–F 9am–9pm, Sa. 9am–1pm </li>\n<li>Notes: Hosts <a href=\"#\" data-directory-link=\"Recovery-Dharma\" aria-label=\"View directory entry for Recovery Dharma\"><strong>Recovery Dharma</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Aspire Counseling Service"
+    ]
+  },
+  "Auntie-Isabell-Foundation": {
+    "title": "Auntie Isabell Foundation",
+    "content": "<h2><span>Auntie Isabell Foundation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.auntieisabellfoundation.org/\" data-external-link=\"true\">auntieisabellfoundation.org</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:info@auntieisabellfoundation.org\" aria-label=\"Email info@auntieisabellfoundation.org\">info@auntieisabellfoundation.org</a> </li>\n<li>Service Area: Paso Robles and SLO County</li>\n</ul>\n",
+    "aliases": [
+      "Auntie Isabell Foundation"
+    ]
+  },
+  "Assistance-League-of-SLO-County": {
+    "title": "Assistance League of SLO County",
+    "content": "<h2><span>Assistance League of SLO County</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.assistanceleague.org/san-luis-obispo-county/\" data-external-link=\"true\">assistanceleague.org/san-luis-obispo-county</a></li>\n<li><strong>Location:</strong> 667A Marsh St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.277358\" data-lon=\"-120.663899\" data-zoom=\"17\" data-label=\"Assistance League\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-782-0824\" aria-label=\"Call 805-782-0824\">805-782-0824</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@alslocounty.org\" aria-label=\"Email info@alslocounty.org\">info@alslocounty.org</a> </li>\n<li>Notes:<ul>\n<li>Operates <a href=\"#\" data-directory-link=\"Assistance-League-Thrift-Store\" aria-label=\"View directory entry for Assistance League Thrift Store\"><strong>Assistance League Thrift Store</strong></a> </li>\n<li>Operates “Operation School Bell” </li>\n<li>Operates “Access to Career Education (ACE)” </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Assistance League of SLO County"
+    ]
+  },
+  "Assistance-League-Thrift-Store": {
+    "title": "Assistance League Thrift Store",
+    "content": "<h2><span>Assistance League Thrift Store</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.assistanceleague.org/san-luis-obispo-county/thrift-shop/\" data-external-link=\"true\">assistanceleague.org/san-luis-obispo-county/thrift-shop</a></li>\n<li><strong>Location:</strong> 667A Marsh St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.277358\" data-lon=\"-120.663899\" data-zoom=\"17\" data-label=\"Assistance League\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-782-0824\" aria-label=\"Call 805-782-0824\">805-782-0824</a> </li>\n<li><strong>Hours:</strong> Tu–Sa 11am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Assistance League Thrift Store"
+    ]
+  },
+  "Atascadero-Senior-Center": {
+    "title": "Atascadero Senior Center",
+    "content": "<h2><span>Atascadero Senior Center</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://atascaderoseniorcenter.org/\" data-external-link=\"true\">atascaderoseniorcenter.org</a></li>\n<li><strong>Location:</strong> 5905 East Mall, Atascadero <a class=\"map-link\" data-lat=\"35.488783\" data-lon=\"-120.667081\" data-zoom=\"17\" data-label=\"Atascadero Senior Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-4674\" aria-label=\"Call 805-466-4674\">805-466-4674</a>  </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:seniorcitizensunitedinc@outlook.com\" aria-label=\"Email seniorcitizensunitedinc@outlook.com\">seniorcitizensunitedinc@outlook.com</a> </li>\n<li><a href=\"mailto:seniorcenter93422@gmail.com\" aria-label=\"Email seniorcenter93422@gmail.com\">seniorcenter93422@gmail.com</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M 11am–1pm, Tu–F 11am–3pm (some activities at other times) </li>\n<li><strong>How to access:</strong> Most activities free for members ($2 for guests); membership ($20/year minimum) open to people 50+</li>\n<li>Notes:<ul>\n<li>A lunch site for <a href=\"#\" data-directory-link=\"Meals-that-Connect\" aria-label=\"View directory entry for Meals that Connect\"><strong>Meals that Connect</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Atascadero Senior Center"
+    ]
+  },
+  "Atascadero-Parks-and-Recreation": {
+    "title": "Atascadero Parks & Recreation",
+    "content": "<h2><span>Atascadero Parks &amp; Recreation</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.atascadero.org/recreation\" data-external-link=\"true\">atascadero.org/recreation</a></li>\n<li><strong>Location:</strong> Colony Park Community Center, 5599 Traffic Way, Atascadero <a class=\"map-link\" data-lat=\"35.494778\" data-lon=\"-120.666963\" data-zoom=\"17\" data-label=\"Atascadero Parks &amp; Recreation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-470-3360\" aria-label=\"Call 805-470-3360\">805-470-3360</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:recreation@atascadero.org\" aria-label=\"Email recreation@atascadero.org\">recreation@atascadero.org</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5pm</li>\n</ul>\n",
+    "aliases": [
+      "Atascadero Parks & Recreation"
+    ]
+  },
+  "Balay-Ko-on-Barka": {
+    "title": "Balay Ko on Barka",
+    "content": "<h2><span>Balay Ko on Barka</span></h2>\n<blockquote>\n<p><em>a.k.a. “My Home for Hope”</em></p>\n</blockquote>\n<ul>\n<li><strong>Location:</strong> Barka St. in Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.111238\" data-lon=\"-120.623521\" data-zoom=\"17\" data-label=\"Balay Ko on Barka\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-305-3031\" aria-label=\"Call 805-305-3031\">805-305-3031</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:shelter@5chc.org\" aria-label=\"Email shelter@5chc.org\">shelter@5chc.org</a></li>\n<li><strong>How to access:</strong> Apply through <a href=\"#\" data-directory-link=\"5CHC\" aria-label=\"View directory entry for 5Cities Homeless Coalition\"><strong>5Cities Homeless Coalition</strong></a> to get on waiting list</li>\n</ul>\n",
+    "aliases": [
+      "Balay Ko on Barka",
+      "“My Home for Hope”*"
+    ]
+  },
+  "Bargain-Boutique": {
+    "title": "Bargain Boutique",
+    "content": "<h2><span>Bargain Boutique</span></h2>\n<blockquote>\n<p><em>See <a href=\"#\" data-directory-link=\"Achievement-House-Thrift-Store\" aria-label=\"View directory entry for Achievement House Thrift Stores\">Achievement House Thrift Stores</a></em></p>\n</blockquote>\n",
+    "aliases": [
+      "Bargain Boutique"
+    ]
+  },
+  "Beach-Area-Storage": {
+    "title": "Beach Area Storage",
+    "content": "<h2><span>Beach Area Storage</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://beachareastorage.com/\" data-external-link=\"true\">beachareastorage.com</a></li>\n<li><strong>Location:</strong> 464 Leoni Dr., Grover Beach <a class=\"map-link\" data-lat=\"35.113070\" data-lon=\"-120.623705\" data-zoom=\"17\" data-label=\"Beach Area Storage\">Map</a> { Source: <a href=\"https://beachareastorage.com/\" data-external-link=\"true\">https://beachareastorage.com/</a> }</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-489-9272\" aria-label=\"Call 805-489-9272\">805-489-9272</a> { Source: <a href=\"https://beachareastorage.com/\" data-external-link=\"true\">https://beachareastorage.com/</a> }</li>\n<li><strong>Email:</strong> <a href=\"mailto:BeachAreaStorage@gmail.com\" aria-label=\"Email BeachAreaStorage@gmail.com\">BeachAreaStorage@gmail.com</a> { Source: <a href=\"https://beachareastorage.com/\" data-external-link=\"true\">https://beachareastorage.com/</a> }</li>\n<li><strong>Hours:</strong><ul>\n<li>Office: M–F 9am–5pm (closed Noon–1pm), Sa 10am–5pm (closed Noon–1pm), Su Noon–5pm (closed 1:30–2pm) { Source: <a href=\"https://beachareastorage.com/location-grover-beach/\" data-external-link=\"true\">https://beachareastorage.com/location-grover-beach/</a> }</li>\n<li>Storage access: Daily 7am–7pm (Daylight Saving Time) or 7am–6pm (standard time) { Source: <a href=\"https://beachareastorage.com/location-grover-beach/\" data-external-link=\"true\">https://beachareastorage.com/location-grover-beach/</a> }</li>\n<li>Closed major holidays { Source: <a href=\"https://beachareastorage.com/location-grover-beach/\" data-external-link=\"true\">https://beachareastorage.com/location-grover-beach/</a> }\n--&gt;</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Beach Area Storage"
+    ]
+  },
+  "BHBH": {
+    "title": "Behavioral Health Bridge Housing (BHBH) Program",
+    "content": "<h2><span>Behavioral Health Bridge Housing (BHBH) Program</span></h2>\n<blockquote>\n<p><em>See <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for Transitions Mental Health Association (TMHA)\"><strong>Transitions Mental Health Association (TMHA)</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/justice-services/behavioral-health-bridge-housing\" data-external-link=\"true\">www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/justice-services/behavioral-health-bridge-housing</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-540-6500\" aria-label=\"Call 805-540-6500\">805-540-6500</a> (Mark Lamore, Director of Homeless Services at <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for TMHA\"><strong>TMHA</strong></a>) </li>\n<li><strong>Email:</strong> <a href=\"mailto:mtorell@co.slo.ca.us\" aria-label=\"Email mtorell@co.slo.ca.us\">mtorell@co.slo.ca.us</a> and <a href=\"mailto:jmprice@co.slo.ca.us\" aria-label=\"Email jmprice@co.slo.ca.us\">jmprice@co.slo.ca.us</a> </li>\n<li><strong>How to access:</strong> must be referred by another agency; call to ask for details </li>\n</ul>\n",
+    "aliases": [
+      "Behavioral Health Bridge Housing (BHBH) Program"
+    ]
+  },
+  "Bella-Vista-by-the-Sea": {
+    "title": "Bella Vista by the Sea",
+    "content": "<h2><span>Bella Vista by the Sea</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.bellavistabythesea.com/\" data-external-link=\"true\">bellavistabythesea.com</a></li>\n<li><strong>Location:</strong> 350 N. Ocean Ave., Cayucos <a class=\"map-link\" data-lat=\"35.451070\" data-lon=\"-120.908597\" data-zoom=\"17\" data-label=\"Bella Vista by the Sea\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-995-3644\" aria-label=\"Call 805-995-3644\">805-995-3644</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:bellavistamhp@tprop.net\" aria-label=\"Email bellavistamhp@tprop.net\">bellavistamhp@tprop.net</a> </li>\n<li><strong>Hours:</strong> (office hours) M–F 10am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Bella Vista by the Sea"
+    ]
+  },
+  "Bike-Kitchen": {
+    "title": "Bike Kitchen",
+    "content": "<h2><span>Bike Kitchen</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://bikeslocounty.org/programs/kitchen/\" data-external-link=\"true\">bikeslocounty.org/programs/kitchen</a></li>\n<li><strong>Location:</strong> 860 Pacific St. #105, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.279103\" data-lon=\"-120.660620\" data-zoom=\"17\" data-label=\"Bike Kitchen\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-547-2055\" aria-label=\"Call 805-547-2055\">805-547-2055</a> </li>\n<li><strong>Hours:</strong> Th–Su 12–5pm (DIY repair), Tu–W 12–5pm (shopping only), M closed </li>\n</ul>\n",
+    "aliases": [
+      "Bike Kitchen"
+    ]
+  },
+  "Blessed-to-Serve": {
+    "title": "Blessed to Serve",
+    "content": "<h2><span>Blessed to Serve</span></h2>\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">12150 Los Osos Valley Road, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.250659\" data-lon=\"-120.684721\" data-zoom=\"17\" data-label=\"Blessed to Serve\">Map</a> (Nissan dealership)</td>\n<td data-label=\"Hours\">M 5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1251 Calle Joaquin, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.251051\" data-lon=\"-120.679879\" data-zoom=\"17\" data-label=\"Blessed to Serve\">Map</a> (BMW dealership)</td>\n<td data-label=\"Hours\">Th 5pm</td>\n</tr>\n</tbody></table>\n",
+    "aliases": [
+      "Blessed to Serve"
+    ]
+  },
+  "Boyd-Bristol-Medical-Equipment-Program": {
+    "title": "Boyd Bristol Medical Equipment Program",
+    "content": "<h2><span>Boyd Bristol Medical Equipment Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://post66slo.org/serving-veterans/\" data-external-link=\"true\">post66slo.org/serving-veterans</a></li>\n<li><strong>Location:</strong> 1161 Mill St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.284710\" data-lon=\"-120.660546\" data-zoom=\"17\" data-label=\"Boyd Bristol Medical Equipment Program\">Map</a><ul>\n<li>Note: delivery can also be arranged </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-6445\" aria-label=\"Call 805-543-6445\">805-543-6445</a> </li>\n<li><strong>How to access:</strong> Only for veterans and veterans’ dependents. By appointment only; call to make an appointment.</li>\n</ul>\n",
+    "aliases": [
+      "Boyd Bristol Medical Equipment Program"
+    ]
+  },
+  "Brookside-Thrift": {
+    "title": "Brookside Thrift",
+    "content": "<h2><span>Brookside Thrift</span></h2>\n<ul>\n<li><strong>Location:</strong> 9330 El Camino Real, Atascadero <a class=\"map-link\" data-lat=\"35.467930\" data-lon=\"-120.651700\" data-zoom=\"17\" data-label=\"North County Christian Thrift Shop\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-1679\" aria-label=\"Call 805-466-1679\">805-466-1679</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:nccts9330@gmail.com\" aria-label=\"Email nccts9330@gmail.com\">nccts9330@gmail.com</a> </li>\n<li><strong>Hours:</strong> M–Sa 9am–6pm</li>\n<li>Notes: formerly known as “North County Christian Thrift”</li>\n</ul>\n",
+    "aliases": [
+      "Brookside Thrift",
+      "“North County Christian Thrift”"
+    ]
+  },
+  "Cabins-for-Change": {
+    "title": "Cabins for Change",
+    "content": "<h2><span>Cabins for Change</span></h2>\n<ul>\n<li><strong>Location:</strong> Rockaway Ave. at 16th St. in Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.119777\" data-lon=\"-120.612577\" data-zoom=\"17\" data-label=\"Cabins for Change\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-305-3031\" aria-label=\"Call 805-305-3031\">805-305-3031</a> </li>\n<li><strong>Text:</strong> <a href=\"sms:+1-805-634-9906\">805-634-9906</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:shelter@5chc.org\" aria-label=\"Email shelter@5chc.org\">shelter@5chc.org</a> </li>\n<li><strong>How to access:</strong> Apply through <a href=\"#\" data-directory-link=\"5CHC\" aria-label=\"View directory entry for 5Cities Homeless Coalition\"><strong>5Cities Homeless Coalition</strong></a> to get on waiting list</li>\n</ul>\n",
+    "aliases": [
+      "Cabins for Change"
+    ]
+  },
+  "California-Cool-Thrift-Store": {
+    "title": "California Cool Thrift Store",
+    "content": "<h2><span>California Cool Thrift Store</span></h2>\n<ul>\n<li><strong>Location:</strong> 737 W. Grand Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.121863\" data-lon=\"-120.622164\" data-zoom=\"17\" data-label=\"California Cool Thrift Store\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-481-3071\" aria-label=\"Call 805-481-3071\">805-481-3071</a> </li>\n<li><strong>Hours:</strong> Daily 10am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "California Cool Thrift Store"
+    ]
+  },
+  "California-Childrens-Services": {
+    "title": "California Children’s Services",
+    "content": "<h2><span>California Children’s Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://dhcs.ca.gov/services/ccs\" data-external-link=\"true\">dhcs.ca.gov/services/ccs</a></li>\n<li><strong>Location:</strong> 2925 McMillan Ave. #108, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.263382\" data-lon=\"-120.648288\" data-zoom=\"17\" data-label=\"California Children’s Services\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5527\" aria-label=\"Call 805-781-5527\">805-781-5527</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:PublicHealth.CMS@co.slo.ca.us\" aria-label=\"Email PublicHealth.CMS@co.slo.ca.us\">PublicHealth.CMS@co.slo.ca.us</a> </li>\n<li><strong>Hours:</strong> M–F 8am–5pm by appointment only </li>\n</ul>\n",
+    "aliases": [
+      "California Children’s Services"
+    ]
+  },
+  "California-Civil-Rights-Department": {
+    "title": "California Civil Rights Department",
+    "content": "<h2><span>California Civil Rights Department</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://calcivilrights.ca.gov\" data-external-link=\"true\">calcivilrights.ca.gov</a><ul>\n<li>Housing discrimination office: <a href=\"https://calcivilrights.ca.gov/housing/\" data-external-link=\"true\">calcivilrights.ca.gov/housing</a></li>\n</ul>\n</li>\n<li><strong>Location:</strong> 651 Bannon Street #200, Sacramento, CA 95811 <a href=\"#\" class=\"map-link\" data-lat=\"38.594598\" data-lon=\"-121.497249\" data-zoom=\"17\" data-label=\"California Civil Rights Department\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-800-884-1684\" aria-label=\"Call 800-884-1684\">800-884-1684</a> (voice) </li>\n<li><a href=\"tel:+1-800-700-2320\" aria-label=\"Call 800-700-2320\">800-700-2320</a> (TTY) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:contact.center@calcivilrights.ca.gov\" aria-label=\"Email contact.center@calcivilrights.ca.gov\">contact.center@calcivilrights.ca.gov</a> </li>\n<li><strong>How to access:</strong> via the <a href=\"https://ccrs.calcivilrights.ca.gov/s/\" data-external-link=\"true\">California Civil Rights System</a> on-line platform</li>\n</ul>\n",
+    "aliases": [
+      "California Civil Rights Department"
+    ]
+  },
+  "California-Connect": {
+    "title": "California Connect",
+    "content": "<h2><span>California Connect</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://caconnect.org/\" data-external-link=\"true\">caconnect.org</a></li>\n<li><strong>Location:</strong> 3426 Empresa Dr. #120, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.253573\" data-lon=\"-120.667102\" data-zoom=\"17\" data-label=\"California Connect\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-806-1191\" aria-label=\"Call 800-806-1191\">800-806-1191</a>  (TTY: <a href=\"tel:+1-800-806-4474\" aria-label=\"Call 800-806-4474\">800-806-4474</a>) </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:info@caconnect.org\" aria-label=\"Email info@caconnect.org\">info@caconnect.org</a> </li>\n<li><a href=\"mailto:ddtp@cpuc.ca.gov\" aria-label=\"Email ddtp@cpuc.ca.gov\">ddtp@cpuc.ca.gov</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "California Connect"
+    ]
+  },
+  "California-Department-of-Rehabilitation": {
+    "title": "California Department of Rehabilitation",
+    "content": "<h2><span>California Department of Rehabilitation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.dor.ca.gov/\" data-external-link=\"true\">dor.ca.gov</a></li>\n<li><strong>Location:</strong> 3320 S. Higuera #102, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.255033\" data-lon=\"-120.668947\" data-zoom=\"17\" data-label=\"California Department of Rehabilitation\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li>Local office:<ul>\n<li><a href=\"tel:+1-805-594-6100\" aria-label=\"Call 805-594-6100\">805-594-6100</a></li>\n<li><a href=\"tel:+1-805-549-3361\" aria-label=\"Call 805-549-3361\">805-549-3361</a> (for ages 16–21) </li>\n<li><a href=\"tel:+1-805-544-7367\" aria-label=\"Call 805-544-7367\">805-544-7367</a> (TTY)</li>\n</ul>\n</li>\n<li>Statewide:<ul>\n<li><a href=\"tel:+1-800-952-5544\" aria-label=\"Call 800-952-5544\">800-952-5544</a> (voice) </li>\n<li><a href=\"tel:+1-916-324-1313\" aria-label=\"Call 916-324-1313\">916-324-1313</a> (voice) </li>\n<li><a href=\"tel:+1-916-558-5673\" aria-label=\"Call 916-558-5673\">916-558-5673</a> (TTY) </li>\n<li>Source: <a href=\"https://www.dor.ca.gov/Home/ContactUs\" data-external-link=\"true\">dor.ca.gov</a></li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>How to access:</strong> No walk-ins. Call them to schedule an Orientation, or complete a form on their website.</li>\n<li>Notes:<ul>\n<li>Can refer you to the “Supported Employment” program</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "California Department of Rehabilitation"
+    ]
+  },
+  "California-DMV": {
+    "title": "California DMV",
+    "content": "<h2><span>California DMV</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.dmv.ca.gov/\" data-external-link=\"true\">dmv.ca.gov</a></li>\n<li><strong>Location:</strong> 3190 S. Higuera St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.257436\" data-lon=\"-120.669167\" data-zoom=\"17\" data-label=\"Department of Motor Vehicles\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-777-0133\" aria-label=\"Call 800-777-0133\">800-777-0133</a> (for appointments)</li>\n<li><strong>Hours:</strong> M/Tu/Th/F/Sa 8am–5pm, W 9am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "California DMV"
+    ]
+  },
+  "California-Rural-Legal-Assistance": {
+    "title": "California Rural Legal Assistance (CRLA)",
+    "content": "<h2><span>California Rural Legal Assistance (CRLA)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.crla.org/\" data-external-link=\"true\">crla.org</a></li>\n<li><strong>Location:</strong> 1880 Santa Barbara Ave. #240, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.275127\" data-lon=\"-120.656168\" data-zoom=\"17\" data-label=\"California Rural Legal Assistance\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-7994\" aria-label=\"Call 805-544-7994\">805-544-7994</a> </li>\n<li><strong>Hours:</strong> M–Th 9am–12pm &amp; 1pm–5pm, F 1pm–5pm</li>\n</ul>\n",
+    "aliases": [
+      "California Rural Legal Assistance (CRLA)"
+    ]
+  },
+  "Cal-Poly-Doggy-Days": {
+    "title": "Cal Poly “Doggy Days” Veterinary Clinics",
+    "content": "<h2><span>Cal Poly “Doggy Days” Veterinary Clinics</span></h2>\n<ul>\n<li><strong>Social media:</strong><ul>\n<li>Facebook: <a href=\"https://www.facebook.com/calpolydoggydays/\" data-external-link=\"true\">facebook.com/calpolydoggydays</a></li>\n<li>Instagram: <a href=\"https://instagram.com/cpdoggydays\" data-external-link=\"true\">@cpdoggydays</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-756-2419\" aria-label=\"Call 805-756-2419\">805-756-2419</a> (Cal Poly Animal Science Department)</li>\n<li><strong>Email:</strong> <a href=\"mailto:calpolydoggydays@gmail.com\" aria-label=\"Email calpolydoggydays@gmail.com\">calpolydoggydays@gmail.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Cal Poly “Doggy Days” Veterinary Clinics"
+    ]
+  },
+  "Cal-Poly-Food-Pantry": {
+    "title": "Cal Poly Food Pantry",
+    "content": "<h2><span>Cal Poly Food Pantry</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://basicneeds.calpoly.edu/foodpantry\" data-external-link=\"true\">basicneeds.calpoly.edu/foodpantry</a></li>\n<li><strong>Location:</strong> Cal Poly campus, building 27, room 10 <a href=\"#\" class=\"map-link\" data-lat=\"35.298148\" data-lon=\"-120.660616\" data-zoom=\"17\" data-label=\"Cal Poly Food Pantry\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-756-7818\" aria-label=\"Call 805-756-7818\">805-756-7818</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>M–F 8:30am–6pm (Cal Poly students) </li>\n<li>F 8:30am–6pm (Cal Poly employees) </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> all Cal Poly students and employees welcome; no additional eligibility requirements </li>\n</ul>\n",
+    "aliases": [
+      "Cal Poly Food Pantry"
+    ]
+  },
+  "CalJOBS": {
+    "title": "CalJOBS",
+    "content": "<h2><span>CalJOBS</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.caljobs.ca.gov/\" data-external-link=\"true\">caljobs.ca.gov</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-758-0398\" aria-label=\"Call 800-758-0398\">800-758-0398</a> </li>\n<li>Note: Can access locally via <a href=\"#\" data-directory-link=\"SLO-Cal-Careers-Center\" aria-label=\"View directory entry for SLO Cal Careers Center\"><strong>SLO Cal Careers Center</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "CalJOBS"
+    ]
+  },
+  "CalWORKs": {
+    "title": "CalWORKs Homeless Assistance Program",
+    "content": "<h2><span>CalWORKs Homeless Assistance Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance\" data-external-link=\"true\">slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance</a></li>\n<li><strong>Locations:</strong> See <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-1600\" aria-label=\"Call 805-781-1600\">805-781-1600</a></li>\n<li><strong>Hours:</strong> M–F 8am–4pm (4–5pm by appointment only)</li>\n<li><strong>How to access:</strong> Contact <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "CalWORKs Homeless Assistance Program"
+    ]
+  },
+  "Cambria-Recycling-Center": {
+    "title": "Cambria Recycling Center",
+    "content": "<h2><span>Cambria Recycling Center</span></h2>\n<ul>\n<li><strong>Location:</strong> 1275 Tamson St., Cambria <a href=\"#\" class=\"map-link\" data-lat=\"35.563214\" data-lon=\"-121.091796\" data-zoom=\"17\" data-label=\"Cambria Recycling Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-550-5489\" aria-label=\"Call 805-550-5489\">805-550-5489</a> </li>\n<li><strong>Hours:</strong> Tu–Sa 10am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Cambria Recycling Center"
+    ]
+  },
+  "Cambria-Vineyard-Church": {
+    "title": "Cambria Vineyard Church",
+    "content": "<h2><span>Cambria Vineyard Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://cambriavineyardchurch.org/\" data-external-link=\"true\">cambriavineyardchurch.org</a></li>\n<li><strong>Location:</strong> 1617 Main St., Cambria <a href=\"#\" class=\"map-link\" data-lat=\"35.563774\" data-lon=\"-121.087216\" data-zoom=\"17\" data-label=\"Cambria Vineyard\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-927-5550\" aria-label=\"Call 805-927-5550\">805-927-5550</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@cambriavineyard.org\" aria-label=\"Email info@cambriavineyard.org\">info@cambriavineyard.org</a></li>\n<li><strong>Hours</strong> (food pantry): Second &amp; fourth Thursdays, Noon–2pm </li>\n<li>Notes: Operates “Re·Create Thrift Store” at 1601 Main St., Cambria (M/Th/F/Sa 10am–4pm) </li>\n</ul>\n",
+    "aliases": [
+      "Cambria Vineyard Church"
+    ]
+  },
+  "Cambrias-Anonymous-Neighbors": {
+    "title": "Cambria’s Anonymous Neighbors (CAN)",
+    "content": "<h2><span>Cambria’s Anonymous Neighbors (CAN)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.joslynrec.org/CAN/index.html\" data-external-link=\"true\">joslynrec.org/CAN</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-927-5673\" aria-label=\"Call 805-927-5673\">805-927-5673</a> </li>\n</ul>\n",
+    "aliases": [
+      "Cambria’s Anonymous Neighbors (CAN)"
+    ]
+  },
+  "Captive-Hearts": {
+    "title": "Captive Hearts",
+    "content": "<h2><span>Captive Hearts</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://captivehearts.org/\" data-external-link=\"true\">captivehearts.org</a></li>\n<li><strong>Location:</strong> 882 W. Grand Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.121358\" data-lon=\"-120.620550\" data-zoom=\"17\" data-label=\"Captive Hearts\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-481-4500\" aria-label=\"Call 805-481-4500\">805-481-4500</a> (before 3pm) </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@captivehearts.org\" aria-label=\"Email info@captivehearts.org\">info@captivehearts.org</a> </li>\n<li>Notes: operates <a href=\"#\" data-directory-link=\"Second-Chances-Thrift-Store\" aria-label=\"View directory entry for Second Chances Thrift Store\">Second Chances Thrift Store</a></li>\n</ul>\n",
+    "aliases": [
+      "Captive Hearts"
+    ]
+  },
+  "C.A.R.E.4Paws": {
+    "title": "C.A.R.E.4Paws",
+    "content": "<h2><span>C.A.R.E.4Paws</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://care4paws.org/\" data-external-link=\"true\">care4paws.org</a></li>\n<li><strong>Location:</strong> mobile clinics<ul>\n<li>Pet Resource Center: 100 S. 4th St., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.121203\" data-lon=\"-120.626739\" data-zoom=\"17\" data-label=\"C.A.R.E.4Paws\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-968-2273\" aria-label=\"Call 805-968-CARE\">805-968-CARE</a> </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:info@care4paws.org\" aria-label=\"Email info@care4paws.org\">info@care4paws.org</a> </li>\n<li><a href=\"mailto:outreach@care4paws.org\" aria-label=\"Email outreach@care4paws.org\">outreach@care4paws.org</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong><ul>\n<li><a href=\"https://care4paws.org/clinics\" data-external-link=\"true\">Mobile Clinics Schedule</a></li>\n<li>Pet Resource Center: M–Th 9am–5pm, F 11am–5pm </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Partners with “The Street Dog Coalition”</li>\n<li>Operates the “Pet Resource Center” with <a href=\"#\" data-directory-link=\"5CHC\" aria-label=\"View directory entry for 5Cities Homeless Coalition\"><strong>5Cities Homeless Coalition</strong></a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "C.A.R.E.4Paws"
+    ]
+  },
+  "Carbon-Health-Urgent-Care-Atascadero": {
+    "title": "Carbon Health Urgent Care (Atascadero)",
+    "content": "<h2><span>Carbon Health Urgent Care (Atascadero)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://carbonhealth.com/en/locations/atascadero-ca\" data-external-link=\"true\">carbonhealth.com/en/locations/atascadero-ca</a></li>\n<li><strong>Location:</strong> 7330 El Camino Real, Atascadero <a class=\"map-link\" data-lat=\"35.482467\" data-lon=\"-120.659886\" data-zoom=\"17\" data-label=\"Carbon Health Urgent Care (Atascadero)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-831-621-1184\" aria-label=\"Call 831-621-1184\">831-621-1184</a> </li>\n<li><strong>Hours:</strong> Every day 8am–6pm </li>\n<li>Notes: Accepts Medicare but not Medi-Cal; walk-ins welcome, same-day appointments available</li>\n</ul>\n",
+    "aliases": [
+      "Carbon Health Urgent Care (Atascadero)"
+    ]
+  },
+  "Carbon-Health-Urgent-Care-Paso-Robles": {
+    "title": "Carbon Health Urgent Care (Paso Robles)",
+    "content": "<h2><span>Carbon Health Urgent Care (Paso Robles)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://carbonhealth.com/en/locations/paso-robles-ca\" data-external-link=\"true\">carbonhealth.com/en/locations/paso-robles-ca</a></li>\n<li><strong>Location:</strong> 500 1st St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.614953\" data-lon=\"-120.692442\" data-zoom=\"17\" data-label=\"Carbon Health Urgent Care\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-831-621-1449\" aria-label=\"Call 831-621-1449\">831-621-1449</a> </li>\n<li><strong>Hours:</strong> Every day 8am–6pm </li>\n<li>Notes: Accepts Medicare but not Medi-Cal; walk-ins welcome, same-day appointments available</li>\n</ul>\n",
+    "aliases": [
+      "Carbon Health Urgent Care (Paso Robles)"
+    ]
+  },
+  "CASA": {
+    "title": "CASA (Court Appointed Special Advocates)",
+    "content": "<h2><span>CASA (Court Appointed Special Advocates)</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocasa.org/\" data-external-link=\"true\">slocasa.org</a></li>\n<li><strong>Location:</strong> 75 Higuera St. #180, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.268096\" data-lon=\"-120.670195\" data-zoom=\"17\" data-label=\"CASA\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-6542\" aria-label=\"Call 805-541-6542\">805-541-6542</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:staff@slocasa.org\" aria-label=\"Email staff@slocasa.org\">staff@slocasa.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "CASA (Court Appointed Special Advocates)"
+    ]
+  },
+  "Casa-Solana": {
+    "title": "Casa Solana",
+    "content": "<h2><span>Casa Solana</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://casasolanainc.org/\" data-external-link=\"true\">casasolanainc.org</a></li>\n<li><strong>Location:</strong> 383 S. 13th St., Grover Beach <a class=\"map-link\" data-lat=\"35.118384\" data-lon=\"-120.615202\" data-zoom=\"17\" data-label=\"Casa Solana\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-481-8555\" aria-label=\"Call 805-481-8555\">805-481-8555</a> (9am–4pm) </li>\n<li><strong>Email:</strong> <a href=\"mailto:casasolanainc@gmail.com\" aria-label=\"Email casasolanainc@gmail.com\">casasolanainc@gmail.com</a> </li>\n<li>Notes: also known as “Sunshine House”</li>\n</ul>\n",
+    "aliases": [
+      "Casa Solana",
+      "“Sunshine House”"
+    ]
+  },
+  "Catholic-Charities": {
+    "title": "Catholic Charities (Diocese of Monterey)",
+    "content": "<h2><span>Catholic Charities (Diocese of Monterey)</span></h2>\n\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://catholiccharitiesdom.org/\" data-external-link=\"true\">catholiccharitiesdom.org</a><ul>\n<li><a href=\"https://catholiccharitiesdom.org/immigration-citizenship/\" data-external-link=\"true\">Immigration and Citizenship Program</a></li>\n<li><a href=\"https://catholiccharitiesdom.org/tattoo-removal-program\" data-external-link=\"true\">Tattoo Removal Program</a></li>\n</ul>\n</li>\n<li><strong>Locations:</strong><ul>\n<li>Main office: 3250 S. Higuera St. #D, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.255397\" data-lon=\"-120.669515\" data-zoom=\"17\" data-label=\"Catholic Charities\">Map</a> </li>\n<li>Financial assistance: 3592 Broad Street #104, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.254868\" data-lon=\"-120.645111\" data-zoom=\"17\" data-label=\"Catholic Charities\">Map</a> </li>\n<li>Behind the Mission: 715 Palm St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.280845\" data-lon=\"-120.665176\" data-zoom=\"17\" data-label=\"Catholic Charities\">Map</a></li>\n<li>Paso Robles satellite: St. Rose of Lima Church, 642 Trigo Ln., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.622914\" data-lon=\"-120.690742\" data-zoom=\"17\" data-label=\"Catholic Charities\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li>Main: <a href=\"tel:+1-805-541-9110\" aria-label=\"Call 805-541-9110\">805-541-9110</a> </li>\n<li>Paso Robles: <a href=\"tel:+1-805-541-9120\" aria-label=\"Call 805-541-9120\">805-541-9120</a> (to schedule appointments) </li>\n<li>Immigration and Citizenship Program: <a href=\"tel:+1-831-722-2675\" aria-label=\"Call 831-722-2675\">831-722-2675</a></li>\n<li>Tattoo Removal: <a href=\"tel:+1-831-316-9121\" aria-label=\"Call 831-316-9121\">831-316-9121</a> (Note: Tattoo removal office is in Santa Cruz, not SLO) </li>\n</ul>\n</li>\n<li><strong>Hours:</strong><ul>\n<li>SLO offices: M–F 8am–5pm (call to confirm hours for specific location)</li>\n<li>Paso Robles: Second Wednesday of every month, 1–5pm</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Catholic Charities (Diocese of Monterey)"
+    ]
+  },
+  "Cayucos-Community-Church": {
+    "title": "Cayucos Community Church",
+    "content": "<h2><span>Cayucos Community Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.cayucoschurch.org/\" data-external-link=\"true\">cayucoschurch.org</a></li>\n<li><strong>Location:</strong> 60 S. 3rd St., Cayucos <a class=\"map-link\" data-lat=\"35.445457\" data-lon=\"-120.898613\" data-zoom=\"17\" data-label=\"Cayucos Community Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-995-3821\" aria-label=\"Call 805-995-3821\">805-995-3821</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@cayucoschurch.com\" aria-label=\"Email info@cayucoschurch.com\">info@cayucoschurch.com</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Office: Tu–Th 10am–2pm (closed Fridays and holidays)</li>\n<li>Food pantry (“Harvest Bag”): First, third, fourth, &amp; fifth Wednesdays at 10:30am </li>\n<li>USDA food distribution: Second Wednesday at 10:30am </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Cayucos Community Church"
+    ]
+  },
+  "CenCal": {
+    "title": "CenCal Health",
+    "content": "<h2><span>CenCal Health</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"Medi-Cal\" aria-label=\"View directory entry for Medi-Cal\"><strong>Medi-Cal</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://cencalhealth.org/\" data-external-link=\"true\">Cencalhealth.org</a></li>\n<li><strong>Locations:</strong> See <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a> </li>\n<li><strong>Phone:</strong><ul>\n<li>Business office: <a href=\"tel:+1-800-421-2560\" aria-label=\"Call 800-421-2560\">800-421-2560</a> or <a href=\"tel:+1-805-685-9525\" aria-label=\"Call 805-685-9525\">805-685-9525</a> </li>\n<li>Enrollment: <a href=\"tel+1-877-227-3051\">877-227-3051</a> </li>\n<li>Member services: <a href=\"tel:+1-877-814-1861\" aria-label=\"Call 877-814-1861\">877-814-1861</a> (M–F, 8am–5pm) </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> You can submit an application online via <a href=\"https://www.coveredca.com/\" data-external-link=\"true\">Covered California</a> or <a href=\"https://www.mybenefitscalwin.org/\" data-external-link=\"true\">My Benefits CalWIN</a> or you can get help applying from the <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a> </li>\n<li>Note: for CenCal Shuttle, <em>See <a href=\"#\" data-directory-link=\"Ride-On-Transportation\" aria-label=\"View directory entry for Ride-On Transportation\"><strong>Ride-On Transportation</strong></a></em></li>\n</ul>\n",
+    "aliases": [
+      "CenCal Health",
+      "**Medi-Cal**"
+    ]
+  },
+  "CARD": {
+    "title": "Center for Autism & Related Disorders",
+    "content": "<h2><span>Center for Autism &amp; Related Disorders</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://centerforautism.com/locations/san-luis-obispo-california/\" data-external-link=\"true\">centerforautism.com</a></li>\n<li><strong>Location:</strong> 1212 Marsh St. #1, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.282685\" data-lon=\"-120.657396\" data-zoom=\"17\" data-label=\"CARD\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-703-2120\" aria-label=\"Call 805-703-2120\">805-703-2120</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:Info@centerforautism.com\" aria-label=\"Email Info@centerforautism.com\">Info@centerforautism.com</a> </li>\n<li><strong>Hours:</strong> M–F 8am–7pm (weekend hours vary) </li>\n<li><strong>How to access:</strong><ul>\n<li>Enroll at <a href=\"https://admissions.centerforautism.com/\" data-external-link=\"true\">this web page</a></li>\n<li>or call <a href=\"tel:+1-877-448-4747;ext=2\" aria-label=\"Call 877-448-4747 x2\">877-448-4747 x2</a> </li>\n<li>or email <a href=\"mailto:cardenrollment@centerforautism.com\" aria-label=\"Email cardenrollment@centerforautism.com\">cardenrollment@centerforautism.com</a> </li>\n</ul>\n</li>\n<li>Notes: Accepts CenCal Health and most other insurance providers </li>\n</ul>\n",
+    "aliases": [
+      "Center for Autism & Related Disorders"
+    ]
+  },
+  "CFS": {
+    "title": "Center for Family Strengthening (CFS)",
+    "content": "<h2><span>Center for Family Strengthening (CFS)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://cfsslo.org/\" data-external-link=\"true\">cfsslo.org</a></li>\n<li><strong>Location:</strong> 1428 Phillips Lane #203, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.288103\" data-lon=\"-120.657544\" data-zoom=\"17\" data-label=\"Center for Family Strengthening\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-1994\" aria-label=\"Call 805-439-1994\">805-439-1994</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@cfsslo.org\" aria-label=\"Email info@cfsslo.org\">info@cfsslo.org</a> </li>\n<li><strong>Hours:</strong> By appointment (call or email to schedule) </li>\n<li>Notes:<ul>\n<li>make referrals via <a href=\"#\" data-directory-link=\"Adult-Protective-Services\" aria-label=\"View directory entry for Adult Protective Services\"><strong>Adult Protective Services</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"Medically-Fragile-Homeless-Program\" aria-label=\"View directory entry for Medically Fragile Homeless Program\"><strong>Medically Fragile Homeless Program</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"Parent-Connection-of-SLO-County\" aria-label=\"View directory entry for Parent Connection of SLO County\"><strong>Parent Connection of SLO County</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"Link-Family-Resource-Center\" aria-label=\"View directory entry for The Link Family Resource Center\"><strong>The Link Family Resource Center</strong></a> (Atascadero and Paso Robles locations)</li>\n<li>partner in <a href=\"#\" data-directory-link=\"SLO-County-UndocuSupport\" aria-label=\"View directory entry for SLO County UndocuSupport\"><strong>SLO County UndocuSupport</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Center for Family Strengthening (CFS)"
+    ]
+  },
+  "The-Center": {
+    "title": "The Center for Health & Prevention",
+    "content": "<h2><span>The Center for Health &amp; Prevention</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/the-center/\" data-external-link=\"true\">capslo.org/the-center</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1152 E. Grand Ave. (Arroyo Grande) <a href=\"#\" class=\"map-link\" data-lat=\"35.120865\" data-lon=\"-120.597299\" data-zoom=\"17\" data-label=\"The Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-489-4026\" aria-label=\"Call 805-489-4026\">805-489-4026</a> (Arroyo Grande)</td>\n<td data-label=\"Hours\">M–F 8:30am–5:30m </td>\n</tr>\n<tr>\n<td data-label=\"Location\">705 Grand Ave. (SLO) <a href=\"#\" class=\"map-link\" data-lat=\"35.290116\" data-lon=\"-120.653550\" data-zoom=\"17\" data-label=\"The Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-544-2498;ext=211\" aria-label=\"Call 805-544-2498 x211\">805-544-2498 x211</a> (SLO)</td>\n<td data-label=\"Hours\">M–F 8:30am–5:30pm </td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-422-2498;ext=121\" aria-label=\"Call 805-422-2498&nbsp;x121\">805-422-2498&nbsp;x121</a> (info line) </li>\n<li><a href=\"tel:+1-805-544-2409;ext=111\" aria-label=\"Call 805-544-2409&nbsp;x111\">805-544-2409&nbsp;x111</a> (mobile reproductive health clinic info) </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> Walk-ins OK, but appointments recommended. </li>\n<li>Note:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)\"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></li>\n<li>Teen clinic Tuesday 3–6pm, Friday 3–5:30pm in Arroyo Grande</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "The Center for Health & Prevention"
+    ]
+  },
+  "CCADRC": {
+    "title": "Central Coast Aging & Disability Resource Center (CCADRC)",
+    "content": "<h2><span>Central Coast Aging &amp; Disability Resource Center (CCADRC)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://centralcoastseniors.org/aging-and-disability-resource-center/\" data-external-link=\"true\">centralcoastseniors.org/aging-and-disability-resource-center</a></li>\n<li><strong>Location:</strong> 528 S. Broadway, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.948009\" data-lon=\"-120.436107\" data-zoom=\"17\" data-label=\"CCADRC\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-928-2552\" aria-label=\"Call 805-928-2552\">805-928-2552</a> / <a href=\"tel:+1-800-510-2020\" aria-label=\"Call 800-510-2020\">800-510-2020</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@centralcoastseniors.org\" aria-label=\"Email info@centralcoastseniors.org\">info@centralcoastseniors.org</a> </li>\n<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm)</li>\n<li><strong>How to access:</strong> Walk-ins OK.</li>\n<li>Notes:<ul>\n<li>partner in <a href=\"#\" data-directory-link=\"Access-Central-Coast\" aria-label=\"View directory entry for Access Central Coast\"><strong>Access Central Coast</strong></a></li>\n<li>operated by <a href=\"#\" data-directory-link=\"Central-Coast-Commission-for-Senior-Citizens\" aria-label=\"View directory entry for Central Coast Commission for Senior Citizens\"><strong>Central Coast Commission for Senior Citizens</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Aging & Disability Resource Center (CCADRC)"
+    ]
+  },
+  "CCATC": {
+    "title": "Central Coast Assistive Technology Center",
+    "content": "<h2><span>Central Coast Assistive Technology Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://ccatc.org/\" data-external-link=\"true\">ccatc.org</a></li>\n<li><strong>Location:</strong> 11491 Los Osos Valley Rd. #202, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.258145\" data-lon=\"-120.692577\" data-zoom=\"17\" data-label=\"CCATC\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-549-7420\" aria-label=\"Call 805-549-7420\">805-549-7420</a>  (TTY: <a href=\"tel:+1-805-549-7424\" aria-label=\"Call 805-549-7424\">805-549-7424</a>)</li>\n<li><strong>How to access:</strong> call to make an appointment</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Assistive Technology Center"
+    ]
+  },
+  "Central-Coast-Autism-Spectrum-Center": {
+    "title": "Central Coast Autism Spectrum Center",
+    "content": "<h2><span>Central Coast Autism Spectrum Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://sloautism.org/\" data-external-link=\"true\">sloautism.org</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 3417, SLO, CA 93403 </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-763-1100\" aria-label=\"Call 805-763-1100\">805-763-1100</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:contact@sloautism.org\" aria-label=\"Email contact@sloautism.org\">contact@sloautism.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Autism Spectrum Center"
+    ]
+  },
+  "Central-Coast-Coalition-for-Undocumented-Student-Success": {
+    "title": "Central Coast Coalition for Undocumented Student Success",
+    "content": "<h2><span>Central Coast Coalition for Undocumented Student Success</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ccc-uss.org/\" data-external-link=\"true\">ccc-uss.org</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 15759, SLO, CA 93406 </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:ccc.undocu@gmail.com\" aria-label=\"Email ccc.undocu@gmail.com\">ccc.undocu@gmail.com</a> </li>\n</ul>\n</li>\n</ul>\n\n<ul>\n<li>Notes:<ul>\n<li>Cal Poly DREAM Center contact: Vania Agama Ramirez</li>\n<li>Cuesta Monarch DREAM Center: <a href=\"tel:+1-805-546-3109\" aria-label=\"Call 805-546-3109\">805-546-3109</a></li>\n<li>Allan Hancock: <a href=\"tel:+1-805-922-6966;ext=3177\" aria-label=\"Call 805-922-6966 x3177\">805-922-6966 x3177</a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Coalition for Undocumented Student Success"
+    ]
+  },
+  "Central-Coast-Commission-for-Senior-Citizens": {
+    "title": "Central Coast Commission for Senior Citizens",
+    "content": "<h2><span>Central Coast Commission for Senior Citizens</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.centralcoastseniors.org/\" data-external-link=\"true\">centralcoastseniors.org</a></li>\n<li><strong>Location:</strong> 528 S. Broadway, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.948009\" data-lon=\"-120.436107\" data-zoom=\"17\" data-label=\"Central Coast Commission for Senior Citizens\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-925-9554\" aria-label=\"Call 805-925-9554\">805-925-9554</a> </li>\n<li><a href=\"tel:+1-800-434-0222\" aria-label=\"Call 800-434-0222\">800-434-0222</a></li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@centralcoastseniors.org\" aria-label=\"Email info@centralcoastseniors.org\">info@centralcoastseniors.org</a></li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li>Notes:<ul>\n<li>the local “Area Agency on Aging” </li>\n<li>operates <a href=\"#\" data-directory-link=\"Senior-Connection\" aria-label=\"View directory entry for Senior Connection\"><strong>Senior Connection</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"HiCAP\" aria-label=\"View directory entry for HiCAP\"><strong>HiCAP</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"CCADRC\" aria-label=\"View directory entry for Central Coast Aging &amp; Disability Resource Center\"><strong>Central Coast Aging &amp; Disability Resource Center</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Commission for Senior Citizens"
+    ]
+  },
+  "CCDS": {
+    "title": "Central Coast Dental Society",
+    "content": "<h2><span>Central Coast Dental Society</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.centralcoastdentalsociety.org/\" data-external-link=\"true\">centralcoastdentalsociety.org</a></li>\n<li><strong>Location:</strong> 1356 Marsh St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.283784\" data-lon=\"-120.655128\" data-zoom=\"17\" data-label=\"Central Coast Dental Society\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-1113\" aria-label=\"Call 805-544-1113\">805-544-1113</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:ccds@charter.net\" aria-label=\"Email ccds@charter.net\">ccds@charter.net</a> </li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Dental Society"
+    ]
+  },
+  "Central-Coast-Home-Health": {
+    "title": "Central Coast Home Health and Hospice",
+    "content": "<h2><span>Central Coast Home Health and Hospice</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://centralcoasthomehealth.com/\" data-external-link=\"true\">centralcoasthomehealth.com</a></li>\n<li><strong>Location:</strong> 253 Granada Dr. #D, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.250819\" data-lon=\"-120.666897\" data-zoom=\"17\" data-label=\"Central Coast Home Health and Hospice\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-543-2244\" aria-label=\"Call 805-543-2244\">805-543-2244</a> (Home Health) </li>\n<li><a href=\"tel:+1-805-540-6020\" aria-label=\"Call 805-540-6020\">805-540-6020</a> (Hospice) </li>\n<li><a href=\"tel:+1-855-240-2530\" aria-label=\"Call 855-240-2530\">855-240-2530</a> (Medi-Cal verification and financial assistance)</li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@cchh08.com\" aria-label=\"Email info@cchh08.com\">info@cchh08.com</a> </li>\n<li><strong>Hours:</strong> 24/7 (Monday–Sunday)</li>\n<li>Notes: Accepts Medicare; call <a href=\"tel:+1-855-240-2530\" aria-label=\"Call 855-240-2530\">855-240-2530</a> to verify Medi-Cal acceptance and discuss financial assistance options</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Home Health and Hospice"
+    ]
+  },
+  "CCPAW": {
+    "title": "Central Coast Partnership for Animal Welfare",
+    "content": "<h2><span>Central Coast Partnership for Animal Welfare</span></h2>\n<ul>\n<li><strong>Locations:</strong> (pet food distribution)<ul>\n<li>946 Rockaway Ave., Grover Beach (<a href=\"#\" data-directory-link=\"Lifepoint-Church\" aria-label=\"View directory entry for Lifepoint Church\"><strong>Lifepoint Church</strong></a>) <a href=\"#\" class=\"map-link\" data-lat=\"35.120091\" data-lon=\"-120.619796\" data-zoom=\"17\" data-label=\"Central Coast Partnership for Animal Welfare\">Map</a></li>\n<li>parking lot at 1710 Ocean St., Oceano <a href=\"#\" class=\"map-link\" data-lat=\"35.100069\" data-lon=\"-120.612256\" data-zoom=\"17\" data-label=\"Central Coast Partnership for Animal Welfare\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-574-0563\" aria-label=\"Call 805-574-0563\">805-574-0563</a><ul>\n<li>Emergency Pet Care: <a href=\"tel:+1-775-841-7463\" aria-label=\"Call 775-841-7463\">775-841-7463</a></li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:mamagack@hotmail.com\" aria-label=\"Email mamagack@hotmail.com\">mamagack@hotmail.com</a></li>\n<li><strong>Hours:</strong><ul>\n<li>Grover Beach: M–F, 2–3:30pm</li>\n<li>Oceano: W 1–2pm</li>\n</ul>\n</li>\n<li><strong>How to access:</strong><ul>\n<li>For pet food distributions, come to locations during operating hours, or call them for delivery options</li>\n<li>For emergency pet care, call, then a case manager conducts interview for Emergency Vet Care Program qualification and vet referrals</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Partnership for Animal Welfare"
+    ]
+  },
+  "Central-Coast-Senior-Center": {
+    "title": "Central Coast Senior Center (Oceano)",
+    "content": "<h2><span>Central Coast Senior Center (Oceano)</span></h2>\n<ul>\n<li><strong>Location:</strong> 1580 Railroad St., Oceano <a class=\"map-link\" data-lat=\"35.101131\" data-lon=\"-120.617666\" data-zoom=\"17\" data-label=\"Central Coast Senior Center (Oceano)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-481-7886\" aria-label=\"Call 805-481-7886\">805-481-7886</a> </li>\n<li><strong>Hours:</strong> M–F, 9am–3pm </li>\n<li>Notes:<ul>\n<li>Open to seniors 50+; for more information call <a href=\"#\" data-directory-link=\"Senior-Connection\" aria-label=\"View directory entry for Senior Connection\"><strong>Senior Connection</strong></a></li>\n<li>Activities cost $2 for members, $3 for non-members (membership is $30 for individuals, $40 for couples)</li>\n<li>A lunch site for meals offered through <a href=\"#\" data-directory-link=\"Meals-that-Connect\" aria-label=\"View directory entry for Meals that Connect\"><strong>Meals that Connect</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Senior Center (Oceano)"
+    ]
+  },
+  "Central-Coast-Veterans-Helping-Veterans": {
+    "title": "Central Coast Veterans Helping Veterans",
+    "content": "<h2><span>Central Coast Veterans Helping Veterans</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ccvhv.org/\" data-external-link=\"true\">ccvhv.org</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 12725, SLO, CA 93406 { Source: <a href=\"https://www.ccvhv.org/contact.html\" data-external-link=\"true\">https://www.ccvhv.org/contact.html</a> }</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-285-5526\" aria-label=\"Call 805-285-5526\">805-285-5526</a> { Source: <a href=\"https://www.ccvhv.org/contact.html\" data-external-link=\"true\">https://www.ccvhv.org/contact.html</a> }</li>\n<li><strong>Email:</strong> <a href=\"ccvetshelpingvets@outlook.com\">ccvetshelpingvets@outlook.com</a> { Source: <a href=\"https://www.ccvhv.org/contact.html\" data-external-link=\"true\">https://www.ccvhv.org/contact.html</a> }\n{ Note: Organization uses P.O. Box; no physical office address or public operating hours found (as of October 2025). Contact via phone or email for services }\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Central Coast Veterans Helping Veterans"
+    ]
+  },
+  "Child-Care-Resource-Connection": {
+    "title": "Child Care Resource Connection",
+    "content": "<h2><span>Child Care Resource Connection</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/child-care-resource-connection/\" data-external-link=\"true\">capslo.org/child-care-resource-connection</a></li>\n<li><strong>Location:</strong> 805A Fiero Ln., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.244059\" data-lon=\"-120.642200\" data-zoom=\"17\" data-label=\"Child Care Resource Connection\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-888-727-2272\" aria-label=\"Call 888-727-2272\">888-727-2272</a> </li>\n<li><a href=\"tel:+1-805-541-2272\" aria-label=\"Call 805-541-2272\">805-541-2272</a> (SLO) </li>\n<li><a href=\"tel:+1-805-474-2062\" aria-label=\"Call 805-474-2062\">805-474-2062</a> (South County)</li>\n<li><a href=\"tel:+1-805-226-3249\" aria-label=\"Call 805-226-3249\">805-226-3249</a> (North County)</li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F, 8am–5pm</li>\n<li><strong>How to access:</strong> walk-ins OK<ul>\n<li>get a referral from the <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a></li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>operated by <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo\"><strong>Community Action Partnership San Luis Obispo</strong></a></li>\n<li>there is often a waiting list for some services</li>\n<li>toy lending library by appointment only</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Child Care Resource Connection"
+    ]
+  },
+  "Child-Development-Resource-Center": {
+    "title": "Child Development Resource Center",
+    "content": "<h2><span>Child Development Resource Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.childrensresource.org/\" data-external-link=\"true\">childrensresource.org</a></li>\n<li><strong>Location:</strong> 1720 Bishop St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.275653\" data-lon=\"-120.644484\" data-zoom=\"17\" data-label=\"Child Development Resource Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-0801\" aria-label=\"Call 805-544-0801\">805-544-0801</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slocdc.org\" aria-label=\"Email info@slocdc.org\">info@slocdc.org</a></li>\n<li><strong>How to access:</strong> Complete <a href=\"https://www.childrensresource.org/regristration\" data-external-link=\"true\">an application</a> or get a referral from child welfare services or from a legal, medical, social services, or emergency shelter provider. Tuition is on a sliding scale based on income. Financial aid is available.</li>\n</ul>\n",
+    "aliases": [
+      "Child Development Resource Center"
+    ]
+  },
+  "Child-Support-Services": {
+    "title": "Child Support Services",
+    "content": "<h2><span>Child Support Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/child-support\" data-external-link=\"true\">slocounty.ca.gov/departments/child-support</a></li>\n<li><strong>Location:</strong> 1200 Monterey St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.283704\" data-lon=\"-120.658514\" data-zoom=\"17\" data-label=\"Child Support Services\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-866-901-3212\" aria-label=\"Call 866-901-3212\">866-901-3212</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:css@co.slo.ca.us\" aria-label=\"Email css@co.slo.ca.us\">css@co.slo.ca.us</a> </li>\n<li><strong>Hours:</strong> M–F 8am–4:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Child Support Services"
+    ]
+  },
+  "Childrens-Resource-Network-of-the-Central-Coast": {
+    "title": "Children’s Resource Network of the Central Coast",
+    "content": "<h2><span>Children’s Resource Network of the Central Coast</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.childrensresourcenetwork.org\" data-external-link=\"true\">childrensresourcenetwork.org</a> </li>\n<li><strong>Location:</strong> 1212 Farroll Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.111293\" data-lon=\"-120.602116\" data-zoom=\"17\" data-label=\"Children’s Resource Network of the Central Coast\">Map</a> </li>\n<li><strong>Mailing address:</strong> P.O. Box 454, Pismo Beach, CA 93448-0454</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-709-8673\" aria-label=\"Call 805-709-8673\">805-709-8673</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:lisa@childrensresourcenetwork.org\" aria-label=\"Email lisa@childrensresourcenetwork.org\">lisa@childrensresourcenetwork.org</a> </li>\n<li>Notes: Operates “Outreach Apparel” and “The Teen’s Closet”</li>\n</ul>\n",
+    "aliases": [
+      "Children’s Resource Network of the Central Coast"
+    ]
+  },
+  "City-of-SLO-Parks-and-Recreation": {
+    "title": "City of SLO Parks and Recreation",
+    "content": "<h2><span>City of SLO Parks and Recreation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocity.org/government/department-directory/parks-and-recreation\" data-external-link=\"true\">slocity.org/government/department-directory/parks-and-recreation</a></li>\n<li><strong>Location:</strong> 1341 Nipomo St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.276384\" data-lon=\"-120.664500\" data-zoom=\"17\" data-label=\"City of SLO Parks and Recreation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-7300\" aria-label=\"Call 805-781-7300\">805-781-7300</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:recreation@slocity.org\" aria-label=\"Email recreation@slocity.org\">recreation@slocity.org</a> </li>\n<li><strong>Hours:</strong> M–F 8am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "City of SLO Parks and Recreation"
+    ]
+  },
+  "Coastal-Dunes": {
+    "title": "Coastal Dunes RV Park & Campground",
+    "content": "<h2><span>Coastal Dunes RV Park &amp; Campground</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocountyparks.com/camp/coastal-dunes/\" data-external-link=\"true\">slocountyparks.com/camp/coastal-dunes</a></li>\n<li><strong>Location:</strong> 1001 Pacific Blvd. <a href=\"#\" class=\"map-link\" data-lat=\"35.113119\" data-lon=\"-120.625704\" data-zoom=\"16\" data-label=\"Coastal Dunes RV Park\">Map</a></li>\n<li><strong>Phone:</strong><ul>\n<li>Park ranger office <a href=\"tel:+1-805-781-4900\" aria-label=\"Call 805-781-4900\">805-781-4900</a>  M–Th 8am–4:30pm; F–Su 8am–6pm</li>\n<li>Reservations: <a href=\"tel:+1-805-781-5930\" aria-label=\"Call 805-781-5930\">805-781-5930</a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Coastal Dunes RV Park & Campground"
+    ]
+  },
+  "CoastHills-Credit-Union": {
+    "title": "CoastHills Credit Union",
+    "content": "<h2><span>CoastHills Credit Union</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://coasthills.coop/\" data-external-link=\"true\">coasthills.coop</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1360 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.121113\" data-lon=\"-120.604811\" data-zoom=\"17\" data-label=\"CoastHills Credit Union\">Map</a></td>\n<td data-label=\"Hours\">M–Th 9am–5pm, F 9am–6pm, Sa. 10am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">8900 Pueblo Ave., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.479914\" data-lon=\"-120.658349\" data-zoom=\"17\" data-label=\"CoastHills Credit Union\">Map</a></td>\n<td data-label=\"Hours\">M–Th 9am–5pm, F 9am–6pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">671 W. Tefft St. #6, Nipomo <a href=\"#\" class=\"map-link\" data-lat=\"35.036884\" data-lon=\"-120.487468\" data-zoom=\"17\" data-label=\"CoastHills Credit Union\">Map</a></td>\n<td data-label=\"Hours\">M–Th 9am–5pm, F 9am–6pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1402 Spring St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.629040\" data-lon=\"-120.691354\" data-zoom=\"17\" data-label=\"CoastHills Credit Union\">Map</a></td>\n<td data-label=\"Hours\">M–Th 9am–5pm, F 9am–6pm, Sa. 10am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">751 Marsh St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.278378\" data-lon=\"-120.662853\" data-zoom=\"17\" data-label=\"CoastHills Credit Union\">Map</a></td>\n<td data-label=\"Hours\">M–Th 9am–5pm, F 9am–6pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-733-7600\" aria-label=\"Call 805-733-7600\">805-733-7600</a> / <a href=\"tel:+1-800-262-4488\" aria-label=\"Call 800-262-4488\">800-262-4488</a> </li>\n</ul>\n",
+    "aliases": [
+      "CoastHills Credit Union"
+    ]
+  },
+  "CAPSLO": {
+    "title": "Community Action Partnership San Luis Obispo (CAPSLO)",
+    "content": "<h2><span>Community Action Partnership San Luis Obispo (CAPSLO)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/\" data-external-link=\"true\">capslo.org</a></li>\n<li><strong>Location:</strong><ul>\n<li>Main Office: 1030 Southwood Dr., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.266202\" data-lon=\"-120.642336\" data-zoom=\"17\" data-label=\"CAPSLO\">Map</a> </li>\n<li>Homeless Services: 40 Prado Rd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.256218\" data-lon=\"-120.672031\" data-zoom=\"17\" data-label=\"40 Prado Homeless Services Center\">Map</a> </li>\n<li>Energy Office: 3970 Short St. #110, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.245356\" data-lon=\"-120.672187\" data-zoom=\"17\" data-label=\"CAPSLO Home and Energy Services\">Map</a> (no walk-ins) </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li>Hotline: <a href=\"tel:+1-805-706-8663\" aria-label=\"Call 805-706-8663\">805-706-8663</a> </li>\n<li>Administration: <a href=\"tel:+1-805-544-4355\" aria-label=\"Call 805-544-4355\">805-544-4355</a> </li>\n<li>Homeless Services Center: <a href=\"tel:+1-805-544-4004\" aria-label=\"Call 805-544-4004\">805-544-4004</a></li>\n<li>Low Income Home Energy Assistance Program: <a href=\"tel:+1-805-541-4122;ext=2125\" aria-label=\"Call 805-541-4122&nbsp;x2125\">805-541-4122&nbsp;x2125</a> or <a href=\"tel:+1-800-495-0501;ext=2114\" aria-label=\"Call 800-495-0501&nbsp;x2114\">800-495-0501&nbsp;x2114</a></li>\n<li>Energy Office: <a href=\"tel:+1-805-541-4122\" aria-label=\"Call 805-541-4122\">805-541-4122</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:hotline@capslo.org\" aria-label=\"Email hotline@capslo.org\">hotline@capslo.org</a> <ul>\n<li>Low Income Home Energy Assistance Program: <a href=\"mailto:HEAP@capslo.org\" aria-label=\"Email HEAP@capslo.org\">HEAP@capslo.org</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 9am–5pm<ul>\n<li>Energy Office: M–F 8am–Noon &amp; 1pm–4pm (no walk-ins)</li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>operates <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"The-Center\" aria-label=\"View directory entry for The Center for Health &amp; Prevention\"><strong>The Center for Health &amp; Prevention</strong></a></li>\n<li>operates “Child Care Resource Connection (CCRC)”</li>\n<li>operates <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n<li>operates “Head Start”</li>\n<li>operates “Home and Energy Services”</li>\n<li>operates <a href=\"#\" data-directory-link=\"Liberty-Tattoo-Removal-Program\" aria-label=\"View directory entry for Liberty Tattoo Removal Program\"><strong>Liberty Tattoo Removal Program</strong></a></li>\n<li>operates “Low Income Home Energy Assistance Program (LIHEAP)”</li>\n<li>operates <a href=\"#\" data-directory-link=\"Outreach-and-Engagement-Services\" aria-label=\"View directory entry for Outreach &amp; Engagement Services\"><strong>Outreach &amp; Engagement Services</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"Rotating-Overnight-Safe-Parking-Program\" aria-label=\"View directory entry for Rotating Overnight Safe Parking Program\"><strong>Rotating Overnight Safe Parking Program</strong></a></li>\n<li>operates “Senior Health Screening”</li>\n<li>operates <a href=\"#\" data-directory-link=\"Supportive-Services-for-Veteran-Families\" aria-label=\"View directory entry for Supportive Services for Veteran Families\"><strong>Supportive Services for Veteran Families</strong></a></li>\n<li>operates “Teen Wellness”</li>\n<li>partner in <a href=\"#\" data-directory-link=\"SLO-Hub\" aria-label=\"View directory entry for SLO Hub\"><strong>SLO Hub</strong></a></li>\n<li>partner in <a href=\"#\" data-directory-link=\"SLO-County-UndocuSupport\" aria-label=\"View directory entry for SLO County UndocuSupport\"><strong>SLO County UndocuSupport</strong></a></li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"Enhanced-Care-Management\" aria-label=\"View directory entry for Enhanced Care Management\"><strong>Enhanced Care Management</strong></a></li>\n<li>on board of “Emergency Food and Shelter Program”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Community Action Partnership San Luis Obispo (CAPSLO)"
+    ]
+  },
+  "Community-Counseling-Center": {
+    "title": "Community Counseling Center",
+    "content": "<h2><span>Community Counseling Center</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"Cal-Poly-Community-Counseling-Service\" aria-label=\"View directory entry for Cal Poly Community Counseling Service\"><strong>Cal Poly Community Counseling Service</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.cccslo.org/what-we-do.php\" data-external-link=\"true\">cccslo.org/what-we-do.php</a></li>\n<li><strong>Location:</strong> 676 Pismo St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.276497\" data-lon=\"-120.662980\" data-zoom=\"17\" data-label=\"Community Counseling Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-7969\" aria-label=\"Call 805-543-7969\">805-543-7969</a> </li>\n<li><strong>Hours:</strong> M–F 9am–6pm </li>\n<li><strong>How to access:</strong> Call to make an appointment or use their <a href=\"https://www.cccslo.org/locations.php\" data-external-link=\"true\">contact form</a> </li>\n</ul>\n",
+    "aliases": [
+      "Community Counseling Center",
+      "**Cal Poly Community Counseling Service**"
+    ]
+  },
+  "CHC": {
+    "title": "Community Health Centers of the Central Coast",
+    "content": "<h2><span>Community Health Centers of the Central Coast</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.communityhealthcenters.org/\" data-external-link=\"true\">communityhealthcenters.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Notes</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">260 Station Way, Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.119769\" data-lon=\"-120.578564\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-573-6201\" aria-label=\"Call 805-573-6201\">805-573-6201</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">1057 Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.118759\" data-lon=\"-120.595400\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-270-1700\" aria-label=\"Call 805-270-1700\">805-270-1700</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">1205 E. Grand Ave. #H, Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.120369\" data-lon=\"-120.600572\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-994-2300\" aria-label=\"Call 805-994-2300\">805-994-2300</a></td>\n<td data-label=\"Notes\">(“urgent care”; walk-ins OK; M–F 8am–8pm, Sa/Su 9am–5pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">7512 Morro Rd., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.477246\" data-lon=\"-120.667898\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-792-1400\" aria-label=\"Call 805-792-1400\">805-792-1400</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">1276 Tamsen Dr., Cambria <a href=\"#\" class=\"map-link\" data-lat=\"35.565935\" data-lon=\"-121.079680\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-927-5292\" aria-label=\"Call 805-927-5292\">805-927-5292</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">150 Tejas Place, Nipomo <a href=\"#\" class=\"map-link\" data-lat=\"35.027106\" data-lon=\"-120.499120\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-929-3211\" aria-label=\"Call 805-929-3211\">805-929-3211</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">2120 Cienaga St., Oceano <a href=\"#\" class=\"map-link\" data-lat=\"35.097852\" data-lon=\"-120.608650\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-994-2100\" aria-label=\"Call 805-994-2100\">805-994-2100</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">2800 Riverside Ave. #101, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.643630\" data-lon=\"-120.688162\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-238-7250\" aria-label=\"Call 805-238-7250\">805-238-7250</a></td>\n<td data-label=\"Notes\">(“immediate care”; walk-ins OK; M–Sa 8am–Noon &amp; 1pm–5pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1385 Mission St., San Miguel <a href=\"#\" class=\"map-link\" data-lat=\"35.752573\" data-lon=\"-120.696391\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-467-2344\" aria-label=\"Call 805-467-2344\">805-467-2344</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">1551 Bishop St. #240, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.273443\" data-lon=\"-120.644957\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-549-0402\" aria-label=\"Call 805-549-0402\">805-549-0402</a></td>\n<td data-label=\"Notes\">(specializes in women’s health)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">77 Casa St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.292914\" data-lon=\"-120.665307\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-269-1500\" aria-label=\"Call 805-269-1500\">805-269-1500</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">40 Prado, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.256495\" data-lon=\"-120.672000\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-269-1500\" aria-label=\"Call 805-269-1500\">805-269-1500</a></td>\n<td data-label=\"Notes\">(<a href=\"#\" data-directory-link=\"HCHP\" aria-label=\"View directory entry for Healthcare for the Homeless Program\"><strong>Healthcare for the Homeless Program</strong></a>)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1330 Las Tablas Rd., Templeton <a href=\"#\" class=\"map-link\" data-lat=\"35.554714\" data-lon=\"-120.723803\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-542-6700\" aria-label=\"Call 805-542-6700\">805-542-6700</a></td>\n<td data-label=\"Notes\">(“immediate care”; walk-ins OK; M–Th 8am–6pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">292 Posada Ln., Templeton <a href=\"#\" class=\"map-link\" data-lat=\"35.553046\" data-lon=\"-120.721773\" data-zoom=\"17\" data-label=\"Community Health Centers of the Central Coast\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-542-6701\" aria-label=\"Call 805-542-6701\">805-542-6701</a></td>\n<td data-label=\"Notes\"></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-866-614-4636\" aria-label=\"Call 866-614-4636\">866-614-4636</a> <ul>\n<li>Text: <a href=\"sms:+1-805-361-8400\">805-361-8400</a> </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> “Immediate care” or “urgent care” centers accept walk-ins. Otherwise, make an appointment.<ul>\n<li>Accepts private pay, full- and partially-insured, Medi-Cal, and Medicare. Also offers a sliding fee scale based on income and family size to people without any health insurance. </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Also operates <a href=\"#\" data-directory-link=\"HCHP\" aria-label=\"View directory entry for Healthcare for the Homeless Program\"><strong>Healthcare for the Homeless Program</strong></a> at the <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a></li>\n<li>“CHC Transportation Services” is a door-to-door ride service to appointments (<a href=\"tel:+1-877-743-3242\" aria-label=\"Call 877-743-3242\">877-743-3242</a>)</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Community Health Centers of the Central Coast"
+    ]
+  },
+  "Community-Partners-in-Caring": {
+    "title": "Community Partners in Caring",
+    "content": "<h2><span>Community Partners in Caring</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://partnersincaring.org/\" data-external-link=\"true\">partnersincaring.org</a></li>\n<li><strong>Location:</strong> 120 E. Jones St. #130, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.945579\" data-lon=\"-120.434639\" data-zoom=\"17\" data-label=\"Community Partners in Caring\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-925-8000\" aria-label=\"Call 805-925-8000\">805-925-8000</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@partnersincaring.org\" aria-label=\"Email info@partnersincaring.org\">info@partnersincaring.org</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–5pm </li>\n<li><strong>How to access:</strong> Complete the client onboarding forms (which can be done via their website) to access the services. </li>\n<li>Notes: operates in Nipomo and the Five Cities area, in addition to Santa Barbara County</li>\n</ul>\n",
+    "aliases": [
+      "Community Partners in Caring"
+    ]
+  },
+  "CES": {
+    "title": "Coordinated Entry System (CES)",
+    "content": "<h2><span>Coordinated Entry System (CES)</span></h2>\n<ul>\n<li><strong>How to access:</strong><ul>\n<li>South County: Contact <a href=\"Directory#5CHC\"><strong>5Cities Homeless Coalition</strong></a></li>\n<li>County-wide: Contact <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a></li>\n<li>Or initiate contact via other participating agencies like <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)\"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a>, <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for Transitions Mental Health Association (TMHA)\"><strong>Transitions Mental Health Association (TMHA)</strong></a>, <a href=\"#\" data-directory-link=\"Good-Samaritan-Shelter\" aria-label=\"View directory entry for Good Samaritan Shelter\"><strong>Good Samaritan Shelter</strong></a>, <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a>, <a href=\"#\" data-directory-link=\"SLO-County-Health-Department\" aria-label=\"View directory entry for SLO County Health Department\"><strong>SLO County Health Department</strong></a></li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Point of entry for <a href=\"#\" data-directory-link=\"Housing-Now\" aria-label=\"View directory entry for Housing Now\"><strong>Housing Now</strong></a>, (at least some of) <a href=\"#\" data-directory-link=\"Peoples-Self-Help-Housing\" aria-label=\"View directory entry for Peoples’ Self-Help Housing\"><strong>Peoples’ Self-Help Housing</strong></a>, <a href=\"#\" data-directory-link=\"Welcome-Home-Village\" aria-label=\"View directory entry for Welcome Home Village\"><strong>Welcome Home Village</strong></a></li>\n<li>Overseen by “Homeless Services Oversight Council (HSOC)”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Coordinated Entry System (CES)"
+    ]
+  },
+  "Cottage-Urgent-Care": {
+    "title": "Cottage Urgent Care",
+    "content": "<h2><span>Cottage Urgent Care</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.cottagehealth.org/urgent-care/\" data-external-link=\"true\">cottagehealth.org/urgent-care</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">Marigold Center: 3970 Broad Street Suite 2, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.249334\" data-lon=\"-120.643117\" data-zoom=\"17\" data-label=\"Cottage Urgent Care\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-762-4996\" aria-label=\"Call 805-762-4996\">805-762-4996</a></td>\n<td data-label=\"Hours\">Every day: 8am–8pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Foothill Plaza: 777 E. Foothill Blvd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.292930\" data-lon=\"-120.671889\" data-zoom=\"17\" data-label=\"Cottage Urgent Care\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-762-4348\" aria-label=\"Call 805-762-4348\">805-762-4348</a></td>\n<td data-label=\"Hours\">Every day 8am–8pm</td>\n</tr>\n</tbody></table>\n",
+    "aliases": [
+      "Cottage Urgent Care"
+    ]
+  },
+  "Creative-Mediation": {
+    "title": "Creative Mediation",
+    "content": "<h2><span>Creative Mediation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slobar.org/legal-resources/listing/creative-mediation/\" data-external-link=\"true\">slobar.org/legal-resources/listing/creative-mediation</a></li>\n<li><strong>Location:</strong> 285 South St. #P, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.269138\" data-lon=\"-120.666145\" data-zoom=\"17\" data-label=\"Creative Mediation\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-549-0442\" aria-label=\"Call 805-549-0442\">805-549-0442</a></li>\n<li><strong>Hours:</strong> M/W/Th/F 9am–5pm, Tu 8am–5pm\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Creative Mediation"
+    ]
+  },
+  "CSF-Medical-Non-Profit-Foundation": {
+    "title": "CSF Medical Non Profit Foundation",
+    "content": "<h2><span>CSF Medical Non Profit Foundation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://csffoundation.org/\" data-external-link=\"true\">csffoundation.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-661-404-4748\" aria-label=\"Call 661-404-4748\">661-404-4748</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@csffoundation.org\" aria-label=\"Email info@csffoundation.org\">info@csffoundation.org</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5:30pm </li>\n</ul>\n",
+    "aliases": [
+      "CSF Medical Non Profit Foundation"
+    ]
+  },
+  "Cuesta-College": {
+    "title": "Cuesta College",
+    "content": "<h2><span>Cuesta College</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.cuesta.edu/\" data-external-link=\"true\">cuesta.edu</a></li>\n<li><strong>Locations:</strong><ul>\n<li>SLO Campus: 3000 Education Dr., SLO (at Highway 1) <a href=\"#\" class=\"map-link\" data-lat=\"35.329042\" data-lon=\"-120.740620\" data-zoom=\"15\" data-label=\"Cuesta College\">Map</a> </li>\n<li>North County Campus: 2800 Buena Vista Dr., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.650499\" data-lon=\"-120.670746\" data-zoom=\"15\" data-label=\"Cuesta College\">Map</a> </li>\n<li>South County Center: A.G. High School office, room 900, corner of Orchard St. &amp; W. Cherry Ave, Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.117021\" data-lon=\"-120.577601\" data-zoom=\"15\" data-label=\"Cuesta College\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-546-3100\" aria-label=\"Call 805-546-3100\">805-546-3100</a> (SLO Campus) </li>\n<li><a href=\"tel:+1-805-591-6200\" aria-label=\"Call 805-591-6200\">805-591-6200</a> (North County Campus) </li>\n<li><a href=\"tel:+1-805-474-3913\" aria-label=\"Call 805-474-3913\">805-474-3913</a> (South County Center) </li>\n<li><a href=\"tel:+1-805-591-6273\" aria-label=\"Call 805-591-6273\">805-591-6273</a> (Continuing Education Office)</li>\n<li>English as a Second Language (ESL) program:<ul>\n<li><a href=\"tel:+1-805-592-9463\" aria-label=\"Call 805-592-9463\">805-592-9463</a> (SLO Campus) </li>\n<li><a href=\"tel:+1-805-591-6273\" aria-label=\"Call 805-591-6273\">805-591-6273</a> (North County Campus) </li>\n<li><a href=\"tel:+1-805-592-9463\" aria-label=\"Call 805-592-9463\">805-592-9463</a> (South County Center) </li>\n<li>Call M–Th 10am–7pm</li>\n</ul>\n</li>\n<li>Continuing Education program:<ul>\n<li><a href=\"tel:+1-805-592-9463\" aria-label=\"Call 805-592-9463\">805-592-9463</a> (SLO Campus) </li>\n<li><a href=\"tel:+1-805-591-6273\" aria-label=\"Call 805-591-6273\">805-591-6273</a> (North County Campus) </li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:basicneeds@cuest.edu\" aria-label=\"Email basicneeds@cuest.edu\">basicneeds@cuest.edu</a> (Basic Needs Center) </li>\n<li><a href=\"mailto:admit@cuesta.edu\" aria-label=\"Email admit@cuesta.edu\">admit@cuesta.edu</a> (Admission)</li>\n<li><a href=\"mailto:scchelp@cuesta.edu\" aria-label=\"Email scchelp@cuesta.edu\">scchelp@cuesta.edu</a> (South County Campus)</li>\n<li><a href=\"mailto:ContinuingEd@cuesta.edu\" aria-label=\"Email ContinuingEd@cuesta.edu\">ContinuingEd@cuesta.edu</a> (Continuing Education) </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Basic Needs Office is in room 5014B of the SLO campus, open M/Th/F 9am–4pm, Tu 9am–6pm </li>\n<li>The Paso Robles campus hosts a Cougar Food Pantry for students in room N1005, M–F 9am–5pm; <a href=\"tel:+1-805-591-4301\" aria-label=\"Call 805-591-4301\">805-591-4301</a> </li>\n<li>The SLO campus hosts a Cougar Food Pantry for students in room 5014A’s cafeteria, M–F 9am–4:30pm </li>\n<li><a href=\"https://www.cuesta.edu/community/index.html\" data-external-link=\"true\">Community Education</a> programs are open to otherwise unenrolled people</li>\n<li><a href=\"https://www.cuesta.edu/academics/continuinged/\" data-external-link=\"true\">Continuing Education</a> has vocational / lifetime-learning programs, and ESL</li>\n<li>Partners with <a href=\"#\" data-directory-link=\"Restorative-Partners\" aria-label=\"View directory entry for The Bridge Cafe\"><strong>The Bridge Cafe</strong></a> for its Culinary Arts program</li>\n<li>Partners with <a href=\"#\" data-directory-link=\"Lucia-Mar-Adult-Education\" aria-label=\"View directory entry for Lucia Mar Adult Education\"><strong>Lucia Mar Adult Education</strong></a> for ESL classes</li>\n<li>The SLO &amp; North County campuses are <a href=\"#\" data-directory-link=\"SLO-Food-Bank\" aria-label=\"View directory entry for SLO Food Bank\"><strong>SLO Food Bank</strong></a> food box distribution sites </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Cuesta College"
+    ]
+  },
+  "Dignity-Health": {
+    "title": "Dignity Health",
+    "content": "<h2><span>Dignity Health</span></h2>\n<ul>\n<li>Website: <a href=\"https://www.dignityhealth.org/\" data-external-link=\"true\">dignityhealth.org</a></li>\n<li>Operates <a href=\"#\" data-directory-link=\"Arroyo-Grande-Community-Hospital\" aria-label=\"View directory entry for Arroyo Grande Community Hospital\"><strong>Arroyo Grande Community Hospital</strong></a>, <a href=\"#\" data-directory-link=\"French-Hospital-Medical-Center\" aria-label=\"View directory entry for French Hospital Medical Center\"><strong>French Hospital Medical Center</strong></a>, and <a href=\"#\" data-directory-link=\"Dignity-Health-Urgent-Care\" aria-label=\"View directory entry for Dignity Health Urgent Care\"><strong>Dignity Health Urgent Care</strong></a></li>\n<li>Operates the “Substance Use Navigator” program</li>\n</ul>\n",
+    "aliases": [
+      "Dignity Health"
+    ]
+  },
+  "Dignity-Health-Urgent-Care": {
+    "title": "Dignity Health Urgent Care",
+    "content": "<h2><span>Dignity Health Urgent Care</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"Dignity-Health\" aria-label=\"View directory entry for Dignity Health\"><strong>Dignity Health</strong></a></em></p>\n</blockquote>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">Atascadero: 5920 W Mall, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.489540\" data-lon=\"-120.668170\" data-zoom=\"17\" data-label=\"Dignity Health Urgent Care\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-461-2131\" aria-label=\"Call 805-461-2131\">805-461-2131</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Pismo Beach: 877 Oak Park Blvd, Pismo Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.132062\" data-lon=\"-120.606526\" data-zoom=\"17\" data-label=\"Dignity Health Urgent Care\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-8450\" aria-label=\"Call 805-474-8450\">805-474-8450</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Hours:</strong> M–F 8am–6pm, Sa 8am–4pm, Su closed </li>\n<li>Notes: Accepts Medicare and Medi-Cal as well as several private insurers; walk-ins welcome, no appointment necessary; lab and X-ray services on site </li>\n</ul>\n",
+    "aliases": [
+      "Dignity Health Urgent Care",
+      "**Dignity Health**"
+    ]
+  },
+  "Disability-Rights-California": {
+    "title": "Disability Rights California",
+    "content": "<h2><span>Disability Rights California</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.disabilityrightsca.org/get-help\" data-external-link=\"true\">www.disabilityrightsca.org/get-help</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-776-5746\" aria-label=\"Call 800-776-5746\">800-776-5746</a> (TTY: <a href=\"tel:+1-800-719-5798\" aria-label=\"Call 800-719-5798\">800-719-5798</a>) </li>\n<li><strong>Hours:</strong> M/Tu/Th/F 9am–3pm </li>\n</ul>\n",
+    "aliases": [
+      "Disability Rights California"
+    ]
+  },
+  "Discipleship-Home": {
+    "title": "Discipleship Home",
+    "content": "<h2><span>Discipleship Home</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://thediscipleshiphome.com/\" data-external-link=\"true\">thediscipleshiphome.com</a></li>\n<li><strong>Location:</strong> 1359 21st Court, Oceano <a class=\"map-link\" data-lat=\"35.104942\" data-lon=\"-120.607980\" data-zoom=\"17\" data-label=\"Discipleship Home\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-668-9185\" aria-label=\"Call 805-668-9185\">805-668-9185</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:thediscipleshiphome15@gmail.com\" aria-label=\"Email thediscipleshiphome15@gmail.com\">thediscipleshiphome15@gmail.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Discipleship Home"
+    ]
+  },
+  "Dove-Creek-Church": {
+    "title": "Dove Creek Church of the Nazarene",
+    "content": "<h2><span>Dove Creek Church of the Nazarene</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://dovecreekchurch.org/\" data-external-link=\"true\">dovecreekchurch.org</a></li>\n<li><strong>Location:</strong> 9333 Santa Barbara Rd., Atascadero <a class=\"map-link\" data-lat=\"35.449172\" data-lon=\"-120.633742\" data-zoom=\"17\" data-label=\"Dove Creek Church of the Nazarene\">Map</a> { Source: <a href=\"https://dovecreekchurch.org/who-we-are/find-us\" data-external-link=\"true\">https://dovecreekchurch.org/who-we-are/find-us</a> }</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-9505\" aria-label=\"Call 805-466-9505\">805-466-9505</a> { Source: <a href=\"https://dovecreekchurch.org/who-we-are/find-us\" data-external-link=\"true\">https://dovecreekchurch.org/who-we-are/find-us</a> }</li>\n<li><strong>Email:</strong> <a href=\"mailto:office@dovecreekchurch.org\" aria-label=\"Email office@dovecreekchurch.org\">office@dovecreekchurch.org</a> { Source: <a href=\"https://dovecreekchurch.org/who-we-are/find-us\" data-external-link=\"true\">https://dovecreekchurch.org/who-we-are/find-us</a> }</li>\n<li>Notes:<ul>\n<li>Operates a food pantry; also known as Atascadero Dove Creek Church of the Nazarene</li>\n<li>As of October 2025, the website says “We are currently on hiatus and in a period of rebuilding”</li>\n<li>See also <a href=\"#\" data-directory-link=\"Restoration-Church\" aria-label=\"View directory entry for Restoration Church\"><strong>Restoration Church</strong></a> which may be a ministry at this same address\n--&gt;</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Dove Creek Church of the Nazarene",
+      "Atascadero Dove Creek Church of the Nazarene"
+    ]
+  },
+  "Eckerd-Connects-Workforce-Development": {
+    "title": "Eckerd Connects Workforce Development",
+    "content": "<h2><span>Eckerd Connects Workforce Development</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.eckerd.org/jobs-training/slo/\" data-external-link=\"true\">eckerd.org/jobs-training/slo</a></li>\n<li><strong>Locations:</strong><ul>\n<li>3450 Broad Street #103A, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.257894\" data-lon=\"-120.646738\" data-zoom=\"17\" data-label=\"Eckerd Connects\">Map</a> </li>\n<li>534 Spring Street, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.619702\" data-lon=\"-120.690592\" data-zoom=\"17\" data-label=\"Eckerd Connects\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-439-2557\" aria-label=\"Call 805-439-2557\">805-439-2557</a> </li>\n<li><a href=\"tel:+1-941-585-9659\" aria-label=\"Call 941-585-9659\">941-585-9659</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:SLOCal@eckerd.org\" aria-label=\"Email SLOCal@eckerd.org\">SLOCal@eckerd.org</a></li>\n<li><strong>Hours:</strong> M–F 9am–4pm (SLO)</li>\n</ul>\n",
+    "aliases": [
+      "Eckerd Connects Workforce Development"
+    ]
+  },
+  "ECHO": {
+    "title": "El Camino Homeless Organization (ECHO)",
+    "content": "<h2><span>El Camino Homeless Organization (ECHO)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.echoshelter.org/\" data-external-link=\"true\">www.echoshelter.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>6370 Atascadero Ave., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.486312\" data-lon=\"-120.670295\" data-zoom=\"17\" data-label=\"El Camino Homeless Organization\">Map</a> </li>\n<li>1134 Black Oak Dr., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.645387\" data-lon=\"-120.687569\" data-zoom=\"17\" data-label=\"El Camino Homeless Organization\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-462-3663\" aria-label=\"Call 805-462-FOOD\">805-462-FOOD</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:wlewis@echoshelter.org\" aria-label=\"Email wlewis@echoshelter.org\">wlewis@echoshelter.org</a> </li>\n<li><strong>How to access:</strong><ul>\n<li>For transitional housing, contact ECHO to get on a waiting list; for dinner/showers/laundry, just attend on time</li>\n<li>Emergency shelter bed signup at the Paso Robles location only, 4:30–5:30pm </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Dinner (also available to non-residents) at 5pm at both locations </li>\n<li>Showers (available to non-residents) M–F from 4–5:30pm at both locations </li>\n<li>Laundry (available to non-residents) W from 10am–6pm at the Paso Robles location. </li>\n<li>The Paso Robles location operates as an emergency warming center during adverse weather </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "El Camino Homeless Organization (ECHO)"
+    ]
+  },
+  "El-Chorro-Regional-Park-Campground": {
+    "title": "El Chorro Regional Park Campground",
+    "content": "<h2><span>El Chorro Regional Park Campground</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocountyparks.com/camp/el-chorro/\" data-external-link=\"true\">slocountyparks.com/camp/el-chorro</a></li>\n<li><strong>Location:</strong> State Hwy 1 @ Dairy Creek (4 miles NW of SLO) <a href=\"#\" class=\"map-link\" data-lat=\"35.338721\" data-lon=\"-120.720193\" data-zoom=\"13\" data-label=\"El Chorro Regional Park Campground\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5930;ext=4\" aria-label=\"Call 805-781-5930 x4\">805-781-5930 x4</a> (Monday–Friday 8:30am–4:30pm)</li>\n<li><strong>Email:</strong> <a href=\"mailto:sloparks@co.slo.ca.us\" aria-label=\"Email sloparks@co.slo.ca.us\">sloparks@co.slo.ca.us</a></li>\n</ul>\n",
+    "aliases": [
+      "El Chorro Regional Park Campground"
+    ]
+  },
+  "Elks-Lodge-2504": {
+    "title": "Elks Lodge #2504",
+    "content": "<h2><span>Elks Lodge #2504</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://oceanoelks2504.org/\" data-external-link=\"true\">oceanoelks2504.org</a></li>\n<li><strong>Location:</strong> 410 Air Park Drive, Oceano <a class=\"map-link\" data-lat=\"35.105357\" data-lon=\"-120.627046\" data-zoom=\"17\" data-label=\"Elks Lodge #2504\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-489-2504\" aria-label=\"Call 805-489-2504\">805-489-2504</a></li>\n<li><strong>Email:</strong> <a href=\"Elks2504@gmail.com\">Elks2504@gmail.com</a></li>\n<li><strong>Hours:</strong> M–Th 9am–4pm</li>\n<li><strong>How to access:</strong> Walk-ins OK, but it’s better to call ahead\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Elks Lodge #2504"
+    ]
+  },
+  "Employment-Development-Department": {
+    "title": "Employment Development Department",
+    "content": "<h2><span>Employment Development Department</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://edd.ca.gov/\" data-external-link=\"true\">edd.ca.gov</a></li>\n<li><strong>Location:</strong> 3450 Broad St. #103A, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.257956\" data-lon=\"-120.646557\" data-zoom=\"17\" data-label=\"EDD\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-800-300-5616\" aria-label=\"Call 800-300-5616\">800-300-5616</a></li>\n<li>Local office: <a href=\"tel:+1-805-878-2842\" aria-label=\"Call 805-878-2842\">805-878-2842</a></li>\n<li>Customer service: <a href=\"tel:+1-805-439-2557\" aria-label=\"Call 805-439-2557\">805-439-2557</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li>Notes:<ul>\n<li>Operates “Migrant Seasonal Farmworker” program</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Employment Development Department"
+    ]
+  },
+  "Enhanced-Care-Management": {
+    "title": "Enhanced Care Management",
+    "content": "<h2><span>Enhanced Care Management</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/enhanced-care-management\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/enhanced-care-management</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-4687\" aria-label=\"Call 805-781-4687\">805-781-4687</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:ph.ecm@co.slo.ca.us\" aria-label=\"Email ph.ecm@co.slo.ca.us\">ph.ecm@co.slo.ca.us</a> </li>\n<li>Notes:<ul>\n<li><a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)\"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a> is the entry-point for this program (including its <a href=\"#\" data-directory-link=\"Outreach-and-Engagement-Services\" aria-label=\"View directory entry for Outreach and Engagement Services\"><strong>Outreach and Engagement Services</strong></a> center)</li>\n<li>Offered to youth through <a href=\"#\" data-directory-link=\"Seneca-Central-Coast\" aria-label=\"View directory entry for Seneca Central Coast\"><strong>Seneca Central Coast</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Enhanced Care Management"
+    ]
+  },
+  "EyeCare-America": {
+    "title": "EyeCare America",
+    "content": "<h2><span>EyeCare America</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://aao.org/eyecare-america\" data-external-link=\"true\">aao.org/eyecare-america</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-877-887-6327\" aria-label=\"Call 877-887-6327\">877-887-6327</a> (M–F 8am–2pm) </li>\n<li><strong>Email:</strong> <a href=\"mailto:eyecareamerica@aao.org\" aria-label=\"Email eyecareamerica@aao.org\">eyecareamerica@aao.org</a> </li>\n<li><strong>How to access:</strong> To begin, complete a questionnaire on their website</li>\n</ul>\n",
+    "aliases": [
+      "EyeCare America"
+    ]
+  },
+  "Family-and-Industrial-Medical-Center": {
+    "title": "Family and Industrial Medical Center",
+    "content": "<h2><span>Family and Industrial Medical Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://fimcslo.com/\" data-external-link=\"true\">fimcslo.com</a></li>\n<li><strong>Location:</strong> 47 Santa Rosa St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.292602\" data-lon=\"-120.667778\" data-zoom=\"17\" data-label=\"Family and Industrial Medical Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-542-9596\" aria-label=\"Call 805-542-9596\">805-542-9596</a> </li>\n<li><strong>Hours:</strong> M–F 8am–7pm, Sa.–Su. 9am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Family and Industrial Medical Center"
+    ]
+  },
+  "Family-Care-Network": {
+    "title": "Family Care Network",
+    "content": "<h2><span>Family Care Network</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://fcni.org\" data-external-link=\"true\">fcni.org</a></li>\n<li><strong>Location:</strong> 1255 Kendall Rd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.236909\" data-lon=\"-120.629489\" data-zoom=\"17\" data-label=\"Family Care\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-3535\" aria-label=\"Call 805-781-3535\">805-781-3535</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:Contact@fcni.org\" aria-label=\"Email Contact@fcni.org\">Contact@fcni.org</a> </li>\n<li>Notes: Operates <a href=\"#\" data-directory-link=\"Housing-Support-Program\" aria-label=\"View directory entry for Housing Support Program (HSP)\"><strong>Housing Support Program (HSP)</strong></a> </li>\n</ul>\n",
+    "aliases": [
+      "Family Care Network"
+    ]
+  },
+  "Five-Cities-Christian-Women-Food-Pantry": {
+    "title": "Five Cities Christian Women Food Pantry",
+    "content": "<h2><span>Five Cities Christian Women Food Pantry</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://fivecitieschristianwomenfoodpantry.org/\" data-external-link=\"true\">fivecitieschristianwomenfoodpantry.org</a></li>\n<li><strong>Location:</strong> 946 Rockaway Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.120091\" data-lon=\"-120.619796\" data-zoom=\"17\" data-label=\"Five Cities Christian Women Food Pantry\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-473-3368\" aria-label=\"Call 805-473-3368\">805-473-3368</a> </li>\n<li><strong>Hours:</strong> M–F 2–3:30pm except federal holidays </li>\n<li>Hosted by <a href=\"#\" data-directory-link=\"Lifepoint-Church\" aria-label=\"View directory entry for Lifepoint Church\"><strong>Lifepoint Church</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Five Cities Christian Women Food Pantry"
+    ]
+  },
+  "5Cities-Meals-on-Wheels": {
+    "title": "Five Cities Meals on Wheels",
+    "content": "<h2><span>Five Cities Meals on Wheels</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.5citiesmow.com/\" data-external-link=\"true\">5citiesmow.com</a></li>\n<li><strong>Location:</strong> 780 Bello Street, Pismo Beach <a class=\"map-link\" data-lat=\"35.143111\" data-lon=\"-120.639100\" data-zoom=\"17\" data-label=\"Five Cities Meals on Wheels\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-773-2053\" aria-label=\"Call 805-773-2053\">805-773-2053</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@5citiesmow.com\" aria-label=\"Email info@5citiesmow.com\">info@5citiesmow.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Five Cities Meals on Wheels"
+    ]
+  },
+  "Flying-Flags-Avila-Beach": {
+    "title": "Flying Flags Avila Beach",
+    "content": "<h2><span>Flying Flags Avila Beach</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.flyingflagsavilabeach.com\" data-external-link=\"true\">flyingflagsavilabeach.com</a></li>\n<li><strong>Location:</strong> 6450 Babe Lane, Avila Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.176751\" data-lon=\"-120.754479\" data-zoom=\"15\" data-label=\"Flying Flags\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-888-0158\" aria-label=\"Call 805-888-0158\">805-888-0158</a></li>\n<li><strong>Hours:</strong> Every day 8am–6pm</li>\n</ul>\n",
+    "aliases": [
+      "Flying Flags Avila Beach"
+    ]
+  },
+  "Food-Not-Bombs": {
+    "title": "Food Not Bombs",
+    "content": "<h2><span>Food Not Bombs</span></h2>\n<ul>\n<li><strong>Social media:</strong><ul>\n<li>Facebook: <a href=\"https://www.facebook.com/FoodNotBombsSLO/\" data-external-link=\"true\">facebook.com/FoodNotBombsSLO</a></li>\n<li>Instagram: <a href=\"https://instagram.com/foodnotbombs_slo\" data-external-link=\"true\">@foodnotbombs_slo</a></li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:slofoodnotbombs@gmail.com\" aria-label=\"Email slofoodnotbombs@gmail.com\">slofoodnotbombs@gmail.com</a> </li>\n<li><strong>Location:</strong> Mitchell Park, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.278724\" data-lon=\"-120.657960\" data-zoom=\"17\" data-label=\"Food Not Bombs\">Map</a> </li>\n<li><strong>Hours:</strong> Su 1–3pm </li>\n</ul>\n",
+    "aliases": [
+      "Food Not Bombs"
+    ]
+  },
+  "Foxys-Thrift-Shop": {
+    "title": "Foxy’s Thrift Shop",
+    "content": "<h2><span>Foxy’s Thrift Shop</span></h2>\n<ul>\n<li><strong>Location:</strong> 655 Morro Bay Blvd., Morro Bay <a class=\"map-link\" data-lat=\"35.366302\" data-lon=\"-120.845882\" data-zoom=\"17\" data-label=\"Foxy’s Thrift Shop\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-772-8800\" aria-label=\"Call 805-772-8800\">805-772-8800</a> </li>\n<li><strong>Hours:</strong> Daily 10am–5pm</li>\n</ul>\n",
+    "aliases": [
+      "Foxy’s Thrift Shop"
+    ]
+  },
+  "Fred-and-Bettys": {
+    "title": "Fred & Betty’s Thrift Store",
+    "content": "<h2><span>Fred &amp; Betty’s Thrift Store</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.fredandbettys.org\" data-external-link=\"true\">fredandbettys.org</a></li>\n<li><strong>Location:</strong> 532 Higuera St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.277121\" data-lon=\"-120.667745\" data-zoom=\"17\" data-label=\"Fred and Betty’s Thrift Store\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-593-0255\" aria-label=\"Call 805-593-0255\">805-593-0255</a> </li>\n<li><strong>Hours:</strong> M–Sa 10am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "Fred & Betty’s Thrift Store"
+    ]
+  },
+  "French-Hospital-Medical-Center": {
+    "title": "French Hospital Medical Center",
+    "content": "<h2><span>French Hospital Medical Center</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"Dignity-Health\" aria-label=\"View directory entry for Dignity Health\"><strong>Dignity Health</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.dignityhealth.org/central-coast/locations/frenchhospital\" data-external-link=\"true\">dignityhealth.org/central-coast/locations/frenchhospital</a></li>\n<li><strong>Location:</strong> 1911 Johnson Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.277962\" data-lon=\"-120.650922\" data-zoom=\"15\" data-label=\"French Hospital Medical Center\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li>ER: <a href=\"tel:+1-805-542-6621\" aria-label=\"Call 805-542-6621\">805-542-6621</a></li>\n<li>Front desk: <a href=\"tel:+1-805-543-5353\" aria-label=\"Call 805-543-5353\">805-543-5353</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> 24/7</li>\n</ul>\n",
+    "aliases": [
+      "French Hospital Medical Center",
+      "**Dignity Health**"
+    ]
+  },
+  "Front-Porch": {
+    "title": "Front Porch",
+    "content": "<h2><span>Front Porch</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.frontporchslo.org/\" data-external-link=\"true\">https://www.frontporchslo.org/</a></li>\n<li><strong>Location:</strong> 1468 E. Foothill, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.297443\" data-lon=\"-120.660964\" data-zoom=\"17\" data-label=\"Front Porch\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-818-731-4984\" aria-label=\"Call 818-731-4984\">818-731-4984</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:hello@frontporchslo.org\" aria-label=\"Email hello@frontporchslo.org\">hello@frontporchslo.org</a> </li>\n<li><strong>Hours:</strong> M–Th 7am–11pm, F 7am–4pm, Su 7am–6pm (depending on volunteer availability, likely closed during Cal Poly breaks) </li>\n<li><strong>How to access:</strong> oriented toward students from Cuesta College or Cal Poly, but “Whoever you are, you are welcome here” and “No matter what, you’re welcome here.” </li>\n</ul>\n",
+    "aliases": [
+      "Front Porch"
+    ]
+  },
+  "GALA": {
+    "title": "GALA Pride & Diversity Center",
+    "content": "<h2><span>GALA Pride &amp; Diversity Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://galacc.org/\" data-external-link=\"true\">galacc.org</a></li>\n<li><strong>Location:</strong> 1060 Palm St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.283421\" data-lon=\"-120.661309\" data-zoom=\"17\" data-label=\"GALA\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-4252\" aria-label=\"Call 805-541-4252\">805-541-4252</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@galacc.org\" aria-label=\"Email info@galacc.org\">info@galacc.org</a></li>\n<li><strong>Hours:</strong> M–F 8am–5pm<ul>\n<li>Food pantry M–F 10am–3pm</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "GALA Pride & Diversity Center"
+    ]
+  },
+  "Genoa-Pharmacy": {
+    "title": "Genoa Pharmacy",
+    "content": "<h2><span>Genoa Pharmacy</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/genoa-pharmacy\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/genoa-pharmacy</a></li>\n<li><strong>Location:</strong> 2178 Johnson Avenue #P1, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.275431\" data-lon=\"-120.646555\" data-zoom=\"17\" data-label=\"Genoa Pharmacy\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-242-4051\" aria-label=\"Call 805-242-4051\">805-242-4051</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–5pm (closed 12:30–1pm) </li>\n<li>Notes: The on-site pharmacy for <a href=\"#\" data-directory-link=\"SLO-County-Behavioral-Health\" aria-label=\"View directory entry for SLO County Behavioral Health\"><strong>SLO County Behavioral Health</strong></a> </li>\n</ul>\n",
+    "aliases": [
+      "Genoa Pharmacy"
+    ]
+  },
+  "Golden-1-Credit-Union": {
+    "title": "Golden 1 Credit Union",
+    "content": "<h2><span>Golden 1 Credit Union</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.golden1.com\" data-external-link=\"true\">golden1.com</a></li>\n<li><strong>Locations:</strong> <ul>\n<li>8727 El Camino Real, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.472833\" data-lon=\"-120.651861\" data-zoom=\"17\" data-label=\"Golden 1 Credit Union\">Map</a></li>\n<li>128 Niblick Rd., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.612529\" data-lon=\"-120.683731\" data-zoom=\"17\" data-label=\"Golden 1 Credit Union\">Map</a></li>\n<li>852 E. Foothill Blvd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.294492\" data-lon=\"-120.670846\" data-zoom=\"17\" data-label=\"Golden 1 Credit Union\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-877-465-3361\" aria-label=\"Call 877-GOLDEN-1\">877-GOLDEN-1</a> </li>\n<li><strong>Hours:</strong> M–F 10am–5pm, Sa 10am–2pm </li>\n</ul>\n",
+    "aliases": [
+      "Golden 1 Credit Union"
+    ]
+  },
+  "Good-Samaritan-Shelter": {
+    "title": "Good Samaritan Shelter",
+    "content": "<h2><span>Good Samaritan Shelter</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://goodsamaritanshelter.org/\" data-external-link=\"true\">goodsamaritanshelter.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Santa Maria emergency shelter: 401 W. Morrison Ave., Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.943820\" data-lon=\"-120.441034\" data-zoom=\"17\" data-label=\"Good Samaritan Shelter\">Map</a> </li>\n<li>Administrative offices: 400 West Park, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.944295\" data-lon=\"-120.440996\" data-zoom=\"17\" data-label=\"Good Samaritan Shelter\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> Emergency shelter: <a href=\"tel:+1-805-347-3338;ext=101\" aria-label=\"Call 805-347-3338 x101\">805-347-3338 x101</a> </li>\n<li><strong>Email:</strong> Layne Harlow (<a href=\"mailto:lharlow@goodsamaritanshelter.org\" aria-label=\"Email lharlow@goodsamaritanshelter.org\">lharlow@goodsamaritanshelter.org</a>)</li>\n<li><strong>Hours:</strong><ul>\n<li>Emergency shelter: 24/7 </li>\n<li>Shelter intake appointments 8:30am–5pm M–F</li>\n<li>Shelter opens at 4:30pm daily</li>\n<li>Administrative offices open 9am–5pm M–F </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> (shelter) Call M–F 8:30am–4:00pm, or walk in 9am–3pm, to establish an intake appointment </li>\n<li>Notes:<ul>\n<li>operates <a href=\"#\" data-directory-link=\"Welcome-Home-Village\" aria-label=\"View directory entry for Welcome Home Village\"><strong>Welcome Home Village</strong></a></li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n<li>operates <a href=\"#\" data-directory-link=\"Supportive-Services-for-Veteran-Families\" aria-label=\"View directory entry for Supportive Services for Veteran Families\"><strong>Supportive Services for Veteran Families</strong></a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Good Samaritan Shelter"
+    ]
+  },
+  "Goodwill": {
+    "title": "Goodwill Stores",
+    "content": "<h2><span>Goodwill Stores</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ccgoodwill.org/\" data-external-link=\"true\">ccgoodwill.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">8310 El Camino Real #A, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.474441\" data-lon=\"-120.656410\" data-zoom=\"17\" data-label=\"Goodwill Store\">Map</a></td>\n<td data-label=\"Hours\">Daily 9am–7pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1628 W. Grand Ave., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.120113\" data-lon=\"-120.611025\" data-zoom=\"17\" data-label=\"Goodwill Store\">Map</a></td>\n<td data-label=\"Hours\">Daily 9am–7pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1020 Park St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.625127\" data-lon=\"-120.689607\" data-zoom=\"17\" data-label=\"Goodwill Store\">Map</a></td>\n<td data-label=\"Hours\">Su–Th 9am–7pm, Fr–Sa 9am–8pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">15 S. Higuera St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.265971\" data-lon=\"-120.670164\" data-zoom=\"17\" data-label=\"Goodwill Store\">Map</a></td>\n<td data-label=\"Hours\">Daily 9am–6pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">880 Industrial Way, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.252988\" data-lon=\"-120.640955\" data-zoom=\"17\" data-label=\"Goodwill Outlet\">Map</a> (Outlet)</td>\n<td data-label=\"Hours\">Daily 7am–4pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-894-8440\" aria-label=\"Call 800-894-8440\">800-894-8440</a><ul>\n<li>Opportunity Platform: <a href=\"tel:+1-805-544-0542;ext=8520\" aria-label=\"Call 805-544-0542&nbsp;x8520\">805-544-0542&nbsp;x8520</a>, <a href=\"mailto:jjauregui@ccgoodwill.org\" aria-label=\"Email jjauregui@ccgoodwill.org\">jjauregui@ccgoodwill.org</a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Goodwill Stores"
+    ]
+  },
+  "Grace-Central-Coast": {
+    "title": "Grace Central Coast",
+    "content": "<h2><span>Grace Central Coast</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://gracecentralcoast.org/\" data-external-link=\"true\">gracecentralcoast.org</a></li>\n<li><strong>Location:</strong> 1350 Osos Street, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.279206\" data-lon=\"-120.658411\" data-zoom=\"17\" data-label=\"God’s Storehouse\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-2358\" aria-label=\"Call 805-543-2358\">805-543-2358</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@gracecentralcoast.org\" aria-label=\"Email info@gracecentralcoast.org\">info@gracecentralcoast.org</a> </li>\n<li><strong>Hours</strong> (God’s Storehouse food distribution): Sa. 8–10am </li>\n</ul>\n",
+    "aliases": [
+      "Grace Central Coast"
+    ]
+  },
+  "Green-Pastures": {
+    "title": "Green Pastures",
+    "content": "<h2><span>Green Pastures</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://fpcslo.org/greenpastures\" data-external-link=\"true\">fpcslo.org/greenpastures</a></li>\n<li><strong>Location:</strong> 981 Marsh St., SLO (First Presbyterian Church) <a href=\"#\" class=\"map-link\" data-lat=\"35.279915\" data-lon=\"-120.660514\" data-zoom=\"17\" data-label=\"Green Pastures\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-5451\" aria-label=\"Call 805-543-5451\">805-543-5451</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:churchoffice@fpcslo.org\" aria-label=\"Email churchoffice@fpcslo.org\">churchoffice@fpcslo.org</a> </li>\n<li><strong>Hours:</strong> First and third Wednesdays at 1pm </li>\n<li><strong>How to access:</strong> Lottery system—first 8 names drawn receive assistance; must be present to enter </li>\n</ul>\n",
+    "aliases": [
+      "Green Pastures"
+    ]
+  },
+  "Grover-Beach-Community-Services": {
+    "title": "Grover Beach Community Services",
+    "content": "<h2><span>Grover Beach Community Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.groverbeach.org/141/Community-Services\" data-external-link=\"true\">groverbeach.org/141/Community-Services</a></li>\n<li><strong>Location:</strong> 1230 Trouville Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.115854\" data-lon=\"-120.616578\" data-zoom=\"17\" data-label=\"Grover Beach Community Services\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-473-4580\" aria-label=\"Call 805-473-4580\">805-473-4580</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:CS@groverbeach.org\" aria-label=\"Email CS@groverbeach.org\">CS@groverbeach.org</a> </li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n</ul>\n",
+    "aliases": [
+      "Grover Beach Community Services"
+    ]
+  },
+  "Gryphon-Society": {
+    "title": "Gryphon Society",
+    "content": "<h2><span>Gryphon Society</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://gryphonsociety.weebly.com/\" data-external-link=\"true\">gryphonsociety.weebly.com</a></li>\n<li><strong>Locations:</strong> Various; gender-segregated</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-550-8140\" aria-label=\"Call 805-550-8140\">805-550-8140</a> (men)</li>\n<li><a href=\"tel:+1-805-748-8491\" aria-label=\"Call 805-748-8491\">805-748-8491</a> (women)</li>\n<li><a href=\"tel:+1-805-748-6204\" aria-label=\"Call 805-748-6204\">805-748-6204</a></li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@gryphonsociety.weebly.com\" aria-label=\"Email info@gryphonsociety.weebly.com\">info@gryphonsociety.weebly.com</a></li>\n</ul>\n",
+    "aliases": [
+      "Gryphon Society"
+    ]
+  },
+  "Habitat-for-Humanity": {
+    "title": "Habitat for Humanity SLO County",
+    "content": "<h2><span>Habitat for Humanity SLO County</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://habitatslo.org/\" data-external-link=\"true\">habitatslo.org</a></li>\n<li><strong>Location:</strong> 844 9th St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.623410\" data-lon=\"-120.688886\" data-zoom=\"17\" data-label=\"Habitat for Humanity\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-782-0687\" aria-label=\"Call 805-782-0687\">805-782-0687</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@habitatslo.org\" aria-label=\"Email info@habitatslo.org\">info@habitatslo.org</a> </li>\n</ul>\n<p><strong>ReStore</strong> (recycled construction and home renovation materials):</p>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://habitatslo.org/restores/\" data-external-link=\"true\">habitatslo.org/restores</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Paso Robles: 844 9th St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.623410\" data-lon=\"-120.688886\" data-zoom=\"17\" data-label=\"Habitat for Humanity ReStore (Paso Robles)\">Map</a> <ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-434-0486\" aria-label=\"Call 805-434-0486\">805-434-0486</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:restorepaso@habitatslo.org\" aria-label=\"Email restorepaso@habitatslo.org\">restorepaso@habitatslo.org</a> </li>\n<li><strong>Hours:</strong> Tu–Sa 10am–5pm </li>\n</ul>\n</li>\n<li>SLO: 2790 Broad St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.264447\" data-lon=\"-120.651866\" data-zoom=\"17\" data-label=\"Habitat for Humanity ReStore (SLO)\">Map</a> <ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-546-8699\" aria-label=\"Call 805-546-8699\">805-546-8699</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:restoreslo@habitatslo.org\" aria-label=\"Email restoreslo@habitatslo.org\">restoreslo@habitatslo.org</a> </li>\n<li><strong>Hours:</strong> Tu–Sa 10am–5pm </li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Habitat for Humanity SLO County"
+    ]
+  },
+  "Healing-and-Restoration-Campus": {
+    "title": "Healing and Restoration Campus",
+    "content": "<h2><span>Healing and Restoration Campus</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.sloharc.org/\" data-external-link=\"true\">sloharc.org</a></li>\n<li><strong>Location:</strong> Los Osos Valley Road near Laguna Lake (former DeVaul Ranch / Sunny Acres property) <a href=\"#\" class=\"map-link\" data-lat=\"35.273513\" data-lon=\"-120.706208\" data-zoom=\"16\" data-label=\"Healing and Restoration Campus\">Map</a></li>\n</ul>\n\n<ul>\n<li>Notes: A project of <a href=\"#\" data-directory-link=\"Restorative-Partners\" aria-label=\"View directory entry for Restorative Partners\"><strong>Restorative Partners</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Healing and Restoration Campus"
+    ]
+  },
+  "HCHP": {
+    "title": "Healthcare for the Homeless Program",
+    "content": "<h2><span>Healthcare for the Homeless Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.communityhealthcenters.org/locations/slo-prado/\" data-external-link=\"true\">communityhealthcenters.org/locations/slo-prado/</a></li>\n<li><strong>Location:</strong> 40 Prado Rd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.256218\" data-lon=\"-120.672031\" data-zoom=\"17\" data-label=\"40 Prado Homeless Services Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-473-4712\" aria-label=\"Call 805-473-4712\">805-473-4712</a> </li>\n<li><strong>Hours:</strong> M/Tu/Th 8am–5pm, W 9am–6pm </li>\n<li>Notes:<ul>\n<li>operated by <a href=\"#\" data-directory-link=\"CHC\" aria-label=\"View directory entry for Community Health Centers of the Central Coast\"><strong>Community Health Centers of the Central Coast</strong></a></li>\n<li>hosted by <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Healthcare for the Homeless Program"
+    ]
+  },
+  "Help-Hope-Live": {
+    "title": "Help Hope Live",
+    "content": "<h2><span>Help Hope Live</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://helphopelive.org/\" data-external-link=\"true\">helphopelive.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-642-8399\" aria-label=\"Call 800-642-8399\">800-642-8399</a> (M–F 9am–6pm Eastern Time) </li>\n</ul>\n",
+    "aliases": [
+      "Help Hope Live"
+    ]
+  },
+  "Help-Me-Grow": {
+    "title": "Help Me Grow SLO County",
+    "content": "<h2><span>Help Me Grow SLO County</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slohelpmegrow.org/\" data-external-link=\"true\">slohelpmegrow.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1030 Southwood Dr., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.266202\" data-lon=\"-120.642336\" data-zoom=\"17\" data-label=\"Help Me Grow\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-305-4481\" aria-label=\"Call 805-305-4481\">805-305-4481</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">704 Spring St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.621655\" data-lon=\"-120.690685\" data-zoom=\"17\" data-label=\"Help Me Grow\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-440-1878\" aria-label=\"Call 805-440-1878\">805-440-1878</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Hours:</strong> M–F 8am–4:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Help Me Grow SLO County"
+    ]
+  },
+  "HiCAP": {
+    "title": "HiCAP (Health Insurance Counseling & Advocacy Program)",
+    "content": "<h2><span>HiCAP (Health Insurance Counseling &amp; Advocacy Program)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://centralcoastseniors.org/hicap/\" data-external-link=\"true\">centralcoastseniors.org/hicap</a></li>\n<li><strong>Location:</strong><ul>\n<li>1445 Santa Rosa St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.278951\" data-lon=\"-120.657079\" data-zoom=\"17\" data-label=\"HiCAP\">Map</a></li>\n<li>528 S. Broadway, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.947390\" data-lon=\"-120.435627\" data-zoom=\"17\" data-label=\"HiCAP\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-928-5663\" aria-label=\"Call 805-928-5663\">805-928-5663</a> / <a href=\"tel:+1-800-434-0222\" aria-label=\"Call 800-434-0222\">800-434-0222</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:hicap@centralcoastseniors.org\" aria-label=\"Email hicap@centralcoastseniors.org\">hicap@centralcoastseniors.org</a></li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li><strong>How to access:</strong> Make an appointment by phone or by visiting the website.</li>\n</ul>\n",
+    "aliases": [
+      "HiCAP (Health Insurance Counseling & Advocacy Program)"
+    ]
+  },
+  "Homeless-Outreach-Full-Service-Partnership": {
+    "title": "Homeless Outreach Full Service Partnership",
+    "content": "<h2><span>Homeless Outreach Full Service Partnership</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-adult-services/homeless-outreach-full-service-partnership\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-adult-services/homeless-outreach-full-service-partnership</a></li>\n<li><strong>Phone:</strong><ul>\n<li>TMHA: <a href=\"tel:+1-805-540-6500\" aria-label=\"Call 805-540-6500\">805-540-6500</a> </li>\n<li>Behavioral Health Access Line: <a href=\"tel:+1-800-838-1361\" aria-label=\"Call 800-838-1361\">800-838-1361</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@t-mha.org\" aria-label=\"Email info@t-mha.org\">info@t-mha.org</a> </li>\n<li><strong>How to access:</strong> Contact <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for Transitions Mental Health Association\"><strong>Transitions Mental Health Association</strong></a> at the above phone number or email </li>\n</ul>\n",
+    "aliases": [
+      "Homeless Outreach Full Service Partnership"
+    ]
+  },
+  "HomeShare-SLO": {
+    "title": "HomeShare SLO",
+    "content": "<h2><span>HomeShare SLO</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.smartsharehousingsolutions.org/homeshare-slo\" data-external-link=\"true\">smartsharehousingsolutions.org/homeshare-slo</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-215-5474\" aria-label=\"Call 805-215-5474\">805-215-5474</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@smartsharehousingsolutions.org\" aria-label=\"Email info@smartsharehousingsolutions.org\">info@smartsharehousingsolutions.org</a> </li>\n<li>Notes: A project of <a href=\"#\" data-directory-link=\"SmartShare-Housing-Solutions\" aria-label=\"View directory entry for SmartShare Housing Solutions\"><strong>SmartShare Housing Solutions</strong></a> </li>\n</ul>\n",
+    "aliases": [
+      "HomeShare SLO"
+    ]
+  },
+  "Hopes-Village": {
+    "title": "Hope’s Village",
+    "content": "<h2><span>Hope’s Village</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://hopesvillageofslo.com/\" data-external-link=\"true\">hopesvillageofslo.com</a></li>\n<li><strong>Mailing address:</strong> PO Box 1991, Templeton, CA 93465 </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-234-5478\" aria-label=\"Call 805-234-5478\">805-234-5478</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:beckyrjorgeson@yahoo.com\" aria-label=\"Email beckyrjorgeson@yahoo.com\">beckyrjorgeson@yahoo.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Hope’s Village"
+    ]
+  },
+  "Hospice-SLO": {
+    "title": "Hospice SLO",
+    "content": "<h2><span>Hospice SLO</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://hospiceslo.org/\" data-external-link=\"true\">hospiceslo.org</a></li>\n<li><strong>Location:</strong> Dorothy D. Rupe Center, 1304 Pacific St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.282539\" data-lon=\"-120.655148\" data-zoom=\"17\" data-label=\"Hospice SLO\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-2266\" aria-label=\"Call 805-544-2266\">805-544-2266</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:hospiceslo@hospiceslo.org\" aria-label=\"Email hospiceslo@hospiceslo.org\">hospiceslo@hospiceslo.org</a> </li>\n<li><strong>Hours:</strong> M–F 10am–4pm </li>\n<li>Notes: All services provided at no charge; does not bill insurance </li>\n</ul>\n",
+    "aliases": [
+      "Hospice SLO"
+    ]
+  },
+  "HouseKeys": {
+    "title": "HouseKeys",
+    "content": "<h2><span>HouseKeys</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.housekeys19.com\" data-external-link=\"true\">housekeys19.com</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-877-460-5397\" aria-label=\"Call 877-460-5397\">877-460-5397</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:customerservice@housekeys.org\" aria-label=\"Email customerservice@housekeys.org\">customerservice@housekeys.org</a> </li>\n<li><strong>How to access:</strong> Create account at MyHouseKeys to enter drawings and receive notifications about available units</li>\n</ul>\n",
+    "aliases": [
+      "HouseKeys"
+    ]
+  },
+  "HASLO": {
+    "title": "Housing Authority of SLO (HASLO)",
+    "content": "<h2><span>Housing Authority of SLO (HASLO)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.haslo.org/\" data-external-link=\"true\">haslo.org</a></li>\n<li><strong>Location:</strong> 487 Leff St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.272418\" data-lon=\"-120.662971\" data-zoom=\"17\" data-label=\"HASLO\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-4478\" aria-label=\"Call 805-543-4478\">805-543-4478</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@haslo.org\" aria-label=\"Email info@haslo.org\">info@haslo.org</a> </li>\n<li><strong>Hours:</strong> M–Th 8am–5pm (also open every other Friday) </li>\n<li><strong>How to access:</strong> submit a paper application to get on the waiting list for affordable apartments</li>\n<li>Notes:<ul>\n<li>Operates “Halcyon Collective” (Arroyo Grande)</li>\n<li>Operates “Macadero Gardens” (Atascadero)</li>\n<li>Operates “Cleaver &amp; Clark Commons” (Grover Beach)</li>\n<li>Operates “Rockview at Sunset” (Morro Bay)</li>\n<li>Operates “Willow Walk Senior Apartments” (Nipomo)</li>\n<li>Operates “Oak Park 1 &amp; 2” (Paso Robles)</li>\n<li>Operates “Paso Homekey” (Paso Robles)</li>\n<li>Operates “Sunset Terrace” (Shell Beach)</li>\n<li>Operates “860 on the Wye” (SLO)</li>\n<li>Operates “The Anderson Apartments” (SLO)</li>\n<li>Operates “Apartments at Toscano” (SLO)</li>\n<li>Operates “Balay-Ko on Monterey” (SLO)</li>\n<li>Operates “Bishop Street Studios” (SLO)</li>\n<li>Operates “Courtyard at the Meadows” (SLO)</li>\n<li>Operates “Iron Works Apartments” (SLO)</li>\n<li>Operates “Madonna Road Apartments” (SLO)</li>\n<li>Operates “Marvin Gardens” (SLO)</li>\n<li>Operates “Moylan Terrace Homeownership” (SLO)</li>\n<li>Operates “SLO Villages” (SLO)</li>\n<li>Operates “South Hills Crossing” (SLO)</li>\n<li>Operates “Parkwood Apartments”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Housing Authority of SLO (HASLO)"
+    ]
+  },
+  "Housing-Now": {
+    "title": "Housing Now",
+    "content": "<h2><span>Housing Now</span></h2>\n<ul>\n<li><strong>How to access:</strong> via the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n<li>Notes:<ul>\n<li>Formerly known as “50 Now” and “70 Now”</li>\n<li>Operated by <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for Transitions Mental Health Association (TMHA)\"><strong>Transitions Mental Health Association (TMHA)</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Housing Now",
+      "“50 Now” and “70 Now”"
+    ]
+  },
+  "Housing-Support-Program": {
+    "title": "Housing Support Program",
+    "content": "<h2><span>Housing Support Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://fcni.org/how-we-help/ensuring-stability/\" data-external-link=\"true\">fcni.org/how-we-help/ensuring-stability</a></li>\n<li><strong>Location:</strong> 1255 Kendall Rd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.237660\" data-lon=\"-120.630188\" data-zoom=\"17\" data-label=\"Housing Support Program\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-3535\" aria-label=\"Call 805-781-3535\">805-781-3535</a>  </li>\n<li><strong>Email:</strong> <a href=\"mailto:Contact@fcni.org\" aria-label=\"Email Contact@fcni.org\">Contact@fcni.org</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–5pm</li>\n<li><strong>How to access:</strong> Get a referral from a <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a> Employment Resource Specialist</li>\n<li>Notes:<ul>\n<li>Run by <a href=\"#\" data-directory-link=\"Family-Care-Network\" aria-label=\"View directory entry for Family Care Network\"><strong>Family Care Network</strong></a></li>\n<li>Can make referrals to <a href=\"#\" data-directory-link=\"Medically-Fragile-Homeless-Program\" aria-label=\"View directory entry for Medically Fragile Homeless Program\"><strong>Medically Fragile Homeless Program</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Housing Support Program"
+    ]
+  },
+  "Immigrant-Hope-Arroyo-Grande": {
+    "title": "Immigrant Hope Arroyo Grande",
+    "content": "<h2><span>Immigrant Hope Arroyo Grande</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://immigranthopeag.org/\" data-external-link=\"true\">immigranthopeag.org</a></li>\n<li><strong>Location:</strong> 995 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.118232\" data-lon=\"-120.592895\" data-zoom=\"17\" data-label=\"Immigrant Hope\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-221-4319\" aria-label=\"Call 805-221-4319\">805-221-4319</a> </li>\n<li><strong>How to access:</strong> Call, visit the office, or use their <a href=\"https://immigranthopeag.org/contact-us/\" data-external-link=\"true\">web contact form</a></li>\n</ul>\n",
+    "aliases": [
+      "Immigrant Hope Arroyo Grande"
+    ]
+  },
+  "Immigrant-Legal-Defense": {
+    "title": "Immigrant Legal Defense (ILD)",
+    "content": "<h2><span>Immigrant Legal Defense (ILD)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ild.org/\" data-external-link=\"true\">ild.org</a></li>\n<li><strong>Location:</strong> Cal Poly Dream Center, Science Building (Building 52), Room E-11, Cal Poly SLO campus <a href=\"#\" class=\"map-link\" data-lat=\"35.300215\" data-lon=\"-120.664443\" data-zoom=\"17\" data-label=\"Cal Poly Dream Center\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-756-6362\" aria-label=\"Call 805-756-6362\">805-756-6362</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:info@ild.org\" aria-label=\"Email info@ild.org\">info@ild.org</a> </li>\n<li><strong>How to access:</strong> Schedule appointments via Calendly at <a href=\"https://calendly.com/csulegalservices/ild\" data-external-link=\"true\">calendly.com/csulegalservices/ild</a> or through Dream Center website at <a href=\"https://dreamcenter.calpoly.edu/LegalServices\" data-external-link=\"true\">dreamcenter.calpoly.edu/LegalServices</a></li>\n</ul>\n",
+    "aliases": [
+      "Immigrant Legal Defense (ILD)"
+    ]
+  },
+  "In-Home-Supportive-Services": {
+    "title": "In-Home Supportive Services (IHSS)",
+    "content": "<h2><span>In-Home Supportive Services (IHSS)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/social-services/adult-services/services/in-home-supportive-services-%28ihss%29-program\" data-external-link=\"true\">slocounty.ca.gov/departments/social-services/adult-services/services/in-home-supportive-services-(ihss)-program</a></li>\n<li><strong>Location:</strong><ul>\n<li>9630 El Camino Real, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.4657747\" data-lon=\"-120.6485702\" data-zoom=\"17\" data-label=\"In-Home Supportive Services\">Map</a> </li>\n<li>1086 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.119759\" data-lon=\"-120.595638\" data-zoom=\"17\" data-label=\"In-Home Supportive Services\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li>Atascadero: <a href=\"tel:+1-805-461-6110\" aria-label=\"Call 805-461-6110\">805-461-6110</a> </li>\n<li>Arroyo Grande: <a href=\"tel:+1-805-474-2103\" aria-label=\"Call 805-474-2103\">805-474-2103</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–5pm </li>\n<li><strong>How to access:</strong> By phone, or by completing an <a href=\"https://www.slocounty.ca.gov/Departments/Social-Services/Forms-Documents/Adult-Services/IHSS-Forms/Online-IHSS-Application-Form.aspx\" data-external-link=\"true\">online application form</a>, or by visiting any <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a> office (no appointment necessary) </li>\n</ul>\n",
+    "aliases": [
+      "In-Home Supportive Services (IHSS)"
+    ]
+  },
+  "Jewish-Family-Services": {
+    "title": "Jewish Family Services",
+    "content": "<h2><span>Jewish Family Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.jccslo.com/jewish-family-services.html\" data-external-link=\"true\">jccslo.com/jewish-family-services.html</a></li>\n<li><strong>Location:</strong> 578 Marsh St., SLO <a class=\"map-link\" data-lat=\"35.277234\" data-lon=\"-120.665549\" data-zoom=\"17\" data-label=\"Jewish Family Services\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-426-5465\" aria-label=\"Call 805-426-5465\">805-426-5465</a></li>\n<li><strong>How to access:</strong> Use the online form; they cannot process assistance requests by phone or email</li>\n</ul>\n",
+    "aliases": [
+      "Jewish Family Services"
+    ]
+  },
+  "Judson-Terrace": {
+    "title": "Judson Terrace",
+    "content": "<h2><span>Judson Terrace</span></h2>\n\n<table>\n<thead>\n<tr>\n<th>Name</th>\n<th>Location</th>\n<th>Phone</th>\n<th>Ages</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Name\"><a href=\"https://www.humangood.org/judson-terrace-homes\" data-external-link=\"true\">Judson Terrace Homes</a></td>\n<td data-label=\"Location\">3000 Augusta St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.267515\" data-lon=\"-120.640529\" data-zoom=\"17\" data-label=\"Judson Terrace Homes\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-544-1600\" aria-label=\"Call 805-544-1600\">805-544-1600</a></td>\n<td data-label=\"Ages\">55+</td>\n</tr>\n<tr>\n<td data-label=\"Name\"><a href=\"https://www.humangood.org/judson-terrace-lodge\" data-external-link=\"true\">Judson Terrace Lodge</a></td>\n<td data-label=\"Location\">3042 Augusta St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.268078\" data-lon=\"-120.639555\" data-zoom=\"17\" data-label=\"Judson Terrace Lodge\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-541-4567\" aria-label=\"Call 805-541-4567\">805-541-4567</a></td>\n<td data-label=\"Ages\">62+</td>\n</tr>\n</tbody></table>\n<ul>\n<li>Notes:<ul>\n<li>Low-income seniors; HUD residents typically pay 30% of gross income for rent</li>\n<li>Applications available only when waiting list is open; contact directly for current status</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Judson Terrace"
+    ]
+  },
+  "Kings-Cupboard": {
+    "title": "King’s Cupboard at El Morro Church",
+    "content": "<h2><span>King’s Cupboard at El Morro Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://sites.vivery.org/kings-cupboard-at-el-morro-church-pantry/los-osos-ca/2156\" data-external-link=\"true\">sites.vivery.org/kings-cupboard-at-el-morro-church-pantry/los-osos-ca/2156</a></li>\n<li><strong>Location:</strong> El Morro Church of the Nazarene, 1480 Santa Ysabel, Bldg. A, Los Osos <a href=\"#\" class=\"map-link\" data-lat=\"35.330593\" data-lon=\"-120.822637\" data-zoom=\"17\" data-label=\"King’s Cupboard at El Morro Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-528-0391\" aria-label=\"Call 805-528-0391\">805-528-0391</a> </li>\n<li><strong>Hours:</strong> Tuesdays, 8–10am </li>\n</ul>\n",
+    "aliases": [
+      "King’s Cupboard at El Morro Church"
+    ]
+  },
+  "Kritter-Care": {
+    "title": "Kritter Care",
+    "content": "<h2><span>Kritter Care</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://krittercare.org/\" data-external-link=\"true\">krittercare.org</a></li>\n<li><strong>Location:</strong> Morro Bay </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-889-9808\" aria-label=\"Call 805-889-9808\">805-889-9808</a> </li>\n</ul>\n",
+    "aliases": [
+      "Kritter Care"
+    ]
+  },
+  "Laundry-Love": {
+    "title": "Laundry Love",
+    "content": "<h2><span>Laundry Love</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://laundrylove.org/\" data-external-link=\"true\">laundrylove.org</a></li>\n<li><strong>Location:</strong> 2179 10th St., Los Osos <a class=\"map-link\" data-lat=\"35.311757\" data-lon=\"-120.832637\" data-zoom=\"17\" data-label=\"Laundry Love\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-441-7262\" aria-label=\"Call 805-441-7262\">805-441-7262</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:naseema6@sbcglobal.net\" aria-label=\"Email naseema6@sbcglobal.net\">naseema6@sbcglobal.net</a> </li>\n<li><strong>Hours:</strong> last Weds. of the month, 11am–1pm (seniors only) &amp; 4–6pm (anyone) </li>\n</ul>\n",
+    "aliases": [
+      "Laundry Love"
+    ]
+  },
+  "Le-Sage-Riviera-RV-Park": {
+    "title": "Le Sage Riviera RV Park",
+    "content": "<h2><span>Le Sage Riviera RV Park</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://lesageriviera.com\" data-external-link=\"true\">lesageriviera.com</a></li>\n<li><strong>Location:</strong> 319 N Highway 1, Grover Beach <a class=\"map-link\" data-lat=\"35.126730\" data-lon=\"-120.631745\" data-zoom=\"17\" data-label=\"Le Sage Riviera RV Park\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-489-5506\" aria-label=\"Call 805-489-5506\">805-489-5506</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@lesageriviera.com\" aria-label=\"Email info@lesageriviera.com\">info@lesageriviera.com</a> </li>\n<li><strong>Hours:</strong> M–Sa 9am–4:30pm, Su 9am–3pm </li>\n</ul>\n",
+    "aliases": [
+      "Le Sage Riviera RV Park"
+    ]
+  },
+  "Legacy-Church-Pantry": {
+    "title": "Legacy Church Pantry",
+    "content": "<h2><span>Legacy Church Pantry</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ourlegacy.church/\" data-external-link=\"true\">ourlegacy.church</a></li>\n<li><strong>Location:</strong><ul>\n<li>Food pantry: 6030 Del Rio Rd., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.512659\" data-lon=\"-120.702113\" data-zoom=\"17\" data-label=\"Legacy Church Food Pantry\">Map</a></li>\n<li>Church: 5545 Ardilla Ave., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.489669\" data-lon=\"-120.674958\" data-zoom=\"17\" data-label=\"Legacy Church\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-2626\" aria-label=\"Call 805-466-2626\">805-466-2626</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@ourlegacy.church\" aria-label=\"Email info@ourlegacy.church\">info@ourlegacy.church</a> </li>\n<li><strong>Hours</strong> (food pantry): Th 1–2pm </li>\n</ul>\n",
+    "aliases": [
+      "Legacy Church Pantry"
+    ]
+  },
+  "Liberty-Tattoo-Removal-Program": {
+    "title": "Liberty Tattoo Removal Program",
+    "content": "<h2><span>Liberty Tattoo Removal Program</span></h2>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-540-8353\" aria-label=\"Call 805-540-8353\">805-540-8353</a> </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:libertytattooremoval@capslo.org\" aria-label=\"Email libertytattooremoval@capslo.org\">libertytattooremoval@capslo.org</a> </li>\n<li><a href=\"mailto:floydbland@capslo.org\" aria-label=\"Email floydbland@capslo.org\">floydbland@capslo.org</a> </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo\"><strong>Community Action Partnership San Luis Obispo</strong></a></li>\n<li>Hosted by <a href=\"#\" data-directory-link=\"Adventist-Health-Sierra-Vista\" aria-label=\"View directory entry for Adventist Health Sierra Vista\"><strong>Adventist Health Sierra Vista</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Liberty Tattoo Removal Program"
+    ]
+  },
+  "Lifepoint-Church": {
+    "title": "Lifepoint Church",
+    "content": "<h2><span>Lifepoint Church</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://lifepointcentralcoast.com/\" data-external-link=\"true\">lifepointcentralcoast.com</a> </li>\n<li><strong>Locations:</strong><ul>\n<li>Main: 207 Pilgrim Way, Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.115749\" data-lon=\"-120.575423\" data-zoom=\"17\" data-label=\"Lifepoint Church\">Map</a></li>\n<li>Outreach location: 946 Rockaway Ave., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.120091\" data-lon=\"-120.619796\" data-zoom=\"17\" data-label=\"Lifepoint Church outreach location\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-489-3328\" aria-label=\"Call 805-489-3328\">805-489-3328</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:church@lifepointcentralcoast.com\" aria-label=\"Email church@lifepointcentralcoast.com\">church@lifepointcentralcoast.com</a></li>\n<li>Notes:<ul>\n<li>Hosts <a href=\"#\" data-directory-link=\"CCPAW\" aria-label=\"View directory entry for Central Coast Partnership for Animal Welfare\"><strong>Central Coast Partnership for Animal Welfare</strong></a></li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Five-Cities-Christian-Women-Food-Pantry\" aria-label=\"View directory entry for Five Cities Christian Women Food Pantry\"><strong>Five Cities Christian Women Food Pantry</strong></a></li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Peoples-Kitchen-GB\" aria-label=\"View directory entry for People’s Kitchen (Grover Beach)\"><strong>People’s Kitchen (Grover Beach)</strong></a></li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Shower-the-People\" aria-label=\"View directory entry for Shower the People\"><strong>Shower the People</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Lifepoint Church"
+    ]
+  },
+  "Lifesigns": {
+    "title": "Lifesigns",
+    "content": "<h2><span>Lifesigns</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://lifesignsinc.org/\" data-external-link=\"true\">lifesignsinc.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-888-930-7776;ext=1\" aria-label=\"Call 888-930-7776 x1\">888-930-7776 x1</a> <ul>\n<li>For after-hours emergency interpreting: <a href=\"tel:+1-800-633-8883\" aria-label=\"Call 800-633-8883\">800-633-8883</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:Lifesigns@lifesignsinc.org\" aria-label=\"Email Lifesigns@lifesignsinc.org\">Lifesigns@lifesignsinc.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Lifesigns"
+    ]
+  },
+  "Life-Steps-Foundation": {
+    "title": "Life Steps Foundation",
+    "content": "<h2><span>Life Steps Foundation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.lifestepsfoundation.org/\" data-external-link=\"true\">lifestepsfoundation.org</a></li>\n<li><strong>Location:</strong> 218 W. Carmen Lane #108, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.924628\" data-lon=\"-120.438631\" data-zoom=\"17\" data-label=\"Life Steps Foundation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-549-0150\" aria-label=\"Call 805-549-0150\">805-549-0150</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:ccasoffice@lifestepsfoundation.org\" aria-label=\"Email ccasoffice@lifestepsfoundation.org\">ccasoffice@lifestepsfoundation.org</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5:30pm</li>\n</ul>\n",
+    "aliases": [
+      "Life Steps Foundation"
+    ]
+  },
+  "Link-Family-Resource-Center": {
+    "title": "The Link Family Resource Center",
+    "content": "<h2><span>The Link Family Resource Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://linkslo.org/\" data-external-link=\"true\">linkslo.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Atascadero: 4507 Del Rio Ave Bldg. #1, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.513562\" data-lon=\"-120.686928\" data-zoom=\"17\" data-label=\"The Link Family Resource Center (Atascadero)\">Map</a> </li>\n<li>Paso Robles: 1802 Chestnut St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.628326\" data-lon=\"-120.691147\" data-zoom=\"17\" data-label=\"The Link Family Resource Center (Paso Robles)\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-5404\" aria-label=\"Call 805-466-5404\">805-466-5404</a> <ul>\n<li>Family Advocate Services: <a href=\"tel:+1-805-794-0217\" aria-label=\"Call 805-794-0217\">805-794-0217</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 9am–5pm </li>\n<li><strong>How to access:</strong> accepts self-referrals, school referrals, and community agency referrals</li>\n<li>Notes:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"CFS\" aria-label=\"View directory entry for Center for Family Strengthening (CFS)\"><strong>Center for Family Strengthening (CFS)</strong></a></li>\n<li>See also <a href=\"#\" data-directory-link=\"North-County-Family-Resource-Center\" aria-label=\"View directory entry for North County Family Resource Center\"><strong>North County Family Resource Center</strong></a></li>\n<li>See also <a href=\"#\" data-directory-link=\"SAFE-Family-Resource-Centers\" aria-label=\"View directory entry for SAFE Family Resource Centers\"><strong>SAFE Family Resource Centers</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "The Link Family Resource Center"
+    ]
+  },
+  "Literacy-For-Life": {
+    "title": "Literacy For Life",
+    "content": "<h2><span>Literacy For Life</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.literacyforlifeslo.org/\" data-external-link=\"true\">literacyforlifeslo.org</a></li>\n<li><strong>Location:</strong> 992 Monterey St. #C, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.281755\" data-lon=\"-120.661662\" data-zoom=\"17\" data-label=\"Literacy For Life\">Map</a><ul>\n<li><a href=\"https://www.literacyforlifeslo.org/learning-centers.php\" data-external-link=\"true\">Learning centers</a> in Arroyo Grande, Atascadero, Cambria, Los Osos, Morro Bay, Nipomo, Paso Robles, and SLO</li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-459-5369\" aria-label=\"Call 805-459-5369\">805-459-5369</a> { Source: <a href=\"https://www.literacyforlifeslo.org/contact.php\" data-external-link=\"true\">https://www.literacyforlifeslo.org/contact.php</a> }</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@literacyforlifeslo.org\" aria-label=\"Email info@literacyforlifeslo.org\">info@literacyforlifeslo.org</a> { Source: <a href=\"https://www.literacyforlifeslo.org/contact.php\" data-external-link=\"true\">https://www.literacyforlifeslo.org/contact.php</a> }</li>\n<li><strong>Hours:</strong> M–Th 9am–5pm\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Literacy For Life"
+    ]
+  },
+  "Literacy-Connection": {
+    "title": "The Literacy Connection",
+    "content": "<h2><span>The Literacy Connection</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://catalog.slolibrary.org/tlc\" data-external-link=\"true\">catalog.slolibrary.org/tlc</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5077\" aria-label=\"Call 805-781-5077\">805-781-5077</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:TLCinfo@slolibrary.org\" aria-label=\"Email TLCinfo@slolibrary.org\">TLCinfo@slolibrary.org</a> </li>\n<li><strong>How to access:</strong> Submit a form on <a href=\"https://catalog.slolibrary.org/tlc\" data-external-link=\"true\">the library website</a> </li>\n<li>Notes: Program of <a href=\"#\" data-directory-link=\"SLO-County-Public-Libraries\" aria-label=\"View directory entry for SLO County Public Libraries\"><strong>SLO County Public Libraries</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "The Literacy Connection"
+    ]
+  },
+  "Little-Free-Libraries": {
+    "title": "Little Free Libraries",
+    "content": "<h2><span>Little Free Libraries</span></h2>\n<p>🗺️ <strong><a href=\"little-free-libraries-map.html\" rel=\"noopener\">View all locations on an interactive map</a></strong></p>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://littlefreelibrary.org/\" data-external-link=\"true\">littlefreelibrary.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Arroyo Grande:<ul>\n<li>330 Alder St. <a href=\"#\" class=\"map-link\" data-lat=\"35.114090\" data-lon=\"-120.593823\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>121 Allen St. <a href=\"#\" class=\"map-link\" data-lat=\"35.119917\" data-lon=\"-120.575391\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Amarillo Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.073182\" data-lon=\"-120.586066\" data-zoom=\"16\" data-label=\"Little Free Library\">Map</a></li>\n<li>2510 Appaloosa Way <a href=\"#\" class=\"map-link\" data-lat=\"35.073411\" data-lon=\"-120.580329\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Corner of Cedar &amp; Boysenberry <a href=\"#\" class=\"map-link\" data-lat=\"35.117185\" data-lon=\"-120.604837\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>529 E. Cherry Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.121326\" data-lon=\"-120.570416\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>615 E. Cherry Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.122401\" data-lon=\"-120.568374\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2385 Clarkie Way <a href=\"#\" class=\"map-link\" data-lat=\"35.087336\" data-lon=\"-120.563930\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Cypress Ridge Pkwy. near Cypress Ridge golf course entrance <a href=\"#\" class=\"map-link\" data-lat=\"35.065912\" data-lon=\"-120.572875\" data-zoom=\"16\" data-label=\"Little Free Library\">Map</a></li>\n<li>485 Dorothy Ln. <a href=\"#\" class=\"map-link\" data-lat=\"35.055285\" data-lon=\"-120.581134\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>303 N. Elm St. <a href=\"#\" class=\"map-link\" data-lat=\"35.123058\" data-lon=\"-120.600336\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>512 S. Elm St. <a href=\"#\" class=\"map-link\" data-lat=\"35.110289\" data-lon=\"-120.600857\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>282 Gait Way <a href=\"#\" class=\"map-link\" data-lat=\"35.089684\" data-lon=\"-120.578772\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1146 Maple St. <a href=\"#\" class=\"map-link\" data-lat=\"35.117013\" data-lon=\"-120.598429\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Maple St. @ Walnut St. <a href=\"#\" class=\"map-link\" data-lat=\"35.116732\" data-lon=\"-120.597214\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>127 S. Mason St. <a href=\"#\" class=\"map-link\" data-lat=\"35.123681\" data-lon=\"-120.575667\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>328 Orchard St. <a href=\"#\" class=\"map-link\" data-lat=\"35.118206\" data-lon=\"-120.578403\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1270 Poplar St. <a href=\"#\" class=\"map-link\" data-lat=\"35.119016\" data-lon=\"-120.603324\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1260 Sage St. <a href=\"#\" class=\"map-link\" data-lat=\"35.118284\" data-lon=\"-120.603290\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1414 Sierra Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.126825\" data-lon=\"-120.603753\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>494 Stagecoach Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.131236\" data-lon=\"-120.564362\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>958 Sycamore Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.108422\" data-lon=\"-120.593270\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>250 Wesley St. <a href=\"#\" class=\"map-link\" data-lat=\"35.126572\" data-lon=\"-120.581547\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Atascadero:<ul>\n<li>9481 Carmel Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.439074\" data-lon=\"-120.615227\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>8505 Carmelita Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.472397\" data-lon=\"-120.673113\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3155 El Camino Real <a href=\"#\" class=\"map-link\" data-lat=\"35.506468\" data-lon=\"-120.690123\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2720 Ferrocarril Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.518062\" data-lon=\"-120.682527\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>8934 Junipero Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.480842\" data-lon=\"-120.652139\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Mariquita Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.494020\" data-lon=\"-120.672484\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>9125 Mountain View Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.466434\" data-lon=\"-120.665097\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>5265 Palma Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.493723\" data-lon=\"-120.675068\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>14985 Powerline Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.420287\" data-lon=\"-120.628037\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>8155 San Gregorio Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.513614\" data-lon=\"-120.722312\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>10675 San Marcos Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.463859\" data-lon=\"-120.699431\" data-zoom=\"16\" data-label=\"Little Free Library\">Map</a></li>\n<li>13400 Santa Ana Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.503843\" data-lon=\"-120.725162\" data-zoom=\"16\" data-label=\"Little Free Library\">Map</a></li>\n<li>6605 Santa Ynez Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.483352\" data-lon=\"-120.669031\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>7310 Sonora Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.487968\" data-lon=\"-120.655054\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>8437 Vaquero Ln. <a href=\"#\" class=\"map-link\" data-lat=\"35.476039\" data-lon=\"-120.647912\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>4555 Viscano Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.507060\" data-lon=\"-120.669193\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Avila Beach:<ul>\n<li>1401 San Luis Bay Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.193967\" data-lon=\"-120.715208\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>191 San Miguel St. <a href=\"#\" class=\"map-link\" data-lat=\"35.180624\" data-lon=\"-120.733256\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>259 Squire Canyon Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.194958\" data-lon=\"-120.681242\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Cambria:<ul>\n<li>6404 Buckley Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.574393\" data-lon=\"-121.098921\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>701 Drake St. <a href=\"#\" class=\"map-link\" data-lat=\"35.548281\" data-lon=\"-121.091709\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>521 Hastings St. <a href=\"#\" class=\"map-link\" data-lat=\"35.564578\" data-lon=\"-121.102896\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2750 Holden Pl. <a href=\"#\" class=\"map-link\" data-lat=\"35.547895\" data-lon=\"-121.074863\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>383 Orlando Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.547507\" data-lon=\"-121.094860\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1176 Pineridge Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.541138\" data-lon=\"-121.073378\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>365 Weymouth St. <a href=\"#\" class=\"map-link\" data-lat=\"35.571884\" data-lon=\"-121.107462\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Cayucos:<ul>\n<li>84 13th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.441637\" data-lon=\"-120.891423\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1175 Cass Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.441671\" data-lon=\"-120.893139\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>151 F St. <a href=\"#\" class=\"map-link\" data-lat=\"35.448532\" data-lon=\"-120.901740\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>517 Lucerne Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.448889\" data-lon=\"-120.910614\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>625 S. Ocean Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.445027\" data-lon=\"-120.896035\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Grover Beach:<ul>\n<li>338 N. 3rd St. <a href=\"#\" class=\"map-link\" data-lat=\"35.124773\" data-lon=\"-120.627183\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>251 S. 4th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.120202\" data-lon=\"-120.626670\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>266 N. 5th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.123621\" data-lon=\"-120.624910\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>240 Anita Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.108002\" data-lon=\"-120.609531\" data-zoom=\"17\" data-label=\"Little Free Libraries\">Map</a></li>\n<li>1230 Trouville Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.115854\" data-lon=\"-120.616578\" data-zoom=\"17\" data-label=\"Little Free Libraries\">Map</a></li>\n<li>1624 Trouville Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.115683\" data-lon=\"-120.611738\" data-zoom=\"17\" data-label=\"Little Free Libraries\">Map</a></li>\n</ul>\n</li>\n<li>Los Osos / Baywood Park:<ul>\n<li>1643 4th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.321573\" data-lon=\"-120.839052\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1182 7th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.330479\" data-lon=\"-120.835297\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1855 7th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.317787\" data-lon=\"-120.835598\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1180 9th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.330435\" data-lon=\"-120.833012\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1257 11th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.328834\" data-lon=\"-120.830823\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1426 16th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.325639\" data-lon=\"-120.825394\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1539 18th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.323582\" data-lon=\"-120.823474\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1639 18th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.321708\" data-lon=\"-120.823474\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2130 Andre Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.310294\" data-lon=\"-120.820349\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2315 Bayview Heights Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.309403\" data-lon=\"-120.833878\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2148 Bush Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.311895\" data-lon=\"-120.834482\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2149 Lariat Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.307316\" data-lon=\"-120.811683\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>561 Loma St. <a href=\"#\" class=\"map-link\" data-lat=\"35.317673\" data-lon=\"-120.843891\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1351 Los Olivos Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.312628\" data-lon=\"-120.825568\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1078 Los Osos Valley Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.311720\" data-lon=\"-120.831102\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2003 Lost Oak Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.314850\" data-lon=\"-120.826659\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>732 Manzanita Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.310765\" data-lon=\"-120.838720\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2345 Oak Ridge Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.307342\" data-lon=\"-120.825877\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2100 Pecho Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.314075\" data-lon=\"-120.851884\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>948 Santa Maria Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.328212\" data-lon=\"-120.834610\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1188 Scenic Way <a href=\"#\" class=\"map-link\" data-lat=\"35.330164\" data-lon=\"-120.821371\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2340 Tierra Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.307885\" data-lon=\"-120.826553\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Morro Bay:<ul>\n<li>720 Cabrillo Pl. <a href=\"#\" class=\"map-link\" data-lat=\"35.355395\" data-lon=\"-120.843558\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Cloisters Community Park <a href=\"#\" class=\"map-link\" data-lat=\"35.390449\" data-lon=\"-120.861604\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>482 Estero Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.361721\" data-lon=\"-120.844277\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2401 Ironwood Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.387703\" data-lon=\"-120.853193\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>495 Main St. <a href=\"#\" class=\"map-link\" data-lat=\"35.361784\" data-lon=\"-120.850224\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>450 San Jacinto St. <a href=\"#\" class=\"map-link\" data-lat=\"35.394094\" data-lon=\"-120.857676\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Nipomo:<ul>\n<li>421 N. Las Flores Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.016626\" data-lon=\"-120.511421\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>789 Live Oak Ridge Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.044438\" data-lon=\"-120.516232\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>525 Sandydale Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.044833\" data-lon=\"-120.493745\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Oceano:<ul>\n<li>1341 18th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.105805\" data-lon=\"-120.611494\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1501 24th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.102689\" data-lon=\"-120.603769\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Paso Robles:<ul>\n<li>14140 Chimney Rock Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.685885\" data-lon=\"-120.949099\" data-zoom=\"15\" data-label=\"Little Free Library\">Map</a></li>\n<li>5090 Deer Creek Way <a href=\"#\" class=\"map-link\" data-lat=\"35.675182\" data-lon=\"-120.599488\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1130 Merry Hill Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.626407\" data-lon=\"-120.701740\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2247 Oak St. <a href=\"#\" class=\"map-link\" data-lat=\"35.637880\" data-lon=\"-120.693794\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2004 Pine St. <a href=\"#\" class=\"map-link\" data-lat=\"35.635204\" data-lon=\"-120.689301\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3773 Ruth Way #A <a href=\"#\" class=\"map-link\" data-lat=\"35.635204\" data-lon=\"-120.689301\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1103 Spring St. <a href=\"#\" class=\"map-link\" data-lat=\"35.625533\" data-lon=\"-120.692883\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>539 Veronica Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.620405\" data-lon=\"-120.668131\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2105 Vine St. <a href=\"#\" class=\"map-link\" data-lat=\"35.636053\" data-lon=\"-120.695039\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>904 Vista Cerro Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.626666\" data-lon=\"-120.657874\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Pismo Beach:<ul>\n<li>28 El Viento <a href=\"#\" class=\"map-link\" data-lat=\"35.141748\" data-lon=\"-120.619004\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>224 Irish Way <a href=\"#\" class=\"map-link\" data-lat=\"35.134519\" data-lon=\"-120.616391\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>990 Price St. <a href=\"#\" class=\"map-link\" data-lat=\"35.143482\" data-lon=\"-120.641506\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2411 Price St. <a href=\"#\" class=\"map-link\" data-lat=\"35.148810\" data-lon=\"-120.651196\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2555 Price St. <a href=\"#\" class=\"map-link\" data-lat=\"35.149153\" data-lon=\"-120.653452\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>995 Skyline Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.136528\" data-lon=\"-120.606985\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>San Miguel:<ul>\n<li>1197 L St. <a href=\"#\" class=\"map-link\" data-lat=\"35.750082\" data-lon=\"-120.698097\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Santa Margarita:<ul>\n<li>22070 H St. <a href=\"#\" class=\"map-link\" data-lat=\"35.394411\" data-lon=\"-120.600808\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3120 Ranchita Canyon Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.735801\" data-lon=\"-120.607985\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Shell Beach:<ul>\n<li>302 Cuyama Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.156784\" data-lon=\"-120.677138\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>262 Esparto Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.155398\" data-lon=\"-120.673018\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>SLO:<ul>\n<li>1330 Alder St. <a href=\"#\" class=\"map-link\" data-lat=\"35.247297\" data-lon=\"-120.629542\" data-zoom=\"16\" data-label=\"Little Free Library\">Map</a></li>\n<li>1378 Avalon St. (@ Oceanaire Dr.) <a href=\"#\" class=\"map-link\" data-lat=\"35.263063\" data-lon=\"-120.687116\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>79 Benton Way <a href=\"#\" class=\"map-link\" data-lat=\"35.291125\" data-lon=\"-120.670781\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Bluerock Drive near Stoneridge Park <a href=\"#\" class=\"map-link\" data-lat=\"35.261906\" data-lon=\"-120.655375\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1410 Broad St. @ Pacific <a href=\"#\" class=\"map-link\" data-lat=\"35.276596\" data-lon=\"-120.662295\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Center St. by Nazarene church</li>\n<li>Center St. between Chorro and Lincoln <a href=\"#\" class=\"map-link\" data-lat=\"35.287044\" data-lon=\"-120.667729\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>171 Cerro Romauldo Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.295083\" data-lon=\"-120.677927\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3450 Dairy Creek Rd. (SLO Botanical Garden) <a href=\"#\" class=\"map-link\" data-lat=\"35.331880\" data-lon=\"-120.728717\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>2378 Boulevard Del Campo <a href=\"#\" class=\"map-link\" data-lat=\"35.270140\" data-lon=\"-120.649130\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1295 Descanso St. <a href=\"#\" class=\"map-link\" data-lat=\"35.265559\" data-lon=\"-120.698268\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>107 Earthwood Ln. <a href=\"#\" class=\"map-link\" data-lat=\"35.236681\" data-lon=\"-120.675588\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1595 Eto Circle <a href=\"#\" class=\"map-link\" data-lat=\"35.255055\" data-lon=\"-120.695018\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1383 Fairway Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.257552\" data-lon=\"-120.699459\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>157 Fel Mar Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.298910\" data-lon=\"-120.684954\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1348 Fernwood Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.264175\" data-lon=\"-120.638396\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1011 George St. <a href=\"#\" class=\"map-link\" data-lat=\"35.274520\" data-lon=\"-120.654666\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1 Grand Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.122113\" data-lon=\"-120.634064\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3440 Gregory Ct. <a href=\"#\" class=\"map-link\" data-lat=\"35.264324\" data-lon=\"-120.635237\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1415 Higuera St. <a href=\"#\" class=\"map-link\" data-lat=\"35.284846\" data-lon=\"-120.654559\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>On a utility pole at Morro St. and Islay St. <a href=\"#\" class=\"map-link\" data-lat=\"35.276876\" data-lon=\"-120.658486\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1121 Islay St. <a href=\"#\" class=\"map-link\" data-lat=\"35.278313\" data-lon=\"-120.655482\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1215 Joyce Ct. <a href=\"#\" class=\"map-link\" data-lat=\"35.269615\" data-lon=\"-120.647253\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3962 Kilbern Way <a href=\"#\" class=\"map-link\" data-lat=\"35.253618\" data-lon=\"-120.636411\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>10 La Entrada Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.293831\" data-lon=\"-120.682958\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>286 Lawrence Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.264210\" data-lon=\"-120.659173\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>655 Lawrence Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.263965\" data-lon=\"-120.653293\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1148 Leff St. <a href=\"#\" class=\"map-link\" data-lat=\"35.277910\" data-lon=\"-120.654495\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>United Church of Christ (11245 Los Osos Valley Road) <a href=\"#\" class=\"map-link\" data-lat=\"35.260531\" data-lon=\"-120.695661\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1708 Lynn <a href=\"#\" class=\"map-link\" data-lat=\"35.259926\" data-lon=\"-120.699974\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Corner of Mill &amp; Toro <a href=\"#\" class=\"map-link\" data-lat=\"35.285083\" data-lon=\"-120.660090\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Monday Club, 1815 Monterey at Grand <a href=\"#\" class=\"map-link\" data-lat=\"35.288367\" data-lon=\"-120.651308\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1430 Noveno Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.260767\" data-lon=\"-120.636610\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1552 Oceanaire Dr. (near Atascadero St.) <a href=\"#\" class=\"map-link\" data-lat=\"35.260794\" data-lon=\"-120.684820\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1906 Oceanaire Dr. (near Pinecove Dr.) <a href=\"#\" class=\"map-link\" data-lat=\"35.255958\" data-lon=\"-120.684262\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>Pacific between Johnson &amp; Pepper <a href=\"#\" class=\"map-link\" data-lat=\"35.282736\" data-lon=\"-120.654597\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1768 Pereira Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.255695\" data-lon=\"-120.688071\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1358 Purple Sage Ln. <a href=\"#\" class=\"map-link\" data-lat=\"35.246714\" data-lon=\"-120.629867\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>333 Sage St. <a href=\"#\" class=\"map-link\" data-lat=\"35.255406\" data-lon=\"-120.663539\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>373 Sage St. <a href=\"#\" class=\"map-link\" data-lat=\"35.255423\" data-lon=\"-120.661865\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1401 San Luis Bay Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.192977\" data-lon=\"-120.715295\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1739 San Luis Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.286554\" data-lon=\"-120.650418\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1391 San Marcos Ct. <a href=\"#\" class=\"map-link\" data-lat=\"35.269203\" data-lon=\"-120.642908\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>In front of The Establishment, 1703 Santa Barbara Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.276342\" data-lon=\"-120.656708\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>By the Montessori school at South Higuera &amp; Los Osos Valley Road <a href=\"#\" class=\"map-link\" data-lat=\"35.241860\" data-lon=\"-120.676929\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>3960 S. Higuera St. #34 <a href=\"#\" class=\"map-link\" data-lat=\"35.248051\" data-lon=\"-120.674354\" data-zoom=\"16\" data-label=\"Little Free Library\">Map</a></li>\n<li>Nazarene church on 3396 Southwood Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.264981\" data-lon=\"-120.635355\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1767 Southwood Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.264823\" data-lon=\"-120.629282\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>4475 Wavertree St. <a href=\"#\" class=\"map-link\" data-lat=\"35.247748\" data-lon=\"-120.627995\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>637 Woodbridge <a href=\"#\" class=\"map-link\" data-lat=\"35.267197\" data-lon=\"-120.656072\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n<li>Templeton:<ul>\n<li>785 Ashley Ln. <a href=\"#\" class=\"map-link\" data-lat=\"35.540835\" data-lon=\"-120.717790\" data-zoom=\"18\" data-label=\"Little Free Library\">Map</a></li>\n<li>620 Old Country Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.549455\" data-lon=\"-120.709426\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>308 Puffin Way <a href=\"#\" class=\"map-link\" data-lat=\"35.553923\" data-lon=\"-120.730080\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>215 S. Main St. <a href=\"#\" class=\"map-link\" data-lat=\"35.550900\" data-lon=\"-120.703762\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>1027 Santa Rita Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.542668\" data-lon=\"-120.722494\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n<li>158 Wessels Way <a href=\"#\" class=\"map-link\" data-lat=\"35.555604\" data-lon=\"-120.706229\" data-zoom=\"17\" data-label=\"Little Free Library\">Map</a></li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>Hours:</strong> Daily, 24/7</li>\n</ul>\n",
+    "aliases": [
+      "Little Free Libraries"
+    ]
+  },
+  "Little-Free-Pantries": {
+    "title": "Little Free Pantries",
+    "content": "<h2><span>Little Free Pantries</span></h2>\n<p>🗺️ <strong><a href=\"little-free-pantries-map.html\" rel=\"noopener\">View all locations on an interactive map</a></strong></p>\n<p>Note: Little Free Pantries come and go.\nSometimes they are neglected, damaged, or removed.\nIf you see one listed here that is no longer in service, please use the feedback button to tell VivaSLO about it.</p>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.littlefreepantry.org/\" data-external-link=\"true\">littlefreepantry.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Arroyo Grande:<ul>\n<li>132 South Halcyon Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.117680\" data-lon=\"-120.591688\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>268 Summit Station Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.064428\" data-lon=\"-120.517080\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Atascadero:<ul>\n<li>9557 Curbaril Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.491538\" data-lon=\"-120.647313\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>9333 Santa Barbara Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.449172\" data-lon=\"-120.633742\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Grover Beach:<ul>\n<li>202 S. 8th St. / 770 Rockaway Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.120336\" data-lon=\"-120.621656\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>393 N. 16th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.124713\" data-lon=\"-120.611462\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>925 Newport Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.125591\" data-lon=\"-120.619581\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Los Osos:<ul>\n<li>1500 block of 5th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.323564\" data-lon=\"-120.837615\" data-zoom=\"16\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>1559 10th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.323314\" data-lon=\"-120.832444\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>490 Los Osos Valley Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.313346\" data-lon=\"-120.845536\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Morro Bay:<ul>\n<li>3000 Hemlock Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.396754\" data-lon=\"-120.857001\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>397 San Joaquin St. <a href=\"#\" class=\"map-link\" data-lat=\"35.392420\" data-lon=\"-120.857967\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Nipomo:<ul>\n<li>181 W Tefft St. <a href=\"#\" class=\"map-link\" data-lat=\"35.041418\" data-lon=\"-120.477533\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>267 W Tefft St. <a href=\"#\" class=\"map-link\" data-lat=\"35.039950\" data-lon=\"-120.479340\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Oceano:<ul>\n<li>1322 24th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.105814\" data-lon=\"-120.604037\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>1501 24th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.102703\" data-lon=\"-120.603613\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>1930 Ocean St. <a href=\"#\" class=\"map-link\" data-lat=\"35.099906\" data-lon=\"-120.610517\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>615 Pier Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.107217\" data-lon=\"-120.624337\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Paso Robles:<ul>\n<li>8th St. and Olive St. <a href=\"#\" class=\"map-link\" data-lat=\"35.622280\" data-lon=\"-120.694835\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>3301 Oak St. <a href=\"#\" class=\"map-link\" data-lat=\"35.648648\" data-lon=\"-120.694685\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>1003 Pioneer Trail Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.606196\" data-lon=\"-120.643111\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Pismo Beach: 206 Margo Way <a href=\"#\" class=\"map-link\" data-lat=\"35.135993\" data-lon=\"-120.610013\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>Santa Margarita:<ul>\n<li>22210 El Camino Real <a href=\"#\" class=\"map-link\" data-lat=\"35.392602\" data-lon=\"-120.606745\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>22495 K St. <a href=\"#\" class=\"map-link\" data-lat=\"35.386645\" data-lon=\"-120.606553\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>SLO:<ul>\n<li>3320 Bullock Ln. <a href=\"#\" class=\"map-link\" data-lat=\"35.260531\" data-lon=\"-120.643519\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>2021 Broad St. <a href=\"#\" class=\"map-link\" data-lat=\"35.271279\" data-lon=\"-120.657976\" data-zoom=\"18\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>226 Ferrini Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.295416\" data-lon=\"-120.673839\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>335 High St. <a href=\"#\" class=\"map-link\" data-lat=\"35.272050\" data-lon=\"-120.665095\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>2075 Johnson Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.276312\" data-lon=\"-120.648300\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>11245 Los Osos Valley Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.260575\" data-lon=\"-120.695157\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>474 Marsh St. <a href=\"#\" class=\"map-link\" data-lat=\"35.276460\" data-lon=\"-120.667080\" data-zoom=\"18\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>1306 Nipomo St. <a href=\"#\" class=\"map-link\" data-lat=\"35.276676\" data-lon=\"-120.664180\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a> </li>\n<li>695 Pismo St. <a href=\"#\" class=\"map-link\" data-lat=\"35.276376\" data-lon=\"-120.662522\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>corner of San Carlos and Bushnell <a href=\"#\" class=\"map-link\" data-lat=\"35.269527\" data-lon=\"-120.652344\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n<li>193 San Jose Ct. <a href=\"#\" class=\"map-link\" data-lat=\"35.291537\" data-lon=\"-120.683366\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li>Templeton: 806 Old Country Rd. <a href=\"#\" class=\"map-link\" data-lat=\"35.547338\" data-lon=\"-120.710440\" data-zoom=\"17\" data-label=\"Little Free Pantry\">Map</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong> Daily, 24/7</li>\n</ul>\n",
+    "aliases": [
+      "Little Free Pantries"
+    ]
+  },
+  "Loaves-and-Fishes-Atascadero": {
+    "title": "Loaves & Fishes (Atascadero)",
+    "content": "<h2><span>Loaves &amp; Fishes (Atascadero)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://alffoodpantry.org/\" data-external-link=\"true\">alffoodpantry.org</a></li>\n<li><strong>Location:</strong> 5411 El Camino Real, Atascadero <a class=\"map-link\" data-lat=\"35.492964\" data-lon=\"-120.676511\" data-zoom=\"17\" data-label=\"Loaves &amp; Fishes (Atascadero)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-461-1504\" aria-label=\"Call 805-461-1504\">805-461-1504</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:contact@alffoodpantry.org\" aria-label=\"Email contact@alffoodpantry.org\">contact@alffoodpantry.org</a> </li>\n<li><strong>Hours</strong> (food pantry): M–F 1–3pm </li>\n<li>Notes: Not affiliated with <a href=\"#\" data-directory-link=\"Loaves-and-Fishes-Paso-Robles\" aria-label=\"View directory entry for Loaves &amp; Fishes (Paso Robles)\"><strong>Loaves &amp; Fishes (Paso Robles)</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Loaves & Fishes (Atascadero)"
+    ]
+  },
+  "Loaves-and-Fishes-Paso-Robles": {
+    "title": "Loaves & Fishes (Paso Robles)",
+    "content": "<h2><span>Loaves &amp; Fishes (Paso Robles)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://loavesandfishespaso.org\" data-external-link=\"true\">loavesandfishespaso.org</a></li>\n<li><strong>Location:</strong> 2650 Spring St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.642136\" data-lon=\"-120.692363\" data-zoom=\"17\" data-label=\"Loaves and Fishes (Paso Robles)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-238-4742\" aria-label=\"Call 805-238-4742\">805-238-4742</a> </li>\n<li><strong>Hours:</strong> M–Th 2pm–4pm, or by appointment </li>\n<li>Notes: Not affiliated with <a href=\"#\" data-directory-link=\"Loaves-and-Fishes-Atascadero\" aria-label=\"View directory entry for Loaves &amp; Fishes (Atascadero)\"><strong>Loaves &amp; Fishes (Atascadero)</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Loaves & Fishes (Paso Robles)"
+    ]
+  },
+  "Long-Term-Care-Ombudsman": {
+    "title": "Long Term Care Ombudsman",
+    "content": "<h2><span>Long Term Care Ombudsman</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://ombudsmanslo.org/\" data-external-link=\"true\">ombudsmanslo.org</a></li>\n<li><strong>Location:</strong> 3232 S. Higuera St. #101B, SLO <a class=\"map-link\" data-lat=\"35.256866\" data-lon=\"-120.668734\" data-zoom=\"17\" data-label=\"Long Term Care Ombudsman\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-785-0132\" aria-label=\"Call 805-785-0132\">805-785-0132</a> (office) </li>\n<li><a href=\"tel:+1-800-231-4024\" aria-label=\"Call 800-231-4024\">800-231-4024</a> (24-hour emergency) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@ombudsmanslo.org\" aria-label=\"Email info@ombudsmanslo.org\">info@ombudsmanslo.org</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–4:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Long Term Care Ombudsman"
+    ]
+  },
+  "Lopez-Lake-Recreation-Area": {
+    "title": "Lopez Lake Recreation Area",
+    "content": "<h2><span>Lopez Lake Recreation Area</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocountyparks.com/camp/lopez-lake/\" data-external-link=\"true\">slocountyparks.com/camp/lopez-lake/</a></li>\n<li><strong>Location:</strong> 6800 Lopez Dr., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.190855\" data-lon=\"-120.457415\" data-zoom=\"15\" data-label=\"Lopez Lake Recreation Area\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-788-2381\" aria-label=\"Call 805-788-2381\">805-788-2381</a>  M–Th 8am–5pm; <a href=\"tel:+1-805-781-5930\" aria-label=\"Call 805-781-5930\">805-781-5930</a> (reservations)</li>\n<li><strong>Email:</strong> <a href=\"mailto:sloparks@co.slo.ca.us\" aria-label=\"Email sloparks@co.slo.ca.us\">sloparks@co.slo.ca.us</a></li>\n<li><strong>Hours:</strong> 6am–sunset daily</li>\n</ul>\n",
+    "aliases": [
+      "Lopez Lake Recreation Area"
+    ]
+  },
+  "Los-Osos-Cares": {
+    "title": "Los Osos Cares Resource Center",
+    "content": "<h2><span>Los Osos Cares Resource Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.losososcares.com/\" data-external-link=\"true\">losososcares.com</a></li>\n<li><strong>Location:</strong> Sunnyside School, 800 Manzanita Dr., Room 18, Los Osos <a class=\"map-link\" data-lat=\"35.309785\" data-lon=\"-120.835047\" data-zoom=\"17\" data-label=\"Los Osos Cares Resource Center\">Map</a> <ul>\n<li>Community Dinners: 2180 Palisades Ave., Los Osos </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-592-2701\" aria-label=\"Call 805-592-2701\">805-592-2701</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:wecareinlososos@gmail.com\" aria-label=\"Email wecareinlososos@gmail.com\">wecareinlososos@gmail.com</a> </li>\n<li><strong>Hours:</strong> Tu/W/Th 1–3pm <ul>\n<li>Community Dinners: Wednesdays 5–6pm </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Hosts Community Dinner at <a href=\"#\" data-directory-link=\"South-Bay-Community-Center\" aria-label=\"View directory entry for South Bay Community Center\"><strong>South Bay Community Center</strong></a></li>\n<li>Hosts “Coastal Family Resource Center”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Los Osos Cares Resource Center"
+    ]
+  },
+  "Lucia-Mar-Adult-Education": {
+    "title": "Lucia Mar Adult Education",
+    "content": "<h2><span>Lucia Mar Adult Education</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://adulted.luciamarschools.org/\" data-external-link=\"true\">adulted.luciamarschools.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Name</th>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Name\">Main office</td>\n<td data-label=\"Location\">602 Orchard St., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.115292\" data-lon=\"-120.576271\" data-zoom=\"17\" data-label=\"Lucia Mar Adult Education\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-3222\" aria-label=\"Call 805-474-3222\">805-474-3222</a></td>\n</tr>\n<tr>\n<td data-label=\"Name\">Nipomo Learning Center</td>\n<td data-label=\"Location\">190 E. Price St. (E &amp; F), Nipomo <a href=\"#\" class=\"map-link\" data-lat=\"35.042848\" data-lon=\"-120.471869\" data-zoom=\"17\" data-label=\"Lucia Mar Adult Education\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-3000;ext=7602\" aria-label=\"Call 805-474-3000 x7602\">805-474-3000 x7602</a></td>\n</tr>\n<tr>\n<td data-label=\"Name\">Oceano Community Center</td>\n<td data-label=\"Location\">1575 17th St. (30, 33, &amp; 34), Oceano <a href=\"#\" class=\"map-link\" data-lat=\"35.101995\" data-lon=\"-120.612296\" data-zoom=\"17\" data-label=\"Lucia Mar Adult Education\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-3000;ext=7601\" aria-label=\"Call 805-474-3000 x7601\">805-474-3000 x7601</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:brienne.phillips@lmusd.org\" aria-label=\"Email brienne.phillips@lmusd.org\">brienne.phillips@lmusd.org</a> </li>\n<li>Notes: Partners with <a href=\"#\" data-directory-link=\"Cuesta-College\" aria-label=\"View directory entry for Cuesta College\"><strong>Cuesta College</strong></a> for ESL classes</li>\n</ul>\n",
+    "aliases": [
+      "Lucia Mar Adult Education"
+    ]
+  },
+  "Lumina-Alliance": {
+    "title": "Lumina Alliance",
+    "content": "<h2><span>Lumina Alliance</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://luminaalliance.org/\" data-external-link=\"true\">luminaalliance.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>555 S. 13th St. #B, Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.116240\" data-lon=\"-120.615517\" data-zoom=\"17\" data-label=\"Lumina Alliance\">Map</a></li>\n<li>102 S. Vine St. #C, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.614368\" data-lon=\"-120.692636\" data-zoom=\"17\" data-label=\"Lumina Alliance\">Map</a> </li>\n<li>51 Zaca Ln. #150, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.251244\" data-lon=\"-120.673442\" data-zoom=\"17\" data-label=\"Lumina Alliance\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-545-8888\" aria-label=\"Call 805-545-8888\">805-545-8888</a> (24-hour free &amp; confidential crisis line) </li>\n<li><a href=\"tel:+1-805-781-6400\" aria-label=\"Call 805-781-6400\">805-781-6400</a> (Business line) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:Contact@LuminaAlliance.org\" aria-label=\"Email Contact@LuminaAlliance.org\">Contact@LuminaAlliance.org</a> </li>\n<li>Note: RISE merged with Stand Strong in 2021 to form Lumina Alliance</li>\n</ul>\n",
+    "aliases": [
+      "Lumina Alliance"
+    ]
+  },
+  "Lumina-Thrift": {
+    "title": "Lumina Thrift",
+    "content": "<h2><span>Lumina Thrift</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://luminaalliance.org/thriftstore/\" data-external-link=\"true\">luminaalliance.org/thriftstore</a></li>\n<li><strong>Location:</strong> 545 Higuera St., SLO <a class=\"map-link\" data-lat=\"35.277002\" data-lon=\"-120.667160\" data-zoom=\"17\" data-label=\"Lumina Thrift\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-592-3596\" aria-label=\"Call 805-592-3596\">805-592-3596</a> </li>\n<li><strong>Hours:</strong> M–Sa 10am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "Lumina Thrift"
+    ]
+  },
+  "Marijuana-Anonymous": {
+    "title": "Marijuana Anonymous",
+    "content": "<h2><span>Marijuana Anonymous</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://marijuana-anonymous.org/\" data-external-link=\"true\">marijuana-anonymous.org</a></li>\n<li><strong>Location:</strong> 2939 Augusta St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.267094\" data-lon=\"-120.641232\" data-zoom=\"17\" data-label=\"Marijuana Anonymous\">Map</a>  (<a href=\"#\" data-directory-link=\"Middlehouse\" aria-label=\"View directory entry for Middlehouse\"><strong>Middlehouse</strong></a>)</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-766-6779\" aria-label=\"Call 800-766-6779\">800-766-6779</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:slo.marijuana.anonymous@gmail.com\" aria-label=\"Email slo.marijuana.anonymous@gmail.com\">slo.marijuana.anonymous@gmail.com</a> </li>\n<li><strong>Hours:</strong> 6:30–7:30pm on Mondays </li>\n</ul>\n",
+    "aliases": [
+      "Marijuana Anonymous"
+    ]
+  },
+  "Marthas-Place-Childrens-Center": {
+    "title": "Martha’s Place Children’s Center",
+    "content": "<h2><span>Martha’s Place Children’s Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/martha%E2%80%99s-place-children-s-center\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/marthas-place-childrens-center</a></li>\n<li><strong>Location:</strong> 2925 McMillan Ave. #108, SLO <a class=\"map-link\" data-lat=\"35.263382\" data-lon=\"-120.648288\" data-zoom=\"17\" data-label=\"Martha’s Place Children’s Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-4948\" aria-label=\"Call 805-781-4948\">805-781-4948</a> </li>\n<li><strong>Hours:</strong> M–F 8am–5pm </li>\n<li>Notes: For children ages 0–5 with behavioral or mental health issues</li>\n</ul>\n",
+    "aliases": [
+      "Martha’s Place Children’s Center"
+    ]
+  },
+  "Meals-that-Connect": {
+    "title": "Meals that Connect",
+    "content": "<h2><span>Meals that Connect</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://mealsthatconnect.org/en/\" data-external-link=\"true\">mealsthatconnect.org</a></li>\n<li><strong>Location:</strong> 265 South St. #B, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.269139\" data-lon=\"-120.666800\" data-zoom=\"17\" data-label=\"Meals that Connect\">Map</a> (office) <ul>\n<li>Serves meals in Atascadero, Templeton, Cambria, San Simeon, Los Osos, Morro Bay, Cayucos, Nipomo, Oceano, Paso Robles, Santa Margarita, and SLO</li>\n<li>Also does some home delivery </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-3312\" aria-label=\"Call 805-541-3312\">805-541-3312</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:officeadmin@mealsthatconnect.org\" aria-label=\"Email officeadmin@mealsthatconnect.org\">officeadmin@mealsthatconnect.org</a> </li>\n<li><strong>Hours:</strong> (varies by site)</li>\n<li><strong>How to access:</strong> open to people aged 60 and above; complete an application </li>\n</ul>\n",
+    "aliases": [
+      "Meals that Connect"
+    ]
+  },
+  "Medi-Cal": {
+    "title": "Medi-Cal",
+    "content": "<h2><span>Medi-Cal</span></h2>\n<blockquote>\n<p><em>See also: <a href=\"#\" data-directory-link=\"CenCal\" aria-label=\"View directory entry for CenCal\"><strong>CenCal</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Locations:</strong> <em>See <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a></em></li>\n<li>Medi-Cal Dental:<ul>\n<li><strong>Website:</strong> <a href=\"http://www.denti-cal.ca.gov/\" data-external-link=\"true\">www.denti-cal.ca.gov</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-322-6384\" aria-label=\"Call 800-322-6384\">800-322-6384</a> (TTY: <a href=\"tel:+1-800-735-2922\" aria-label=\"Call 800-735-2922\">800-735-2922</a>)</li>\n</ul>\n</li>\n<li>Medi-Cal Rx:<ul>\n<li><strong>Website:</strong> <a href=\"https://medi-calrx.dhcs.ca.gov/\" data-external-link=\"true\">medi-calrx.dhcs.ca.gov</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-977-2273\" aria-label=\"Call 800-977-2273\">800-977-2273</a></li>\n</ul>\n</li>\n<li>Medi-Cal Shuttle: <em>See <a href=\"#\" data-directory-link=\"Ride-On-Transportation\" aria-label=\"View directory entry for Ride-On Transportation\"><strong>Ride-On Transportation</strong></a></em></li>\n<li>Notes:<ul>\n<li><a href=\"#\" data-directory-link=\"CenCal\" aria-label=\"View directory entry for CenCal Health\"><strong>CenCal Health</strong></a> is the local Medi-Cal administrator </li>\n<li>Apply at <a href=\"https://www.coveredca.com/\" data-external-link=\"true\">www.coveredca.com</a> or <a href=\"https://benefitscal.com/\" data-external-link=\"true\">BenefitsCal.com</a> or in person at local DSS offices </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Medi-Cal"
+    ]
+  },
+  "Medically-Fragile-Homeless-Program": {
+    "title": "Medically Fragile Homeless Program",
+    "content": "<h2><span>Medically Fragile Homeless Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://cfsslo.org/#mfh\" data-external-link=\"true\">cfsslo.org/#mfh</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:carrie@linkslo.org\" aria-label=\"Email carrie@linkslo.org\">carrie@linkslo.org</a> </li>\n<li>Notes:<ul>\n<li>Access through <a href=\"#\" data-directory-link=\"SLO-County-Department-of-Social-Services\" aria-label=\"View directory entry for SLO County Department of Social Services\"><strong>SLO County Department of Social Services</strong></a> or <a href=\"#\" data-directory-link=\"Housing-Support-Program\" aria-label=\"View directory entry for Housing Support Program (HSP)\"><strong>Housing Support Program (HSP)</strong></a> or <a href=\"#\" data-directory-link=\"Adult-Protective-Services\" aria-label=\"View directory entry for Adult Protective Services\"><strong>Adult Protective Services</strong></a> or <a href=\"#\" data-directory-link=\"CalWORKs\" aria-label=\"View directory entry for CalWORKs\"><strong>CalWORKs</strong></a></li>\n<li>Operated by <a href=\"#\" data-directory-link=\"CFS\" aria-label=\"View directory entry for Center for Family Strengthening (CFS)\"><strong>Center for Family Strengthening (CFS)</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Medically Fragile Homeless Program"
+    ]
+  },
+  "MISP": {
+    "title": "Medically Indigent Services Program (MISP)",
+    "content": "<h2><span>Medically Indigent Services Program (MISP)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/medically-indigent-services-program-%28misp%29\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/medically-indigent-services-program-(misp)</a></li>\n<li><strong>Location:</strong> 2180 Johnson Ave., SLO <a class=\"map-link\" data-lat=\"35.274671\" data-lon=\"-120.646514\" data-zoom=\"17\" data-label=\"Medically Indigent Services Program\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5500\" aria-label=\"Call 805-781-5500\">805-781-5500</a> </li>\n<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm) </li>\n</ul>\n",
+    "aliases": [
+      "Medically Indigent Services Program (MISP)"
+    ]
+  },
+  "MedStop": {
+    "title": "MedStop",
+    "content": "<h2><span>MedStop</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://medstopurgentcare.com/\" data-external-link=\"true\">medstopurgentcare.com</a></li>\n<li><strong>Location:</strong> 283 Madonna Rd. Suite B (Madonna Plaza), SLO </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-549-8880\" aria-label=\"Call 805-549-8880\">805-549-8880</a> </li>\n<li><strong>Hours:</strong> M–F 8am–7pm, Sa.–Su. 8am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "MedStop"
+    ]
+  },
+  "MHET": {
+    "title": "Mental Health Evaluation Team",
+    "content": "<h2><span>Mental Health Evaluation Team</span></h2>\n<ul>\n<li><strong>Website:</strong><ul>\n<li>MHET: <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-%28mhet%29\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-(mhet)</a></li>\n<li>Mobile Crisis Team: <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-%28mct%29\" data-external-link=\"true\">https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-(mct)</a></li>\n</ul>\n</li>\n<li><strong>Location:</strong> county-wide</li>\n<li><strong>Phone:</strong><ul>\n<li>MHET: <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> </li>\n<li>Mobile Crisis Team: <a href=\"tel:+1-800-783-0607\" aria-label=\"Call 800-783-0607\">800-783-0607</a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Mental Health Evaluation Team"
+    ]
+  },
+  "Mobile-Crisis-Team": {
+    "title": "Mobile Crisis Team",
+    "content": "<h2><span>Mobile Crisis Team</span></h2>\n<ul>\n<li><strong>Website:</strong><ul>\n<li>MHET: <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-%28mhet%29\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-(mhet)</a></li>\n<li>Mobile Crisis Team: <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-%28mct%29\" data-external-link=\"true\">https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-(mct)</a></li>\n</ul>\n</li>\n<li><strong>Location:</strong> county-wide</li>\n<li><strong>Phone:</strong><ul>\n<li>MHET: <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> </li>\n<li>Mobile Crisis Team: <a href=\"tel:+1-800-783-0607\" aria-label=\"Call 800-783-0607\">800-783-0607</a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Mental Health Evaluation Team"
+    ]
+  },
+  "Middlehouse": {
+    "title": "Middlehouse",
+    "content": "<h2><span>Middlehouse</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://middlehouse.org/\" data-external-link=\"true\">middlehouse.org</a></li>\n<li><strong>Location:</strong> 2939 Augusta St., SLO <a class=\"map-link\" data-lat=\"35.267094\" data-lon=\"-120.641232\" data-zoom=\"17\" data-label=\"Middlehouse\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-8328\" aria-label=\"Call 805-544-8328\">805-544-8328</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:middlehouse93401@gmail.com\" aria-label=\"Email middlehouse93401@gmail.com\">middlehouse93401@gmail.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Middlehouse"
+    ]
+  },
+  "Mission-Thrift": {
+    "title": "Mission Thrift",
+    "content": "<h2><span>Mission Thrift</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.omsslo.org/apps/pages/index.jsp?uREC_ID=3643070&amp;type=d&amp;pREC_ID=2413322\" data-external-link=\"true\">omsslo.org/apps/pages/index.jsp?uREC_ID=3643070&amp;type=d&amp;pREC_ID=2413322</a></li>\n<li><strong>Location:</strong> 2958 S. Higuera St., SLO <a class=\"map-link\" data-lat=\"35.259753\" data-lon=\"-120.668913\" data-zoom=\"17\" data-label=\"Mission Thrift\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-548-2660\" aria-label=\"Call 805-548-2660\">805-548-2660</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:Morradre@omsslo.com\" aria-label=\"Email Morradre@omsslo.com\">Morradre@omsslo.com</a> </li>\n<li><strong>Hours:</strong> M–Sa 12pm–5pm </li>\n</ul>\n",
+    "aliases": [
+      "Mission Thrift"
+    ]
+  },
+  "Mobile-Crisis-Unit": {
+    "title": "Mobile Crisis Unit",
+    "content": "<h2><span>Mobile Crisis Unit</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocity.org/government/department-directory/fire-department/mobile-crisis-unit-mcu\" data-external-link=\"true\">slocity.org/government/department-directory/fire-department/mobile-crisis-unit-mcu</a></li>\n<li><strong>Location:</strong> SLO city only</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-550-7270\" aria-label=\"Call 805-550-7270\">805-550-7270</a> </li>\n<li><a href=\"tel:+1-805-781-7312\" aria-label=\"Call 805-781-7312\">805-781-7312</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–Th 8am–5:30pm; every other Friday 8am–5:30pm</li>\n</ul>\n",
+    "aliases": [
+      "Mobile Crisis Unit"
+    ]
+  },
+  "Morro-Bay-Lions-Foundation": {
+    "title": "Morro Bay Lions Foundation",
+    "content": "<h2><span>Morro Bay Lions Foundation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://morrobaylions.org/2025/07/24/community-dinners-at-vets-hall/\" data-external-link=\"true\">morrobaylions.org/2025/07/24/community-dinners-at-vets-hall</a></li>\n<li><strong>Location:</strong> Morro Bay Vets Memorial Building, 209 Surf St., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.370461\" data-lon=\"-120.853497\" data-zoom=\"17\" data-label=\"Morro Bay Lions Foundation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-772-4421\" aria-label=\"Call 805-772-4421\">805-772-4421</a></li>\n<li><strong>Hours:</strong><ul>\n<li>Mondays: 4:30pm (doors open for pantry shopping, free clothes, towels, toiletries) </li>\n<li>Dinner service: 5:30–6:30pm </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Morro Bay Lions Foundation"
+    ]
+  },
+  "Morro-Bay-Senior-Center": {
+    "title": "Morro Bay Senior Citizens",
+    "content": "<h2><span>Morro Bay Senior Citizens</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://morrobayseniors.org/\" data-external-link=\"true\">morrobayseniors.org</a></li>\n<li><strong>Location:</strong> 1001 Kennedy Way, Morro Bay <a class=\"map-link\" data-lat=\"35.368668\" data-lon=\"-120.845781\" data-zoom=\"17\" data-label=\"Morro Bay Senior Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-772-4421\" aria-label=\"Call 805-772-4421\">805-772-4421</a> </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:info@morrobayseniors.org\" aria-label=\"Email info@morrobayseniors.org\">info@morrobayseniors.org</a> </li>\n<li><a href=\"mailto:mbactivesrs@gmail.com\" aria-label=\"Email mbactivesrs@gmail.com\">mbactivesrs@gmail.com</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 9am–4pm </li>\n<li>Membership: $25/year individual, $40/year household (90+ free); open to people 55+ </li>\n<li>Notes:<ul>\n<li>Hosts <a href=\"#\" data-directory-link=\"HiCAP\" aria-label=\"View directory entry for HiCAP\"><strong>HiCAP</strong></a></li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Senior-Legal-Services-Project\" aria-label=\"View directory entry for Senior Legal Services Project\"><strong>Senior Legal Services Project</strong></a> on the first Friday of the month</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Morro Bay Senior Citizens"
+    ]
+  },
+  "Morro-Bay-Parks-and-Recreation": {
+    "title": "Morro Bay Parks & Recreation",
+    "content": "<h2><span>Morro Bay Parks &amp; Recreation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.morrobayca.gov/292/Recreation-Services\" data-external-link=\"true\">morrobayca.gov/292/Recreation-Services</a></li>\n<li><strong>Location:</strong> Morro Bay Community Center, 1001 Kennedy Way, Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.368668\" data-lon=\"-120.845781\" data-zoom=\"17\" data-label=\"Morro Bay Parks and Recreation\">Map</a> { Source: <a href=\"https://www.morrobayca.gov/292/Recreation-Services\" data-external-link=\"true\">https://www.morrobayca.gov/292/Recreation-Services</a> }</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-772-6278\" aria-label=\"Call 805-772-6278\">805-772-6278</a> { Source: <a href=\"https://www.morrobayca.gov/292/Recreation-Services\" data-external-link=\"true\">https://www.morrobayca.gov/292/Recreation-Services</a> }</li>\n<li><strong>Email:</strong> <a href=\"mailto:kcarmichael@morrobayca.gov\" aria-label=\"Email kcarmichael@morrobayca.gov\">kcarmichael@morrobayca.gov</a> { Source: <a href=\"https://www.morrobayca.gov/292/Recreation-Services\" data-external-link=\"true\">https://www.morrobayca.gov/292/Recreation-Services</a> }</li>\n<li><strong>Hours:</strong> M–F 8:30am–5pm (registration)\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Morro Bay Parks & Recreation"
+    ]
+  },
+  "NAMI-SLO-County": {
+    "title": "NAMI SLO County",
+    "content": "<h2><span>NAMI SLO County</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.namislo.org/\" data-external-link=\"true\">namislo.org</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 3158, San Luis Obispo, CA 93403 { Source: <a href=\"https://www.namislo.org/\" data-external-link=\"true\">https://www.namislo.org/</a> }</li>\n<li><strong>Phone</strong><ul>\n<li>immediate crisis support: NAMI national helpline <a href=\"tel:+1-800-950-6264\" aria-label=\"Call 800-950-6264\">800-950-6264</a> (M–F 7am–3pm PT), or call/text 988</li>\n<li>NAMI SLO County: <a href=\"tel:+1-805-434-7220\" aria-label=\"Call 805-434-7220\">805-434-7220</a> { Source: <a href=\"https://www.namislo.org/\" data-external-link=\"true\">https://www.namislo.org/</a> }</li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:namisanluisobispo@gmail.com\" aria-label=\"Email namisanluisobispo@gmail.com\">namisanluisobispo@gmail.com</a> { Source: <a href=\"https://www.namislo.org/\" data-external-link=\"true\">https://www.namislo.org/</a> }<ul>\n<li>support groups: <a href=\"mailto:sgroups.nami.sloco@gmail.com\" aria-label=\"Email sgroups.nami.sloco@gmail.com\">sgroups.nami.sloco@gmail.com</a> { Source: <a href=\"https://www.namislo.org/nami-support-groups\" data-external-link=\"true\">https://www.namislo.org/nami-support-groups</a> }\n--&gt;</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "NAMI SLO County"
+    ]
+  },
+  "Narcotics-Anonymous": {
+    "title": "Narcotics Anonymous",
+    "content": "<h2><span>Narcotics Anonymous</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://centralcoastna.org/\" data-external-link=\"true\">centralcoastna.org</a></li>\n<li><strong>Locations:</strong> <a href=\"https://www.centralcoastna.org/directory/\" data-external-link=\"true\">various locations</a> in Arroyo Grande, Atascadero, Cambria, Guadalupe, Lompoc, Orcutt, Paso Robles, San Luis Obispo, and Santa Maria <ul>\n<li>Also has some virtual (Zoom) meetings</li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-549-7730\" aria-label=\"Call 805-549-7730\">805-549-7730</a> </li>\n</ul>\n",
+    "aliases": [
+      "Narcotics Anonymous"
+    ]
+  },
+  "NCI-Affiliates-Thrift": {
+    "title": "NCI Affiliates Thrift",
+    "content": "<h2><span>NCI Affiliates Thrift</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://nciaffiliates.org/thrift-stores/\" data-external-link=\"true\">nciaffiliates.org/thrift-stores</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">2070 El Camino Real, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.512708\" data-lon=\"-120.698150\" data-zoom=\"17\" data-label=\"NCI Affiliates Thrift\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-462-0500\" aria-label=\"Call 805-462-0500\">805-462-0500</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">183 Niblick Rd., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.616768\" data-lon=\"-120.682216\" data-zoom=\"17\" data-label=\"NCI Affiliates Thrift\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-296-3153\" aria-label=\"Call 805-296-3153\">805-296-3153</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Hours:</strong> Daily 10am–6pm </li>\n<li>Notes: Operated by NCI Affiliates; training location for vocational services</li>\n</ul>\n",
+    "aliases": [
+      "NCI Affiliates Thrift"
+    ]
+  },
+  "NeedyMeds": {
+    "title": "NeedyMeds",
+    "content": "<h2><span>NeedyMeds</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://needymeds.org/\" data-external-link=\"true\">needymeds.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-503-6897\" aria-label=\"Call 800-503-6897\">800-503-6897</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@needymeds.org\" aria-label=\"Email info@needymeds.org\">info@needymeds.org</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5pm Eastern Time </li>\n</ul>\n",
+    "aliases": [
+      "NeedyMeds"
+    ]
+  },
+  "New-Life-U-Pick-Pantry": {
+    "title": "New Life U-Pick Pantry",
+    "content": "<h2><span>New Life U-Pick Pantry</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.newlifepismo.com/pantry/\" data-external-link=\"true\">newlifepismo.com/pantry</a></li>\n<li><strong>Location:</strong> 941 N. Oak Park Blvd., Pismo Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.136159\" data-lon=\"-120.606430\" data-zoom=\"17\" data-label=\"New Life U-Pick Pantry\">Map</a> (New Life Community Center) </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-489-3891\" aria-label=\"Call 805-489-3891\">805-489-3891</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:pantry@newlifepismo.com\" aria-label=\"Email pantry@newlifepismo.com\">pantry@newlifepismo.com</a> </li>\n<li><strong>Hours:</strong> Tu 6–7:30pm, W 10am–noon, Th 1:30–3:30pm </li>\n</ul>\n",
+    "aliases": [
+      "New Life U-Pick Pantry"
+    ]
+  },
+  "Nipomo-Community-Presbyterian": {
+    "title": "Nipomo Community Presbyterian",
+    "content": "<h2><span>Nipomo Community Presbyterian</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.nipomopresbyterian.org\" data-external-link=\"true\">nipomopresbyterian.org</a></li>\n<li><strong>Location:</strong> 1235 N. Thompson Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.070495\" data-lon=\"-120.512163\" data-zoom=\"17\" data-label=\"Nipomo Community Presbyterian\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-473-8059\" aria-label=\"Call 805-473-8059\">805-473-8059</a></li>\n<li>Hours (food pantry): F 12:45–1:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Nipomo Community Presbyterian"
+    ]
+  },
+  "Nipomo-Food-Basket": {
+    "title": "Nipomo Food Basket",
+    "content": "<h2><span>Nipomo Food Basket</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.nipomofoodbasket.com/\" data-external-link=\"true\">nipomofoodbasket.com</a></li>\n<li><strong>Location:</strong> 197 W. Tefft St., Nipomo <a class=\"map-link\" data-lat=\"35.042387\" data-lon=\"-120.476916\" data-zoom=\"17\" data-label=\"Nipomo Food Basket\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-619-7681\" aria-label=\"Call 805-619-7681\">805-619-7681</a> </li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:helpu@nipomofoodbasket.org\" aria-label=\"Email helpu@nipomofoodbasket.org\">helpu@nipomofoodbasket.org</a> </li>\n<li><a href=\"mailto:info@nipomofoodbasket.com\" aria-label=\"Email info@nipomofoodbasket.com\">info@nipomofoodbasket.com</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M/Tu/Th/F 10am–1pm </li>\n</ul>\n",
+    "aliases": [
+      "Nipomo Food Basket"
+    ]
+  },
+  "Nipomo-Senior-Center": {
+    "title": "Nipomo Senior Center",
+    "content": "<h2><span>Nipomo Senior Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://nipomoseniorcenter.org/\" data-external-link=\"true\">nipomoseniorcenter.org</a></li>\n<li><strong>Location:</strong> 200 E. Dana St., Nipomo <a class=\"map-link\" data-lat=\"35.044026\" data-lon=\"-120.471889\" data-zoom=\"17\" data-label=\"Nipomo Senior Center\">Map</a> (entrance on Beechnut St.)</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-929-1615\" aria-label=\"Call 805-929-1615\">805-929-1615</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:contact@nipomoseniorcenter\" aria-label=\"Email contact@nipomoseniorcenter\">contact@nipomoseniorcenter</a> </li>\n<li><strong>Hours:</strong> M–F 9am–1pm </li>\n<li>Note: Hosts <a href=\"#\" data-directory-link=\"Meals-that-Connect\" aria-label=\"View directory entry for Meals that Connect\"><strong>Meals that Connect</strong></a> lunches </li>\n</ul>\n",
+    "aliases": [
+      "Nipomo Senior Center"
+    ]
+  },
+  "North-County-Family-Resource-Center": {
+    "title": "North County Family Resource Center",
+    "content": "<h2><span>North County Family Resource Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/north-county-family-resource-center/\" data-external-link=\"true\">capslo.org/north-county-family-resource-center</a></li>\n<li><strong>Location:</strong> 704 Spring St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.621655\" data-lon=\"-120.690685\" data-zoom=\"17\" data-label=\"Family Resource Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-440-1878\" aria-label=\"Call 805-440-1878\">805-440-1878</a> </li>\n<li>Notes:<ul>\n<li>See also <a href=\"#\" data-directory-link=\"Link-Family-Resource-Center\" aria-label=\"View directory entry for Link Family Resource Center\"><strong>Link Family Resource Center</strong></a></li>\n<li>See also <a href=\"#\" data-directory-link=\"SAFE-Family-Resource-Centers\" aria-label=\"View directory entry for SAFE Family Resource Centers\"><strong>SAFE Family Resource Centers</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "North County Family Resource Center"
+    ]
+  },
+  "North-County-NeighborAid": {
+    "title": "North County NeighborAid",
+    "content": "<h2><span>North County NeighborAid</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://cfsslo.org/north-county-neighboraid/\" data-external-link=\"true\">cfsslo.org/north-county-neighboraid</a></li>\n<li><strong>Location:</strong> 1428 Phillips Lane #203, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.288103\" data-lon=\"-120.657544\" data-zoom=\"17\" data-label=\"North County NeighborAid\">Map</a> </li>\n<li><strong>Mailing address:</strong> 7343 El Camino Real #346, Atascadero </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-5404\" aria-label=\"Call 805-466-5404\">805-466-5404</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@NoCoNeighborAid.org\" aria-label=\"Email info@NoCoNeighborAid.org\">info@NoCoNeighborAid.org</a> </li>\n<li><strong>Hours:</strong> By appointment</li>\n<li><strong>How to access:</strong> Make a request by using their <a href=\"https://cfsslo.org/north-county-neighboraid/\" data-external-link=\"true\">web form</a></li>\n<li>Notes: Grassroots initiative managed by <a href=\"#\" data-directory-link=\"CFS\" aria-label=\"View directory entry for Center for Family Strengthening\"><strong>Center for Family Strengthening</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "North County NeighborAid"
+    ]
+  },
+  "North-County-Paws-Cause": {
+    "title": "North County Paws Cause",
+    "content": "<h2><span>North County Paws Cause</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.northcounty-pawscause.org/\" data-external-link=\"true\">northcounty-pawscause.org</a></li>\n<li><strong>Location:</strong> Paso Robles </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-674-8664\" aria-label=\"Call 805-674-8664\">805-674-8664</a> / <a href=\"sms:+1-805-674-8664\">805-674-8664</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:northcountypawscause@gmail.com\" aria-label=\"Email northcountypawscause@gmail.com\">northcountypawscause@gmail.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "North County Paws Cause"
+    ]
+  },
+  "North-County-Care": {
+    "title": "North County Care Minor Emergency Services",
+    "content": "<h2><span>North County Care Minor Emergency Services</span></h2>\n\n<ul>\n<li><strong>Location:</strong> 636 Spring St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.621268\" data-lon=\"-120.690517\" data-zoom=\"17\" data-label=\"North County Care Minor Emergency Services\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-238-2422\" aria-label=\"Call 805-238-2422\">805-238-2422</a> </li>\n<li><strong>Hours:</strong> M–F 10am–5pm </li>\n</ul>\n\n",
+    "aliases": [
+      "North County Care Minor Emergency Services"
+    ]
+  },
+  "Oceano-Campground": {
+    "title": "Oceano Campground",
+    "content": "<h2><span>Oceano Campground</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocountyparks.com/camp/oceano/\" data-external-link=\"true\">https://slocountyparks.com/camp/oceano/</a></li>\n<li><strong>Location:</strong> 494 Air Park Dr., Oceano <a class=\"map-link\" data-lat=\"35.104656\" data-lon=\"-120.625624\" data-zoom=\"17\" data-label=\"Oceano Campground\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-4900\" aria-label=\"Call 805-781-4900\">805-781-4900</a>  M–Th 8am–4:30pm; F–Su 8am–6pm, <a href=\"tel:+1-805-781-5930\" aria-label=\"Call 805-781-5930\">805-781-5930</a> (reservations)</li>\n</ul>\n",
+    "aliases": [
+      "Oceano Campground"
+    ]
+  },
+  "Open-Arms-Pantry": {
+    "title": "Open Arms Pantry at Rock Harbor",
+    "content": "<h2><span>Open Arms Pantry at Rock Harbor</span></h2>\n<ul>\n<li><strong>Location:</strong> Rock Harbor Christian Fellowship, 1475 Quintana Rd., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.363751\" data-lon=\"-120.824600\" data-zoom=\"17\" data-label=\"Open Arms Pantry at Rock Harbor\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-799-7031\" aria-label=\"Call 805-799-7031\">805-799-7031</a> </li>\n<li><strong>Hours:</strong> Sa 9:30–10:30am; also available throughout the week on a walk-in basis </li>\n</ul>\n",
+    "aliases": [
+      "Open Arms Pantry at Rock Harbor"
+    ]
+  },
+  "Outreach-and-Engagement-Services": {
+    "title": "Outreach and Engagement Services",
+    "content": "<h2><span>Outreach and Engagement Services</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)\"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Location:</strong> 1320 Nipomo St., SLO <a class=\"map-link\" data-lat=\"35.276474\" data-lon=\"-120.663915\" data-zoom=\"17\" data-label=\"Outreach and Engagement Services\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-4004\" aria-label=\"Call 805-544-4004\">805-544-4004</a></li>\n<li><strong>Hours:</strong> M–F 10am–3pm</li>\n<li><strong>How to access:</strong> Walk-ins OK</li>\n</ul>\n",
+    "aliases": [
+      "Outreach and Engagement Services",
+      "**Community Action Partnership San Luis Obispo (CAPSLO)**"
+    ]
+  },
+  "Parent-Connection-of-SLO-County": {
+    "title": "Parent Connection of SLO County",
+    "content": "<h2><span>Parent Connection of SLO County</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://sloparents.org/\" data-external-link=\"true\">sloparents.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-3700\" aria-label=\"Call 805-543-3700\">805-543-3700</a>  (Español: <a href=\"tel:+1-805-540-1223\" aria-label=\"Call 805-540-1223\">805-540-1223</a>)</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@sloparents.org\" aria-label=\"Email info@sloparents.org\">info@sloparents.org</a> </li>\n<li>Note: operated by <a href=\"#\" data-directory-link=\"CFS\" aria-label=\"View directory entry for Center for Family Strengthening (CFS)\"><strong>Center for Family Strengthening (CFS)</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Parent Connection of SLO County"
+    ]
+  },
+  "Parents-Helping-Parents": {
+    "title": "Parents Helping Parents of SLO County",
+    "content": "<h2><span>Parents Helping Parents of SLO County</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.phpslo.org/\" data-external-link=\"true\">phpslo.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">7305 Morro Rd. #104a, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.478644\" data-lon=\"-120.666592\" data-zoom=\"17\" data-label=\"Parents Helping Parents\">Map</a></td>\n<td data-label=\"Hours\">W 10am–1pm (by appointment)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1146 Farmhouse Lane, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.239987\" data-lon=\"-120.634147\" data-zoom=\"17\" data-label=\"Parents Helping Parents\">Map</a></td>\n<td data-label=\"Hours\">M–F 8am–4:30pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-3277\" aria-label=\"Call 805-543-3277\">805-543-3277</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:php@ucp-slo.org\" aria-label=\"Email php@ucp-slo.org\">php@ucp-slo.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Parents Helping Parents of SLO County"
+    ]
+  },
+  "Paso-Cares": {
+    "title": "Paso Cares",
+    "content": "<h2><span>Paso Cares</span></h2>\n<p>{ Source: <a href=\"https://www.findhelp.org/paso-cares%2D%2Dpaso-robles-ca%2D%2Dfeeding-the-homeless/5153804446597120\" data-external-link=\"true\">https://www.findhelp.org/paso-cares%2D%2Dpaso-robles-ca%2D%2Dfeeding-the-homeless/5153804446597120</a> }</p>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.pasocares.org/\" data-external-link=\"true\">pasocares.org</a></li>\n</ul>\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">Riverside &amp; 24th St. parking lot, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.637837\" data-lon=\"-120.688419\" data-zoom=\"16\" data-label=\"Paso Cares\">Map</a></td>\n<td data-label=\"Hours\">M–F 5–6pm, Su 4–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1335 Oak St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.628242\" data-lon=\"-120.693108\" data-zoom=\"17\" data-label=\"Paso Cares\">Map</a></td>\n<td data-label=\"Hours\">Sa. Noon–1pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-591-0078\" aria-label=\"Call 805-591-0078\">805-591-0078</a> { Source: <a href=\"https://www.pasocares.org/\" data-external-link=\"true\">https://www.pasocares.org/</a> and other pages on that site }\n{ <a href=\"tel:+1-805-571-0078\" aria-label=\"Call 805-571-0078\">805-571-0078</a> Source: <a href=\"https://www.pasocares.org/contact\" data-external-link=\"true\">https://www.pasocares.org/contact</a> only (typo?) }</li>\n<li><strong>Email:</strong> <a href=\"mailto:pasocares@gmail.com\" aria-label=\"Email pasocares@gmail.com\">pasocares@gmail.com</a> { Source: <a href=\"https://www.pasocares.org/\" data-external-link=\"true\">https://www.pasocares.org/</a> }\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Paso Cares"
+    ]
+  },
+  "Paso-Robles-Housing-Authority": {
+    "title": "Paso Robles Housing Authority",
+    "content": "<h2><span>Paso Robles Housing Authority</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://pasoroblesha.org/\" data-external-link=\"true\">pasoroblesha.org</a></li>\n<li><strong>Location:</strong> 901 30th Street, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.645727\" data-lon=\"-120.690330\" data-zoom=\"17\" data-label=\"Paso Robles Housing Authority\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-238-4015\" aria-label=\"Call 805-238-4015\">805-238-4015</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@pasoroblesha.org\" aria-label=\"Email info@pasoroblesha.org\">info@pasoroblesha.org</a> </li>\n<li><strong>Hours:</strong> M–F 9am–4:30pm (closed Noon–1pm) </li>\n<li><strong>How to access:</strong> Call or email</li>\n<li>Notes:<ul>\n<li>Operates affordable housing properties including Oak Park 1–4 and Sunrise Villas </li>\n<li>Offers community services including “Youth Works” program </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Paso Robles Housing Authority"
+    ]
+  },
+  "Paso-Robles-Senior-Center": {
+    "title": "Paso Robles Senior Center",
+    "content": "<h2><span>Paso Robles Senior Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.prcity.com/293/Senior-Services\" data-external-link=\"true\">prcity.com/293/Senior-Services</a></li>\n<li><strong>Location:</strong> 270 Scott St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.608089\" data-lon=\"-120.655487\" data-zoom=\"17\" data-label=\"Paso Robles Senior Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-237-3880\" aria-label=\"Call 805-237-3880\">805-237-3880</a></li>\n<li><strong>Hours:</strong> M–F 8am–5pm <ul>\n<li>Food pantry: Second and fourth Tuesdays of the month at 10am </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>A lunch service site for <a href=\"#\" data-directory-link=\"Meals-that-Connect\" aria-label=\"View directory entry for Meals that Connect\"><strong>Meals that Connect</strong></a> </li>\n<li>A <a href=\"#\" data-directory-link=\"SLO-Food-Bank\" aria-label=\"View directory entry for SLO Food Bank\"><strong>SLO Food Bank</strong></a> pantry &amp; food box distribution site </li>\n<li>Hosts <a href=\"#\" data-directory-link=\"HiCAP\" aria-label=\"View directory entry for HiCAP\"><strong>HiCAP</strong></a> </li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Senior-Legal-Services-Project\" aria-label=\"View directory entry for Senior Legal Services Project\"><strong>Senior Legal Services Project</strong></a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Paso Robles Senior Center"
+    ]
+  },
+  "Paso-Robles-Parks-and-Recreation": {
+    "title": "Paso Robles Recreation Services",
+    "content": "<h2><span>Paso Robles Recreation Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.prcity.com/268/Recreation-Services\" data-external-link=\"true\">prcity.com/268/Recreation-Services</a></li>\n<li><strong>Location:</strong> Centennial Park, 600 Nickerson Dr., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.622846\" data-lon=\"-120.670075\" data-zoom=\"17\" data-label=\"Paso Robles Parks and Recreation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-237-3988\" aria-label=\"Call 805-237-3988\">805-237-3988</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:recservices@prcity.com\" aria-label=\"Email recservices@prcity.com\">recservices@prcity.com</a></li>\n<li><strong>Hours:</strong> M–Th 12pm–5pm (registration desk) </li>\n<li>Note: offers scholarships to cover fees for its recreation activities; apply in person at the registration desk </li>\n</ul>\n",
+    "aliases": [
+      "Paso Robles Recreation Services"
+    ]
+  },
+  "PathPoint": {
+    "title": "PathPoint",
+    "content": "<h2><span>PathPoint</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://pathpoint.org/locations/san-luis-obispo\" data-external-link=\"true\">pathpoint.org/locations/san-luis-obispo</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">775 W. Grand Ave. #C (Grover Beach) <a href=\"#\" class=\"map-link\" data-lat=\"35.121994\" data-lon=\"-120.621843\" data-zoom=\"17\" data-label=\"PathPoint\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-473-9582\" aria-label=\"Call 805-473-9582\">805-473-9582</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">11491 Los Osos Valley Rd. (SLO) <a href=\"#\" class=\"map-link\" data-lat=\"35.258145\" data-lon=\"-120.692577\" data-zoom=\"17\" data-label=\"PathPoint\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-782-8890\" aria-label=\"Call 805-782-8890\">805-782-8890</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:info@pathpoint.org\" aria-label=\"Email info@pathpoint.org\">info@pathpoint.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "PathPoint"
+    ]
+  },
+  "Peoples-Justice-Project": {
+    "title": "People’s Justice Project",
+    "content": "<h2><span>People’s Justice Project</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://peoplesjusticeproject.org/\" data-external-link=\"true\">peoplesjusticeproject.org</a></li>\n<li><strong>Location:</strong> 5708 Hollister Ave., Ste. A #1033, Goleta <a href=\"#\" class=\"map-link\" data-lat=\"34.435859\" data-lon=\"-119.823284\" data-zoom=\"17\" data-label=\"People’s Justice Project\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-242-6691\" aria-label=\"Call 805-242-6691\">805-242-6691</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:legal@peoplesjusticeproject.org\" aria-label=\"Email legal@peoplesjusticeproject.org\">legal@peoplesjusticeproject.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "People’s Justice Project"
+    ]
+  },
+  "Peoples-Kitchen-GB": {
+    "title": "People’s Kitchen (Grover Beach)",
+    "content": "<h2><span>People’s Kitchen (Grover Beach)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.scpk.org/\" data-external-link=\"true\">scpk.org</a></li>\n<li><strong>Location:</strong> 946 Rockaway Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.120091\" data-lon=\"-120.619796\" data-zoom=\"17\" data-label=\"People’s Kitchen (Grover Beach)\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-266-1838\" aria-label=\"Call 805-266-1838\">805-266-1838</a> </li>\n<li><a href=\"tel:+1-805-458-1992\" aria-label=\"Call 805-458-1992\">805-458-1992</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:scpk5cities@gmail.com\" aria-label=\"Email scpk5cities@gmail.com\">scpk5cities@gmail.com</a> </li>\n<li><a href=\"mailto:dnimwold@gmail.com\" aria-label=\"Email dnimwold@gmail.com\">dnimwold@gmail.com</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> Daily 11:30am–1pm </li>\n<li>Notes: Hosted by House of God Church </li>\n</ul>\n",
+    "aliases": [
+      "People’s Kitchen (Grover Beach)"
+    ]
+  },
+  "Peoples-Kitchen-SLO": {
+    "title": "People’s Kitchen (SLO)",
+    "content": "<h2><span>People’s Kitchen (SLO)</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slopeopleskitchen.org/\" data-external-link=\"true\">slopeopleskitchen.org</a></li>\n<li><strong>Location:</strong> 43 Prado Road, SLO <a class=\"map-link\" data-lat=\"35.256164\" data-lon=\"-120.672655\" data-zoom=\"17\" data-label=\"People’s Kitchen\">Map</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:mnparker539@gmail.com\" aria-label=\"Email mnparker539@gmail.com\">mnparker539@gmail.com</a> </li>\n<li><strong>Hours:</strong> Daily at noon </li>\n<li><strong>How to access:</strong> Come during serving time. </li>\n</ul>\n",
+    "aliases": [
+      "People’s Kitchen (SLO)",
+      "**40 Prado Homeless Services Center**"
+    ]
+  },
+  "Peoples-Self-Help-Housing": {
+    "title": "Peoples’ Self-Help Housing",
+    "content": "<h2><span>Peoples’ Self-Help Housing</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.pshhc.org/\" data-external-link=\"true\">pshhc.org</a></li>\n<li><strong>Location:</strong> 1060 Kendall Road, SLO <a class=\"map-link\" data-lat=\"35.236784\" data-lon=\"-120.633302\" data-zoom=\"17\" data-label=\"People’s Self-Help Housing\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-3088\" aria-label=\"Call 805-781-3088\">805-781-3088</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@pshhc.org\" aria-label=\"Email info@pshhc.org\">info@pshhc.org</a> </li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li><strong>How to access:</strong> Submit a rental application at their website, or download it, complete it, and submit it by email, mail, or in person </li>\n<li>Notes:<ul>\n<li>Operates “Broad Street Place”</li>\n<li>Operates “Sea Breeze Apartments”</li>\n<li>Operates “Tiburon Place”</li>\n<li>Operates “Villas at Higuera”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Peoples’ Self-Help Housing"
+    ]
+  },
+  "Pets-of-the-Homeless": {
+    "title": "Pets of the Homeless",
+    "content": "<h2><span>Pets of the Homeless</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://petsofthehomeless.org/\" data-external-link=\"true\">petsofthehomeless.org</a></li>\n<li><strong>Mailing addresses:</strong> 710 W. Washington St., Carson City, NV 89703 </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-775-841-7463\" aria-label=\"Call 775-841-7463\">775-841-7463</a> <ul>\n<li>Emergency Veterinary Care Program: case managers available M–F 9am–3pm for new cases </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@petsofthehomeless.org\" aria-label=\"Email info@petsofthehomeless.org\">info@petsofthehomeless.org</a> </li>\n<li>Notes: Has partner locations in SLO including Animal Care Clinic, Mission Animal Hospital, and Woods Humane Society </li>\n</ul>\n",
+    "aliases": [
+      "Pets of the Homeless"
+    ]
+  },
+  "Pismo-Beach-Athletic-Club": {
+    "title": "Pismo Beach Athletic Club",
+    "content": "<h2><span>Pismo Beach Athletic Club</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://pbac.com/\" data-external-link=\"true\">pbac.com</a></li>\n<li><strong>Location:</strong> 1751 Price St., Pismo Beach <a class=\"map-link\" data-lat=\"35.146449\" data-lon=\"-120.646490\" data-zoom=\"17\" data-label=\"Pismo Beach Athletic Club\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-773-3011\" aria-label=\"Call 805-773-3011\">805-773-3011</a> </li>\n<li><strong>Hours:</strong> M–F 5:30am–9pm, Sa–Su 7am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Pismo Beach Athletic Club"
+    ]
+  },
+  "Pismo-Beach-Recreation-Division": {
+    "title": "Pismo Beach Recreation Division",
+    "content": "<h2><span>Pismo Beach Recreation Division</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.pismobeach.org/73/Recreation\" data-external-link=\"true\">pismobeach.org/73/Recreation</a></li>\n<li><strong>Location:</strong> 760 Mattie Rd., Pismo Beach <a class=\"map-link\" data-lat=\"35.165712\" data-lon=\"-120.688289\" data-zoom=\"17\" data-label=\"Pismo Beach Recreation Division\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-773-7063\" aria-label=\"Call 805-773-7063\">805-773-7063</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:recreation@pismobeach.org\" aria-label=\"Email recreation@pismobeach.org\">recreation@pismobeach.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Pismo Beach Recreation Division"
+    ]
+  },
+  "Planned-Parenthood": {
+    "title": "Planned Parenthood",
+    "content": "<h2><span>Planned Parenthood</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://plannedparenthood.org/planned-parenthood-california-central-coast\" data-external-link=\"true\">plannedparenthood.org/planned-parenthood-california-central-coast</a></li>\n<li><strong>Location:</strong> 743 Pismo St., SLO <a class=\"map-link\" data-lat=\"35.276498\" data-lon=\"-120.661688\" data-zoom=\"17\" data-label=\"Planned Parenthood\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-888-898-3806\" aria-label=\"Call 888-898-3806\">888-898-3806</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:health.center@ppcentralcoast.org\" aria-label=\"Email health.center@ppcentralcoast.org\">health.center@ppcentralcoast.org</a> </li>\n<li><strong>Hours:</strong> M 9am–6pm, Tu–Sa 8am–5pm (closed some holidays) </li>\n<li>Notes: entry-point for “FamilyPACT”</li>\n</ul>\n",
+    "aliases": [
+      "Planned Parenthood"
+    ]
+  },
+  "Port-San-Luis-Harbor-District": {
+    "title": "Port San Luis Harbor District",
+    "content": "<h2><span>Port San Luis Harbor District</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.portsanluis.com/\" data-external-link=\"true\">portsanluis.com</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-595-5400\" aria-label=\"Call 805-595-5400\">805-595-5400</a> </li>\n<li><strong>Hours</strong> (administrative): M–F 8am–4:30pm (closed Noon–1pm) </li>\n<li>Coastal Gateway Multi-Purpose Room<ul>\n<li><strong>Website:</strong> <a href=\"https://www.portsanluis.com/2164/Coastal-Gateway-Multi-Purpose-Room\" data-external-link=\"true\">portsanluis.com/2164/Coastal-Gateway-Multi-Purpose-Room</a></li>\n<li><strong>Location:</strong> 3900 Avila Beach Dr., Avila Beach <a class=\"map-link\" data-lat=\"35.172545\" data-lon=\"-120.756491\" data-zoom=\"17\" data-label=\"Port San Luis Harbor District\">Map</a> </li>\n</ul>\n</li>\n<li>RV Camping<ul>\n<li><strong>Website:</strong> <a href=\"https://www.portsanluis.com/2163/RV-Camping\" data-external-link=\"true\">portsanluis.com/2163/RV-Camping</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-305-4796\" aria-label=\"Call 805-305-4796\">805-305-4796</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:reservations@portsanluis.com\" aria-label=\"Email reservations@portsanluis.com\">reservations@portsanluis.com</a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Port San Luis Harbor District"
+    ]
+  },
+  "Pregnancy-Parenting-Support": {
+    "title": "Pregnancy & Parenting Support",
+    "content": "<h2><span>Pregnancy &amp; Parenting Support</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ppsslo.org/\" data-external-link=\"true\">www.ppsslo.org</a></li>\n<li><strong>Location:</strong> 3480 S. Higuera #110, SLO <a class=\"map-link\" data-lat=\"35.245008\" data-lon=\"-120.673657\" data-zoom=\"17\" data-label=\"Pregnancy &amp; Parenting Support\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-3367\" aria-label=\"Call 805-541-3367\">805-541-3367</a>, <a href=\"sms:+1-805-541-3367\">805-541-3367</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@ppsslo.org\" aria-label=\"Email info@ppsslo.org\">info@ppsslo.org</a> </li>\n<li><strong>Hours:</strong> M–F 10am–3pm </li>\n<li><strong>How to access:</strong> By appointment only; call or text to make an appointment </li>\n</ul>\n",
+    "aliases": [
+      "Pregnancy & Parenting Support"
+    ]
+  },
+  "Recovery-Dharma": {
+    "title": "Recovery Dharma",
+    "content": "<h2><span>Recovery Dharma</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://recoverydharma.org/\" data-external-link=\"true\">recoverydharma.org</a></li>\n<li><strong>Location:</strong> 865 Aerovista Pl. #106, SLO (<a href=\"#\" data-directory-link=\"Aspire-Counseling-Service\" aria-label=\"View directory entry for Aspire Counseling Service\"><strong>Aspire Counseling Service</strong></a>) <a href=\"#\" class=\"map-link\" data-lat=\"35.242312\" data-lon=\"-120.640925\" data-zoom=\"17\" data-label=\"Aspire Counseling Service\">Map</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:tedrossini@gmail.com\" aria-label=\"Email tedrossini@gmail.com\">tedrossini@gmail.com</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-510-417-6162\" aria-label=\"Call 510-417-6162\">510-417-6162</a> </li>\n<li><strong>Hours:</strong> Sa. 10:20–11:20am </li>\n</ul>\n",
+    "aliases": [
+      "Recovery Dharma"
+    ]
+  },
+  "Recuperative-Care-Program": {
+    "title": "Recuperative Care Program",
+    "content": "<h2><span>Recuperative Care Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/rcp/\" data-external-link=\"true\">capslo.org/rcp</a></li>\n<li><strong>Location:</strong> <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado\"><strong>40 Prado</strong></a>, SLO <a class=\"map-link\" data-lat=\"35.256164\" data-lon=\"-120.672655\" data-zoom=\"17\" data-label=\"40 Prado Homeless Services Center\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-458-2895\" aria-label=\"Call 805-458-2895\">805-458-2895</a> (Ariana Long) </li>\n<li><a href=\"tel:+1-805-503-2984\" aria-label=\"Call 805-503-2984\">805-503-2984</a> (Amy Nielson, inquiries) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:rcp40prado@capslo.org\" aria-label=\"Email rcp40prado@capslo.org\">rcp40prado@capslo.org</a> </li>\n<li><strong>Hours:</strong> 24/7 </li>\n<li><strong>How to access:</strong> Must be referred by a medical professional </li>\n</ul>\n",
+    "aliases": [
+      "Recuperative Care Program"
+    ]
+  },
+  "Recycle-101": {
+    "title": "Recycle 101",
+    "content": "<h2><span>Recycle 101</span></h2>\n<ul>\n<li><strong>Location:</strong> 1909 Front St., Oceano <a class=\"map-link\" data-lat=\"35.098794\" data-lon=\"-120.612028\" data-zoom=\"17\" data-label=\"Recycle 101 — Oceano\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-363-1034\" aria-label=\"Call 805-363-1034\">805-363-1034</a> </li>\n<li><strong>Hours:</strong> W 9am–4pm, M/Tu/Th/F/Sa 9am–Noon, M/Tu/Th/F 12:30–4pm </li>\n<li>Notes: CRV recycling for cash (5¢ for containers &lt;24oz, 10¢ for ≥24oz)</li>\n</ul>\n",
+    "aliases": [
+      "Recycle 101"
+    ]
+  },
+  "Red-Cross": {
+    "title": "Red Cross",
+    "content": "<h2><span>Red Cross</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.redcross.org/local/california/central-california.html\" data-external-link=\"true\">redcross.org/local/california/central-california.html</a></li>\n<li><strong>Location:</strong> 225 Prado Rd. #A <a class=\"map-link\" data-lat=\"35.253953\" data-lon=\"-120.666367\" data-zoom=\"17\" data-label=\"Red Cross\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li>Local office: <a href=\"tel:+1-805-543-0696\" aria-label=\"Call 805-543-0696\">805-543-0696</a> </li>\n<li>24/7 national line: <a href=\"tel:+1-800-733-2767\" aria-label=\"Call 800-733-2767\">800-733-2767</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 9am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "Red Cross"
+    ]
+  },
+  "Red-Rover-Relief": {
+    "title": "Red Rover Relief",
+    "content": "<h2><span>Red Rover Relief</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://redrover.org/relief/\" data-external-link=\"true\">redrover.org/relief</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 188890, Sacramento, CA 95818 </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-916-429-2457\" aria-label=\"Call 916-429-2457\">916-429-2457</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@redrover.org\" aria-label=\"Email info@redrover.org\">info@redrover.org</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–4:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Red Rover Relief"
+    ]
+  },
+  "Refuge-Church-Atascadero": {
+    "title": "Refuge Church",
+    "content": "<h2><span>Refuge Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://refugechurch.info/connect/open-arms-ministry\" data-external-link=\"true\">refugechurch.info/connect/open-arms-ministry</a></li>\n<li><strong>Location:</strong> 6955 Portola Rd., Atascadero <a class=\"map-link\" data-lat=\"35.476475\" data-lon=\"-120.679480\" data-zoom=\"17\" data-label=\"Refuge Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-3554\" aria-label=\"Call 805-466-3554\">805-466-3554</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:office@refugechurch.info\" aria-label=\"Email office@refugechurch.info\">office@refugechurch.info</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Food and clothing pantry: Tu 5–6pm, W 6–6:30pm, or by appointment</li>\n<li>Refuge recovery (for anyone struggling with addiction): Tu 6pm </li>\n<li>Free meals: Tu 5pm/W 6pm dinner</li>\n<li>Office: M–F 8am–5pm</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Refuge Church"
+    ]
+  },
+  "Renovate-Church": {
+    "title": "Renovate Church",
+    "content": "<h2><span>Renovate Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://renovateslo.com/\" data-external-link=\"true\">renovateslo.com</a></li>\n<li><strong>Location:</strong> 2075 Johnson Ave., SLO <a class=\"map-link\" data-lat=\"35.276312\" data-lon=\"-120.648300\" data-zoom=\"17\" data-label=\"Renovate Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-0945\" aria-label=\"Call 805-543-0945\">805-543-0945</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:office@renovateslo.com\" aria-label=\"Email office@renovateslo.com\">office@renovateslo.com</a></li>\n<li>Hours (food pantry): M 4–6pm</li>\n</ul>\n",
+    "aliases": [
+      "Renovate Church"
+    ]
+  },
+  "Restoration-Church": {
+    "title": "Restoration Church",
+    "content": "<h2><span>Restoration Church</span></h2>\n<ul>\n<li><strong>Location:</strong> 9333 Santa Barbara Rd., Atascadero <a class=\"map-link\" data-lat=\"35.449172\" data-lon=\"-120.633742\" data-zoom=\"17\" data-label=\"Restoration Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-538-0449\" aria-label=\"Call 805-538-0449\">805-538-0449</a> </li>\n<li><strong>Hours</strong> (food pantry): first Saturday of the month, 1–3pm </li>\n</ul>\n",
+    "aliases": [
+      "Restoration Church"
+    ]
+  },
+  "Restorative-Partners": {
+    "title": "Restorative Partners",
+    "content": "<h2><span>Restorative Partners</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://restorativepartners.org/\" data-external-link=\"true\">restorativepartners.org</a></li>\n<li><strong>Location:</strong> 3380 South Higuera St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.255072\" data-lon=\"-120.669130\" data-zoom=\"17\" data-label=\"Restorative Partners\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-242-1272\" aria-label=\"Call 805-242-1272\">805-242-1272</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@restorativepartners.org\" aria-label=\"Email info@restorativepartners.org\">info@restorativepartners.org</a></li>\n<li><strong>Hours:</strong> M–F 9am–5pm </li>\n<li>Notes:<ul>\n<li>Operates <a href=\"#\" data-directory-link=\"Healing-and-Restoration-Campus\" aria-label=\"View directory entry for Healing and Restoration Campus\"><strong>Healing and Restoration Campus</strong></a> </li>\n<li>Operates “The Bridge Cafe” <ul>\n<li><strong>Location:</strong> 1074 Higuera St., SLO </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-1689\" aria-label=\"Call 805-439-1689\">805-439-1689</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@thebridgecafe.org\" aria-label=\"Email info@thebridgecafe.org\">info@thebridgecafe.org</a> </li>\n<li><strong>Hours:</strong> M–F 7am–3pm </li>\n</ul>\n</li>\n<li>Operates a housing program (<a href=\"https://restorativepartners.org/housing/\" data-external-link=\"true\">restorativepartners.org/housing</a>):<ul>\n<li>Anna’s Home (Paso Robles): Supports 5 women and their children with employment support, job management, financial literacy, life skills, and permanent housing goals </li>\n<li>Hope House (Los Osos): For returning women, offers 24/7 supervision, transportation, 12-step meetings, life skills training, mentorship, outpatient treatment </li>\n<li>Rapha House (Los Osos): 8-bed home for men focusing on recovery from addiction, restorative justice practices, clean and sober lifestyle </li>\n<li>LyonHeart Place (San Luis Obispo): Men’s State Parolee Reentry Housing Program with Joseph House and Francis House providing clinically structured and supportive environment </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-234-9074\" aria-label=\"Call 805-234-9074\">805-234-9074</a></li>\n<li><strong>Email:</strong> <a href=\"mailto:housing@restorativepartners.org\" aria-label=\"Email housing@restorativepartners.org\">housing@restorativepartners.org</a> </li>\n<li><strong>How to access:</strong> contact Restorative Partners to get on the waiting list</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Restorative Partners"
+    ]
+  },
+  "Ride-On-Transportation": {
+    "title": "Ride-On Transportation",
+    "content": "<h2><span>Ride-On Transportation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ride-on.org/\" data-external-link=\"true\">ride-on.org</a></li>\n<li><strong>Location:</strong> 3620 Sacramento Dr. #201, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.255366\" data-lon=\"-120.641446\" data-zoom=\"17\" data-label=\"Ride-On Transportation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-8747\" aria-label=\"Call 805-541-8747\">805-541-8747</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:contact@ride-on.org\" aria-label=\"Email contact@ride-on.org\">contact@ride-on.org</a> </li>\n<li><a href=\"#\" data-directory-link=\"Medi-Cal\" aria-label=\"View directory entry for Medi-Cal\"><strong>Medi-Cal</strong></a> Shuttle a.k.a. <a href=\"https://www.cencalhealth.org/members/transportation/\" data-external-link=\"true\">CenCal Health Transportation</a><ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-855-659-4600\" aria-label=\"Call 855-659-4600\">855-659-4600</a> (Ventura Transit System) </li>\n</ul>\n</li>\n<li>Veterans Express Shuttle<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-8747\" aria-label=\"Call 805-541-8747\">805-541-8747</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 6:30am–5:00pm (phone hours) </li>\n<li><strong>How to access:</strong> Call, or <a href=\"https://www.ride-on.org/ride-on-ride-request.php\" data-external-link=\"true\">submit a ride request online</a></li>\n</ul>\n",
+    "aliases": [
+      "Ride-On Transportation",
+      "[CenCal Health Transportation](https://www"
+    ]
+  },
+  "Rotating-Overnight-Safe-Parking-Program": {
+    "title": "Rotating Overnight Safe Parking Program",
+    "content": "<h2><span>Rotating Overnight Safe Parking Program</span></h2>\n<blockquote>\n<p><em>See <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/safe-parking/\" data-external-link=\"true\">capslo.org/safe-parking</a></li>\n<li><strong>Location:</strong> (various; apply at 40 Prado Rd., SLO <a class=\"map-link\" data-lat=\"35.256164\" data-lon=\"-120.672655\" data-zoom=\"17\" data-label=\"40 Prado Homeless Services Center\">Map</a>)</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-544-4004\" aria-label=\"Call 805-544-4004\">805-544-4004</a> (main 40 Prado)</li>\n<li><a href=\"tel:+1-805-440-6168\" aria-label=\"Call 805-440-6168\">805-440-6168</a> (Cecil Hale, Safe Parking inquiries)</li>\n</ul>\n</li>\n<li><strong>How to access:</strong> Must first complete intake at <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a>, then you are referred to the rotating program on a case-by-case basis</li>\n<li><strong>Hours:</strong> 7pm–7am overnight only</li>\n</ul>\n",
+    "aliases": [
+      "Rotating Overnight Safe Parking Program"
+    ]
+  },
+  "RVs-for-Veterans": {
+    "title": "RVs for Veterans",
+    "content": "<h2><span>RVs for Veterans</span></h2>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-234-5478\" aria-label=\"Call 805-234-5478\">805-234-5478</a> </li>\n<li>Note: a project of <a href=\"#\" data-directory-link=\"Hopes-Village\" aria-label=\"View directory entry for Hope’s Village\">Hope’s Village</a></li>\n</ul>\n",
+    "aliases": [
+      "RVs for Veterans"
+    ]
+  },
+  "Second-Chances-Thrift-Store": {
+    "title": "Second Chances Thrift Store",
+    "content": "<h2><span>Second Chances Thrift Store</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.captivehearts.org/second-chances-store.html\" data-external-link=\"true\">captivehearts.org/second-chances-store.html</a></li>\n<li><strong>Location:</strong> 892 W. Grand Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.121353\" data-lon=\"-120.620453\" data-zoom=\"17\" data-label=\"Second Chances Thrift Store\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-202-8800\" aria-label=\"Call 805-202-8800\">805-202-8800</a> </li>\n<li><strong>Hours:</strong> M–Sa 10am–4:30pm </li>\n<li>Notes: Operated by <a href=\"#\" data-directory-link=\"Captive-Hearts\" aria-label=\"View directory entry for Captive Hearts\">Captive Hearts</a> </li>\n</ul>\n",
+    "aliases": [
+      "Second Chances Thrift Store"
+    ]
+  },
+  "SAFE-Family-Resource-Centers": {
+    "title": "SAFE Family Resource Centers",
+    "content": "<h2><span>SAFE Family Resource Centers</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/s-a-f-e-family-resource-centers/\" data-external-link=\"true\">capslo.org/s-a-f-e-family-resource-centers</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1511 19th St., Oceano <a href=\"#\" class=\"map-link\" data-lat=\"35.102919\" data-lon=\"-120.610154\" data-zoom=\"17\" data-label=\"SAFE Family Resource Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-3690\" aria-label=\"Call 805-474-3690\">805-474-3690</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">1086 Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.119759\" data-lon=\"-120.595638\" data-zoom=\"17\" data-label=\"SAFE Family Resource Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-2105\" aria-label=\"Call 805-474-2105\">805-474-2105</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">920 W. Tefft St., Nipomo <a href=\"#\" class=\"map-link\" data-lat=\"35.027607\" data-lon=\"-120.497553\" data-zoom=\"16\" data-label=\"SAFE Family Resource Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-3000;ext=5147\" aria-label=\"Call 805-474-3000&nbsp;x5147\">805-474-3000&nbsp;x5147</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:southcountysafe@capslo.org\" aria-label=\"Email southcountysafe@capslo.org\">southcountysafe@capslo.org</a> </li>\n<li><strong>How to access:</strong> Walk-ins OK; appointments preferred.</li>\n<li>Note:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)\"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></li>\n<li>See also <a href=\"#\" data-directory-link=\"Link-Family-Resource-Center\" aria-label=\"View directory entry for Link Family Resource Center\"><strong>Link Family Resource Center</strong></a></li>\n<li>See also <a href=\"#\" data-directory-link=\"North-County-Family-Resource-Center\" aria-label=\"View directory entry for North County Family Resource Center\"><strong>North County Family Resource Center</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SAFE Family Resource Centers"
+    ]
+  },
+  "St-Barnabas-Thrift-Shop": {
+    "title": "St. Barnabas Thrift Shop",
+    "content": "<h2><span>St. Barnabas Thrift Shop</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://saintbarnabas-ag.org/get-involved/thrift-shop/\" data-external-link=\"true\">saintbarnabas-ag.org/get-involved/thrift-shop</a></li>\n<li><strong>Location:</strong> 1328 Grand Ave. #F, Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.121001\" data-lon=\"-120.614790\" data-zoom=\"17\" data-label=\"St. Barnabas Thrit Shop\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-270-4023\" aria-label=\"Call 805-270-4023\">805-270-4023</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:stbarnabasthriftstore@gmail.com\" aria-label=\"Email stbarnabasthriftstore@gmail.com\">stbarnabasthriftstore@gmail.com</a> </li>\n<li><strong>Hours:</strong> Tu–F 10am–4pm, Sa Noon–4pm <ul>\n<li>“Bag Day” sale on the last Friday of the month</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "St. Barnabas Thrift Shop"
+    ]
+  },
+  "St-Josephs-Church": {
+    "title": "Saint Joseph’s Church",
+    "content": "<h2><span>Saint Joseph’s Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://stjosephcayucos.org/\" data-external-link=\"true\">stjosephcayucos.org</a></li>\n<li><strong>Location:</strong> 360 Park Ave., Cayucos <a class=\"map-link\" data-lat=\"35.447245\" data-lon=\"-120.897665\" data-zoom=\"17\" data-label=\"Saint Joseph’s Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-995-3243\" aria-label=\"Call 805-995-3243\">805-995-3243</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:stjosephcayucos@charter.net\" aria-label=\"Email stjosephcayucos@charter.net\">stjosephcayucos@charter.net</a> </li>\n<li><strong>Hours</strong> (food pantry): Fridays 10am–Noon, or Thursdays by appointment</li>\n</ul>\n",
+    "aliases": [
+      "Saint Joseph’s Church"
+    ]
+  },
+  "St-Patricks-Church": {
+    "title": "Saint Patrick’s Church",
+    "content": "<h2><span>Saint Patrick’s Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.stpatsag.org/\" data-external-link=\"true\">stpatsag.org</a></li>\n<li><strong>Location:</strong> 501 Fair Oaks Ave., Arroyo Grande <a class=\"map-link\" data-lat=\"35.114145\" data-lon=\"-120.583486\" data-zoom=\"17\" data-label=\"Saint Patrick’s Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-489-2680\" aria-label=\"Call 805-489-2680\">805-489-2680</a> </li>\n</ul>\n\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:info@stpatsag.org\" aria-label=\"Email info@stpatsag.org\">info@stpatsag.org</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Office: M/Tu/Th 9am–5pm (closed Noon–1:30pm), W 9:30am–5pm (closed Noon–1:30pm) </li>\n<li>Food pantry: Tu/W/Th 4–5pm</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Saint Patrick’s Church"
+    ]
+  },
+  "St-Patricks-Shamrock-Thrift": {
+    "title": "St. Patrick’s Shamrock Thrift",
+    "content": "<h2><span>St. Patrick’s Shamrock Thrift</span></h2>\n<ul>\n<li><strong>Location:</strong> 924 W. Grand Ave., Grover Beach <a class=\"map-link\" data-lat=\"35.121190\" data-lon=\"-120.619932\" data-zoom=\"17\" data-label=\"St. Patrick’s Shamrock Thrift\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-481-0612\" aria-label=\"Call 805-481-0612\">805-481-0612</a> </li>\n<li><strong>Hours:</strong> Tu–Sa 10am–4pm </li>\n</ul>\n",
+    "aliases": [
+      "St. Patrick’s Shamrock Thrift"
+    ]
+  },
+  "Salvation-Army": {
+    "title": "Salvation Army",
+    "content": "<h2><span>Salvation Army</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.salvationarmyusa.org/usa-western-territory/\" data-external-link=\"true\">salvationarmyusa.org/usa-western-territory</a><ul>\n<li><a href=\"https://sanluisobispo.salvationarmy.org/\" data-external-link=\"true\">sanluisobispo.salvationarmy.org</a></li>\n</ul>\n</li>\n</ul>\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Food Pantry</th>\n<th>Notes</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">815 Islay St., SLO <a class=\"map-link\" data-lat=\"35.276084\" data-lon=\"-120.659073\" data-zoom=\"17\" data-label=\"Salvation Army\">Map</a> </td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-544-2401\" aria-label=\"Call 805-544-2401\">805-544-2401</a> </td>\n<td data-label=\"Food Pantry\">W/F 10am–Noon, Th. 2–4pm </td>\n<td data-label=\"Notes\">Operates a “Rapid Rehousing Program”</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1550 W. Branch St., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.130889\" data-lon=\"-120.603205\" data-zoom=\"17\" data-label=\"Salvation Army\">Map</a> </td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-481-0278\" aria-label=\"Call 805-481-0278\">805-481-0278</a> </td>\n<td data-label=\"Food Pantry\">M/W/F 10am–2pm</td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">8420 El Camino Real <a href=\"#\" class=\"map-link\" data-lat=\"35.473181\" data-lon=\"-120.654509\" data-zoom=\"17\" data-label=\"Salvation Army\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-466-7201\" aria-label=\"Call 805-466-7201\">805-466-7201</a> </td>\n<td data-label=\"Food Pantry\"></td>\n<td data-label=\"Notes\"></td>\n</tr>\n<tr>\n<td data-label=\"Location\">540 Quintana Rd., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.369278\" data-lon=\"-120.845871\" data-zoom=\"17\" data-label=\"Salvation Army\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-772-7062\" aria-label=\"Call 805-772-7062\">805-772-7062</a> </td>\n<td data-label=\"Food Pantry\"></td>\n<td data-label=\"Notes\">(was temporarily closed as of September 2025) </td>\n</tr>\n<tr>\n<td data-label=\"Location\">711 Paso Robles St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.621917\" data-lon=\"-120.685548\" data-zoom=\"17\" data-label=\"Salvation Army\">Map</a> </td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-238-9591\" aria-label=\"Call 805-238-9591\">805-238-9591</a> </td>\n<td data-label=\"Food Pantry\"></td>\n<td data-label=\"Notes\">(was temporarily closed as of September 2025) </td>\n</tr>\n</tbody></table>\n",
+    "aliases": [
+      "Salvation Army"
+    ]
+  },
+  "San-Luis-Coastal-Adult-School": {
+    "title": "San Luis Coastal Adult School",
+    "content": "<h2><span>San Luis Coastal Adult School</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://ae.slcusd.org/\" data-external-link=\"true\">ae.slcusd.org</a></li>\n<li><strong>Location:</strong> 1500 Lizzie St., SLO <a class=\"map-link\" data-lat=\"35.281251\" data-lon=\"-120.649489\" data-zoom=\"17\" data-label=\"San Luis Coastal Adult School\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-549-1222\" aria-label=\"Call 805-549-1222\">805-549-1222</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:adultschool@slcusd.org\" aria-label=\"Email adultschool@slcusd.org\">adultschool@slcusd.org</a></li>\n<li><strong>How to access:</strong><ul>\n<li>Register for classes on-line at <a href=\"https://slcusd.asapconnected.com/\" data-external-link=\"true\">slcusd.asapconnected.com</a></li>\n<li>Or, come to the office during business hours</li>\n<li>Or, call during business hours</li>\n</ul>\n</li>\n<li>Note:<ul>\n<li>Hosts “San Luis Obispo Family Resource Center”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "San Luis Coastal Adult School"
+    ]
+  },
+  "SLO-College-of-Law-Legal-Clinic": {
+    "title": "San Luis Obispo College of Law Legal Clinic",
+    "content": "<h2><span>San Luis Obispo College of Law Legal Clinic</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://montereylaw.edu/clinics/indexslocl.html\" data-external-link=\"true\">montereylaw.edu/clinics/indexslocl.html</a></li>\n<li><strong>Location:</strong> 4119 Broad St. #200, SLO <a class=\"map-link\" data-lat=\"35.245787\" data-lon=\"-120.642691\" data-zoom=\"17\" data-label=\"SLO College of Law Legal Clinic\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-902-2752\" aria-label=\"Call 805-902-CRLA\">805-902-CRLA</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:mclworkshops@montereylaw.edu\" aria-label=\"Email mclworkshops@montereylaw.edu\">mclworkshops@montereylaw.edu</a></li>\n<li><strong>Hours:</strong> M–Th 9am–3pm (scheduling); consultations Tu 4:30–6:30pm</li>\n<li><strong>How to access:</strong> Telephone or Zoom appointments only </li>\n</ul>\n",
+    "aliases": [
+      "San Luis Obispo College of Law Legal Clinic"
+    ]
+  },
+  "Cal-Poly-Community-Counseling-Service": {
+    "title": "San Luis Obispo Counseling Service at Cal Poly",
+    "content": "<h2><span>San Luis Obispo Counseling Service at Cal Poly</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"Community-Counseling-Center\" aria-label=\"View directory entry for Community Counseling Center\"><strong>Community Counseling Center</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocounselingservice.calpoly.edu/about\" data-external-link=\"true\">slocounselingservice.calpoly.edu/about</a></li>\n<li><strong>Location:</strong> Cotchett Education Bldg. 2, Room 125, Cal Poly SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.300215\" data-lon=\"-120.664443\" data-zoom=\"17\" data-label=\"Cal Poly Community Counseling Service\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-756-1532\" aria-label=\"Call 805-756-1532\">805-756-1532</a> </li>\n<li><strong>How to access:</strong> No walk-ins; Call to make an appointment. </li>\n</ul>\n",
+    "aliases": [
+      "San Luis Obispo Counseling Service at Cal Poly",
+      "**Community Counseling Center**"
+    ]
+  },
+  "SLO-Veterans-Services-Collaborative": {
+    "title": "San Luis Obispo Veterans Services Collaborative",
+    "content": "<h2><span>San Luis Obispo Veterans Services Collaborative</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocvsc.org/\" data-external-link=\"true\">slocvsc.org</a></li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-610-0934\" aria-label=\"Call 805-610-0934\">805-610-0934</a> { Source: <a href=\"https://www.slocvsc.org/contact-us\" data-external-link=\"true\">https://www.slocvsc.org/contact-us</a> }</li>\n<li><a href=\"tel:+1-805-270-2988\" aria-label=\"Call 805-270-2988\">805-270-2988</a> { Source: <a href=\"https://www.facebook.com/SLOVsc/\" data-external-link=\"true\">https://www.facebook.com/SLOVsc/</a> }</li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:SLOVSC1@Gmail.com\" aria-label=\"Email SLOVSC1@Gmail.com\">SLOVSC1@Gmail.com</a> { Source: <a href=\"https://www.facebook.com/SLOVsc/\" data-external-link=\"true\">https://www.facebook.com/SLOVsc/</a> }\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "San Luis Obispo Veterans Services Collaborative"
+    ]
+  },
+  "Santa-Margarita-KOA-Holiday": {
+    "title": "Santa Margarita KOA Holiday",
+    "content": "<h2><span>Santa Margarita KOA Holiday</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://koa.com/campgrounds/santa-margarita/\" data-external-link=\"true\">koa.com/campgrounds/santa-margarita</a></li>\n<li><strong>Location:</strong> 4765 Santa Margarita Lake Rd., Santa Margarita <a class=\"map-link\" data-lat=\"35.319614\" data-lon=\"-120.499214\" data-zoom=\"17\" data-label=\"Santa Margarita KOA Holiday\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-438-5618\" aria-label=\"Call 805-438-5618\">805-438-5618</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:santamargarita@koa.com\" aria-label=\"Email santamargarita@koa.com\">santamargarita@koa.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Santa Margarita KOA Holiday"
+    ]
+  },
+  "Santa-Margarita-Lake-Recreation-Area": {
+    "title": "Santa Margarita Lake Recreation Area",
+    "content": "<h2><span>Santa Margarita Lake Recreation Area</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocountyparks.com/camp/santa-margarita-lake/\" data-external-link=\"true\">slocountyparks.com/camp/santa-margarita-lake/</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-788-2397\" aria-label=\"Call 805-788-2397\">805-788-2397</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:sloparks@co.slo.ca.us\" aria-label=\"Email sloparks@co.slo.ca.us\">sloparks@co.slo.ca.us</a></li>\n</ul>\n",
+    "aliases": [
+      "Santa Margarita Lake Recreation Area"
+    ]
+  },
+  "Santa-Margarita-Senior-Center": {
+    "title": "Santa Margarita Area Senior Citizens Club",
+    "content": "<h2><span>Santa Margarita Area Senior Citizens Club</span></h2>\n<ul>\n<li><strong>Location:</strong> 22202 “H” St., Santa Margarita <a href=\"#\" class=\"map-link\" data-lat=\"35.392015\" data-lon=\"-120.605121\" data-zoom=\"17\" data-label=\"Senior Center\">Map</a><ul>\n<li>Note: some maps show the address as 2201 “H” St.</li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-438-5854\" aria-label=\"Call 805-438-5854\">805-438-5854</a></li>\n<li><a href=\"tel:+1-805-438-3482\" aria-label=\"Call 805-438-3482\">805-438-3482</a> </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>A lunch service site for <a href=\"#\" data-directory-link=\"Meals-that-Connect\" aria-label=\"View directory entry for Meals that Connect\"><strong>Meals that Connect</strong></a></li>\n<li>A <a href=\"#\" data-directory-link=\"SLO-Food-Bank\" aria-label=\"View directory entry for SLO Food Bank\"><strong>SLO Food Bank</strong></a> neighborhood food distribution site</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Santa Margarita Area Senior Citizens Club"
+    ]
+  },
+  "Santa-Maria-Valley-Hispanic-Church": {
+    "title": "Santa Maria Valley Hispanic SDA Church",
+    "content": "<h2><span>Santa Maria Valley Hispanic SDA Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://santamariavalleyhispanicca.adventistchurch.org/\" data-external-link=\"true\">santamariavalleyhispanicca.adventistchurch.org</a></li>\n<li><strong>Location:</strong> 1575 Orchard Rd., Nipomo <a href=\"#\" class=\"map-link\" data-lat=\"35.005086\" data-lon=\"-120.459890\" data-zoom=\"17\" data-label=\"Santa Maria Valley Hispanic Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-929-5694\" aria-label=\"Call 805-929-5694\">805-929-5694</a> </li>\n<li><strong>Hours</strong> (food pantry): Sa 11am–12:30pm</li>\n</ul>\n",
+    "aliases": [
+      "Santa Maria Valley Hispanic SDA Church"
+    ]
+  },
+  "Seneca-Central-Coast": {
+    "title": "Seneca Central Coast",
+    "content": "<h2><span>Seneca Central Coast</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://senecafoa.org/regions/central-coast/\" data-external-link=\"true\">senecafoa.org/regions/central-coast</a></li>\n<li><strong>Location:</strong> 6850 Morro Rd., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.482077\" data-lon=\"-120.666571\" data-zoom=\"17\" data-label=\"Seneca Central Coast\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-434-2449\" aria-label=\"Call 805-434-2449\">805-434-2449</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@senecacenter.org\" aria-label=\"Email info@senecacenter.org\">info@senecacenter.org</a> </li>\n<li>Notes:<ul>\n<li>formerly called “Kinship Center”</li>\n<li>offers <a href=\"#\" data-directory-link=\"Enhanced-Care-Management\" aria-label=\"View directory entry for Enhanced Care Management\"><strong>Enhanced Care Management</strong></a> </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Seneca Central Coast"
+    ]
+  },
+  "Senior-Connection": {
+    "title": "Senior Connection",
+    "content": "<h2><span>Senior Connection</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://centralcoastseniors.org/senior-connection/\" data-external-link=\"true\">centralcoastseniors.org/senior-connection</a></li>\n<li><strong>Location:</strong> 528 S. Broadway, Santa Maria <a href=\"#\" class=\"map-link\" data-lat=\"34.947346\" data-lon=\"-120.435439\" data-zoom=\"17\" data-label=\"Senior Connection\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-800-510-2020\" aria-label=\"Call 800-510-2020\">800-510-2020</a> </li>\n<li><a href=\"tel:+1-805-928-2552\" aria-label=\"Call 805-928-2552\">805-928-2552</a> </li>\n<li><a href=\"tel:+1-805-928-9554\" aria-label=\"Call 805-928-9554\">805-928-9554</a> </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@centralcoastseniors.org\" aria-label=\"Email info@centralcoastseniors.org\">info@centralcoastseniors.org</a></li>\n<li><strong>Hours:</strong> M–F 8am–5pm </li>\n<li><strong>How to access:</strong> Walk-ins OK.</li>\n</ul>\n",
+    "aliases": [
+      "Senior Connection"
+    ]
+  },
+  "Senior-Go": {
+    "title": "Senior Go!",
+    "content": "<h2><span>Senior Go!</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.sloseniorgo.org/\" data-external-link=\"true\">sloseniorgo.org</a></li>\n<li><strong>Locations:</strong> Throughout SLO County </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-473-3333\" aria-label=\"Call 805-473-3333\">805-473-3333</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5pm, Sa 10am–3pm (closed major holidays) </li>\n</ul>\n",
+    "aliases": [
+      "Senior Go!"
+    ]
+  },
+  "Senior-Legal-Services-Project": {
+    "title": "Senior Legal Services Project",
+    "content": "<h2><span>Senior Legal Services Project</span></h2>\n<ul>\n<li><strong>Location:</strong><ul>\n<li>3232 S. Higuera St. #101D, SLO <a class=\"map-link\" data-lat=\"35.256866\" data-lon=\"-120.668734\" data-zoom=\"17\" data-label=\"Senior Legal Services Project\">Map</a> </li>\n<li>102 S. Vine St. #C, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.614368\" data-lon=\"-120.692636\" data-zoom=\"17\" data-label=\"Lumina Alliance\">Map</a> </li>\n<li>Also operates clinics at various Senior Centers and similar sites</li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-5140\" aria-label=\"Call 805-543-5140\">805-543-5140</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:intake@slolaf.org\" aria-label=\"Email intake@slolaf.org\">intake@slolaf.org</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–5pm</li>\n<li>Note: a project of <a href=\"#\" data-directory-link=\"SLO-Legal-Assistance-Foundation\" aria-label=\"View directory entry for SLO Legal Assistance Foundation (SLOLAF)\"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Senior Legal Services Project"
+    ]
+  },
+  "SESLOC-Credit-Union": {
+    "title": "SESLOC Credit Union",
+    "content": "<h2><span>SESLOC Credit Union</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.sesloc.org/\" data-external-link=\"true\">sesloc.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>1399 Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.120489\" data-lon=\"-120.605442\" data-zoom=\"17\" data-label=\"SESLOC Credit Union\">Map</a> </li>\n<li>8380 El Camino Real, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.473958\" data-lon=\"-120.654657\" data-zoom=\"17\" data-label=\"SESLOC Credit Union\">Map</a> </li>\n<li>1 Grand Ave. Bldg. 65, Cal Poly <a href=\"#\" class=\"map-link\" data-lat=\"35.300241\" data-lon=\"-120.658679\" data-zoom=\"16\" data-label=\"SESLOC Credit Union\">Map</a> (closed during academic break periods) </li>\n<li>705 Golden Hill Rd., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.622969\" data-lon=\"-120.659648\" data-zoom=\"17\" data-label=\"SESLOC Credit Union\">Map</a> </li>\n<li>3807 Broad St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.250534\" data-lon=\"-120.644817\" data-zoom=\"17\" data-label=\"SESLOC Credit Union\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-1816\" aria-label=\"Call 805-543-1816\">805-543-1816</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5pm </li>\n</ul>\n",
+    "aliases": [
+      "SESLOC Credit Union"
+    ]
+  },
+  "Shower-the-People": {
+    "title": "Shower the People",
+    "content": "<h2><span>Shower the People</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://showerthepeopleslo.org/\" data-external-link=\"true\">showerthepeopleslo.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">946 Rockaway Ave., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.120119\" data-lon=\"-120.619991\" data-zoom=\"17\" data-label=\"Shower the People\">Map</a></td>\n<td data-label=\"Hours\">W 10am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">2201 Lawton Ave., SLO           <a href=\"#\" class=\"map-link\" data-lat=\"35.269229\" data-lon=\"-120.657617\" data-zoom=\"17\" data-label=\"Shower the People\">Map</a></td>\n<td data-label=\"Hours\">Tu &amp; Th 10am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">11245 Los Osos Valley Rd., SLO  <a href=\"#\" class=\"map-link\" data-lat=\"35.260128\" data-lon=\"-120.696026\" data-zoom=\"17\" data-label=\"Shower the People\">Map</a></td>\n<td data-label=\"Hours\">Sa 10am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">995 Palm St., SLO               <a href=\"#\" class=\"map-link\" data-lat=\"35.282298\" data-lon=\"-120.662520\" data-zoom=\"17\" data-label=\"Shower the People\">Map</a></td>\n<td data-label=\"Hours\">Su 12:30–3:30pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:showerthepeopleslo@gmail.com\" aria-label=\"Email showerthepeopleslo@gmail.com\">showerthepeopleslo@gmail.com</a></li>\n<li>Note: Hosted by <a href=\"#\" data-directory-link=\"Lifepoint-Church\" aria-label=\"View directory entry for Lifepoint Church\"><strong>Lifepoint Church</strong></a> and <a href=\"#\" data-directory-link=\"UUSLO\" aria-label=\"View directory entry for Unitarian Universalists San Luis Obispo\"><strong>Unitarian Universalists San Luis Obispo</strong></a> among others</li>\n</ul>\n",
+    "aliases": [
+      "Shower the People"
+    ]
+  },
+  "Silver-City-Resort": {
+    "title": "Silver City Resort",
+    "content": "<h2><span>Silver City Resort</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.silvercitymorrobay.com/\" data-external-link=\"true\">silvercitymorrobay.com</a></li>\n<li><strong>Location:</strong> 500 Atascadero Rd., Morro Bay <a class=\"map-link\" data-lat=\"35.381677\" data-lon=\"-120.859918\" data-zoom=\"17\" data-label=\"Silver City Resort\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-772-7478\" aria-label=\"Call 805-772-7478\">805-772-7478</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:silvercity@dmhllc.com\" aria-label=\"Email silvercity@dmhllc.com\">silvercity@dmhllc.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "Silver City Resort"
+    ]
+  },
+  "SLO4Home": {
+    "title": "SLO for HOME",
+    "content": "<h2><span>SLO for HOME</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.sloforhome.org/\" data-external-link=\"true\">sloforhome.org</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 3901, SLO, CA 93403 </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@sloforhome.org\" aria-label=\"Email info@sloforhome.org\">info@sloforhome.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO for HOME"
+    ]
+  },
+  "SLO-Bangers": {
+    "title": "SLO Bangers",
+    "content": "<h2><span>SLO Bangers</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slobangers.com/\" data-external-link=\"true\">slobangers.com</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">6370 Atascadero Ave., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.486312\" data-lon=\"-120.670295\" data-zoom=\"17\" data-label=\"SLO Bangers\">Map</a></td>\n<td data-label=\"Hours\">Su 4–6pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">760 Morro Bay Blvd., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.365706\" data-lon=\"-120.844141\" data-zoom=\"17\" data-label=\"SLO Bangers\">Map</a></td>\n<td data-label=\"Hours\">M 2–4pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">1134 Black Oak Dr., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.645387\" data-lon=\"-120.687569\" data-zoom=\"17\" data-label=\"SLO Bangers\">Map</a></td>\n<td data-label=\"Hours\">Tu 4:30–5:30pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">2191 Johnson Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274319\" data-lon=\"-120.646781\" data-zoom=\"17\" data-label=\"SLO Bangers\">Map</a></td>\n<td data-label=\"Hours\">W 5:30–8:15pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-458-0123\" aria-label=\"Call 805-458-0123\">805-458-0123</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:slobangers07@gmail.com\" aria-label=\"Email slobangers07@gmail.com\">slobangers07@gmail.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO Bangers"
+    ]
+  },
+  "SLO-Cal-Careers-Center": {
+    "title": "SLO Cal Careers Center",
+    "content": "<h2><span>SLO Cal Careers Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://SLOCalCareers.org\" data-external-link=\"true\">SLOCalCareers.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>3563 Empleo Street, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.251551\" data-lon=\"-120.668077\" data-zoom=\"18\" data-label=\"SLO Cal Careers Center\">Map</a></li>\n<li>Youth Services: 3450 Broad St. #103a, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.257929\" data-lon=\"-120.646915\" data-zoom=\"17\" data-label=\"SLO Cal Careers Youth Services Center\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-2557\" aria-label=\"Call 805-439-2557\">805-439-2557</a></li>\n<li><strong>Email:</strong><ul>\n<li><a href=\"mailto:SLOCal@eckerd.org\" aria-label=\"Email SLOCal@eckerd.org\">SLOCal@eckerd.org</a></li>\n<li><a href=\"mailto:info@slocalcareers.org\" aria-label=\"Email info@slocalcareers.org\">info@slocalcareers.org</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 9am–4pm</li>\n<li>Notes:<ul>\n<li>a.k.a. “America’s Job Center of California”</li>\n<li>formerly “Business and Career One Stop”</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO Cal Careers Center",
+      "“America’s Job Center of California”"
+    ]
+  },
+  "SLOCOG": {
+    "title": "SLO Council of Governments (SLOCOG)",
+    "content": "<h2><span>SLO Council of Governments (SLOCOG)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocog.org/\" data-external-link=\"true\">slocog.org</a></li>\n<li><strong>Location:</strong> 1114 Marsh Street, SLO <a class=\"map-link\" data-lat=\"35.281490\" data-lon=\"-120.658717\" data-zoom=\"17\" data-label=\"SLO Council of Governments\">Map</a> { Source: <a href=\"https://www.slocog.org/\" data-external-link=\"true\">https://www.slocog.org/</a> }</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-4219\" aria-label=\"Call 805-781-4219\">805-781-4219</a> { Source: <a href=\"https://www.slocog.org/contact-page\" data-external-link=\"true\">https://www.slocog.org/contact-page</a> }</li>\n<li><strong>Email:</strong> <a href=\"mailto:slocog@slocog.org\" aria-label=\"Email slocog@slocog.org\">slocog@slocog.org</a> { Source: <a href=\"https://www.slocog.org/contact-page\" data-external-link=\"true\">https://www.slocog.org/contact-page</a> }\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "SLO Council of Governments (SLOCOG)"
+    ]
+  },
+  "SLO-County-Animal-Services": {
+    "title": "SLO County Animal Services",
+    "content": "<h2><span>SLO County Animal Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/animal-services\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/animal-services</a></li>\n<li><strong>Location:</strong> 885 Oklahoma Ave., SLO <a class=\"map-link\" data-lat=\"35.318844\" data-lon=\"-120.715762\" data-zoom=\"17\" data-label=\"SLO County Animal Services\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-781-4400\" aria-label=\"Call 805-781-4400\">805-781-4400</a> (main office) </li>\n<li><a href=\"tel:+1-805-781-4407\" aria-label=\"Call 805-781-4407\">805-781-4407</a> (found animal recording) </li>\n</ul>\n</li>\n<li><strong>Hours:</strong><ul>\n<li>Office: M/Tu/Th/F 8am–5pm, W 8am–7pm; Sa 9am–5pm </li>\n<li>Kennel: M/Tu/Th/F/Sa 1pm–5pm; W 1pm–7pm </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> call to make an appointment</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Animal Services"
+    ]
+  },
+  "SLO-County-Bar-Association": {
+    "title": "SLO County Bar Association Lawyer Referral and Information Service",
+    "content": "<h2><span>SLO County Bar Association Lawyer Referral and Information Service</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slobarlris.org/\" data-external-link=\"true\">slobarlris.org</a></li>\n<li><strong>Mailing address:</strong> P.O. Box 585, SLO, CA 93406 </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-5502\" aria-label=\"Call 805-541-5502\">805-541-5502</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:lris@slobar.org\" aria-label=\"Email lris@slobar.org\">lris@slobar.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO County Bar Association Lawyer Referral and Information Service"
+    ]
+  },
+  "SLO-County-Behavioral-Health": {
+    "title": "SLO County Behavioral Health",
+    "content": "<h2><span>SLO County Behavioral Health</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Main Office: 2180 Johnson Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274722\" data-lon=\"-120.646040\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> </li>\n<li>Arroyo Grande: 1350 Grand Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.120967\" data-lon=\"-120.604497\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-474-2154\" aria-label=\"Call 805-474-2154\">805-474-2154</a> <ul>\n<li>Services Affirming Family Empowerment: 1086 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.119759\" data-lon=\"-120.595638\" data-zoom=\"17\" data-label=\"SLO County Department of Social Services\">Map</a> — <a href=\"tel:+1-805-474-2105\" aria-label=\"Call 805-474-2105\">805-474-2105</a> </li>\n</ul>\n</li>\n<li>Atascadero Health Campus: 5575 Hospital Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.492613\" data-lon=\"-120.662895\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-461-6060\" aria-label=\"Call 805-461-6060\">805-461-6060</a> (adult mental health), <a href=\"tel:+1-805-461-6113\" aria-label=\"Call 805-461-6113\">805-461-6113</a> (youth mental health), <a href=\"tel:+1-805-461-6080\" aria-label=\"Call 805-461-6080\">805-461-6080</a> (adult drug and alcohol services) </li>\n<li>Grover Beach:<ul>\n<li>Youth &amp; Adult Drug and Alcohol Services: 1523 Longbranch Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.119403\" data-lon=\"-120.612598\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-473-7080\" aria-label=\"Call 805-473-7080\">805-473-7080</a> </li>\n<li>Youth Mental Health Services: 1666 Ramona Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.119877\" data-lon=\"-120.612731\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-473-7060\" aria-label=\"Call 805-473-7060\">805-473-7060</a> </li>\n</ul>\n</li>\n<li>Paso Robles Health Campus: 805 4th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.618660\" data-lon=\"-120.689219\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-237-3090\" aria-label=\"Call 805-237-3090\">805-237-3090</a> (adult mental health), <a href=\"tel:+1-805-237-3070\" aria-label=\"Call 805-237-3070\">805-237-3070</a> (youth mental health), <a href=\"tel:+1-805-226-3200\" aria-label=\"Call 805-226-3200\">805-226-3200</a> (adult drug and alcohol services) </li>\n<li>SLO:<ul>\n<li>Adult Drug and Alcohol Services: 2180 Johnson Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.274910\" data-lon=\"-120.646191\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-781-4275\" aria-label=\"Call 805-781-4275\">805-781-4275</a> </li>\n<li>Adult Mental Health Services: 2178 Johnson Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.275337\" data-lon=\"-120.646539\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-781-4700\" aria-label=\"Call 805-781-4700\">805-781-4700</a> </li>\n<li>Youth Drug and Alcohol Services: 277 South St. #T, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.268064\" data-lon=\"-120.666476\" data-zoom=\"17\" data-label=\"SLO County Drug and Alcohol Services\">Map</a> — <a href=\"tel:+1-805-781-4754\" aria-label=\"Call 805-781-4754\">805-781-4754</a> </li>\n<li>Youth Mental Health Services: 2975 McMillan Suite 160 <a href=\"#\" class=\"map-link\" data-lat=\"35.263533\" data-lon=\"-120.648100\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-781-4179\" aria-label=\"Call 805-781-4179\">805-781-4179</a> </li>\n<li>Psychiatric Health Facility: 2178 Johnson Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.275431\" data-lon=\"-120.646555\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> </li>\n<li>Martha’s Place Children’s Center (Ages 0–5): 2925 McMillan Ave. Suite 108 <a href=\"#\" class=\"map-link\" data-lat=\"35.263382\" data-lon=\"-120.648288\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-805-781-4948\" aria-label=\"Call 805-781-4948\">805-781-4948</a> </li>\n<li>Prevention and Outreach Services: 277 South St. #T, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.268064\" data-lon=\"-120.666476\" data-zoom=\"17\" data-label=\"SLO County Drug and Alcohol Services\">Map</a> — <a href=\"tel:+1-805-781-4754\" aria-label=\"Call 805-781-4754\">805-781-4754</a> </li>\n<li>SLO Sobering Center: 2180 Johnson Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.274910\" data-lon=\"-120.646191\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> — <a href=\"tel:+1-820-280-0415\" aria-label=\"Call 820-280-0415\">820-280-0415</a> </li>\n</ul>\n</li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li>Behavioral Health Access Line: <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> </li>\n<li>Local mental health crisis hotline: <a href=\"tel:+1-800-783-0607\" aria-label=\"Call 800-783-0607\">800-783-0607</a> </li>\n<li>Patient’s rights advocate: <a href=\"tel:+1-805-781-4738\" aria-label=\"Call 805-781-4738\">805-781-4738</a></li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm for lunch) </li>\n<li>Cost: “No clients are denied access to services due to inability to pay. Discounted fees and sliding fee schedules are available based on family size and income.” </li>\n<li>Notes:<ul>\n<li>Operates <a href=\"#\" data-directory-link=\"SLO-County-Drug-and-Alcohol-Services\" aria-label=\"View directory entry for SLO County Drug and Alcohol Services\"><strong>SLO County Drug and Alcohol Services</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Genoa-Pharmacy\" aria-label=\"View directory entry for Genoa Pharmacy\"><strong>Genoa Pharmacy</strong></a> is the on-site pharmacy for SLO County Behavioral Health</li>\n<li>Can refer you to the “Supported Employment” program</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Behavioral Health"
+    ]
+  },
+  "SLO-County-Clerk-Recorder": {
+    "title": "SLO County Clerk-Recorder",
+    "content": "<h2><span>SLO County Clerk-Recorder</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/clerk-recorder\" data-external-link=\"true\">slocounty.ca.gov/departments/clerk-recorder</a></li>\n<li><strong>Locations:</strong><ul>\n<li>6565 Capistrano Ave., Second Floor, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.489136\" data-lon=\"-120.663893\" data-zoom=\"17\" data-label=\"SLO County Clerk-Recorder\">Map</a> </li>\n<li>1055 Monterey St. #D120, SLO <a class=\"map-link\" data-lat=\"35.282079\" data-lon=\"-120.660193\" data-zoom=\"17\" data-label=\"SLO County Clerk-Recorder\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-781-5080\" aria-label=\"Call 805-781-5080\">805-781-5080</a> </li>\n<li><a href=\"tel:+1-805-461-6041\" aria-label=\"Call 805-461-6041\">805-461-6041</a> (North County office) </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> SLO office only: M/Tu/Th/F 8am–5pm, W 8am–4pm (transactions end 30 minutes before closing) </li>\n</ul>\n",
+    "aliases": [
+      "SLO County Clerk-Recorder"
+    ]
+  },
+  "SLO-County-Department-of-Social-Services": {
+    "title": "SLO County Department of Social Services",
+    "content": "<h2><span>SLO County Department of Social Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/social-services\" data-external-link=\"true\">slocounty.ca.gov/departments/social-services</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1086 E. Grand Ave., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.119759\" data-lon=\"-120.595638\" data-zoom=\"17\" data-label=\"SLO County Department of Social Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-2000\" aria-label=\"Call 805-474-2000\">805-474-2000</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">9630 El Camino Real, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.465765\" data-lon=\"-120.648798\" data-zoom=\"17\" data-label=\"Department of Social Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-461-6000\" aria-label=\"Call 805-461-6000\">805-461-6000</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">600 Quintana Rd., Morro Bay <a href=\"#\" class=\"map-link\" data-lat=\"35.369273\" data-lon=\"-120.844726\" data-zoom=\"17\" data-label=\"Department of Social Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-772-6405\" aria-label=\"Call 805-772-6405\">805-772-6405</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">681 W. Tefft St. #1, Nipomo <a href=\"#\" class=\"map-link\" data-lat=\"35.033619\" data-lon=\"-120.487984\" data-zoom=\"17\" data-label=\"Department of Social Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-931-1800\" aria-label=\"Call 805-931-1800\">805-931-1800</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">406 Spring St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.618565\" data-lon=\"-120.690345\" data-zoom=\"17\" data-label=\"Department of Social Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-237-3110\" aria-label=\"Call 805-237-3110\">805-237-3110</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">3433 S. Higuera, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.253655\" data-lon=\"-120.668725\" data-zoom=\"17\" data-label=\"SLO County Department of Social Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-1600\" aria-label=\"Call 805-781-1600\">805-781-1600</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Hours:</strong> M–F 8am–5pm (4pm–5pm by appointment only) </li>\n<li>Notes:<ul>\n<li>operates <a href=\"#\" data-directory-link=\"CalWORKs\" aria-label=\"View directory entry for CalWORKs Homeless Assistance Program\"><strong>CalWORKs Homeless Assistance Program</strong></a></li>\n<li>operates <a href=\"https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/general-assistance-cash-aid\" data-external-link=\"true\">“General Assistance Disabled Program”</a></li>\n<li>operates <a href=\"https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/general-assistance-cash-aid\" data-external-link=\"true\">“General Relief / General Assistance”</a></li>\n<li>operates “Temporary Assistance for Needy Families (TANF)”</li>\n<li>entry-point for “CalFresh / EBT (Food Stamps)”</li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"Housing-Support-Program\" aria-label=\"View directory entry for Housing Support Program (HSP)\"><strong>Housing Support Program (HSP)</strong></a></li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"Medically-Fragile-Homeless-Program\" aria-label=\"View directory entry for Medically Fragile Homeless Program\"><strong>Medically Fragile Homeless Program</strong></a></li>\n<li>can refer you to the <a href=\"#\" data-directory-link=\"Child-Care-Resource-Connection\" aria-label=\"View directory entry for Child Care Resource Connection\"><strong>Child Care Resource Connection</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Department of Social Services"
+    ]
+  },
+  "SLO-County-Drug-and-Alcohol-Services": {
+    "title": "SLO County Drug and Alcohol Services",
+    "content": "<h2><span>SLO County Drug and Alcohol Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/drug-and-alcohol-services\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health/drug-and-alcohol-services</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Walk-in Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">1523 Longbranch Ave., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.119403\" data-lon=\"-120.612598\" data-zoom=\"17\" data-label=\"SLO County Drug and Alcohol Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-473-7080\" aria-label=\"Call 805-473-7080\">805-473-7080</a> or <a href=\"tel:+1-805-473-7081\" aria-label=\"Call 805-473-7081\">805-473-7081</a></td>\n<td data-label=\"Walk-in Hours\">Mo,Fr 8am–11am; Tu 2:30–5:30pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">805 E. 4th Street, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.618678\" data-lon=\"-120.689326\" data-zoom=\"17\" data-label=\"SLO County Drug and Alcohol Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-226-3200\" aria-label=\"Call 805-226-3200\">805-226-3200</a></td>\n<td data-label=\"Walk-in Hours\">Mo,Th 8am–11am; Tu 2:30–5:30pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">2180 Johnson Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274910\" data-lon=\"-120.646191\" data-zoom=\"17\" data-label=\"SLO County Drug and Alcohol Services\">Map</a> — for adults</td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-4275\" aria-label=\"Call 805-781-4275\">805-781-4275</a></td>\n<td data-label=\"Walk-in Hours\">Tu,We 8am–11am; Th 2:30–5:30pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">277 South St. #T, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.268064\" data-lon=\"-120.666476\" data-zoom=\"17\" data-label=\"SLO County Drug and Alcohol Services\">Map</a> — for youth &amp; veterans</td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-4754\" aria-label=\"Call 805-781-4754\">805-781-4754</a></td>\n<td data-label=\"Walk-in Hours\">M–F 8am–5pm</td>\n</tr>\n</tbody></table>\n\n\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> (main access line)</li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li><strong>How to access:</strong> walk-ins OK (see Hours above), or call the main access line to make an appointment</li>\n<li>Notes:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"SLO-County-Behavioral-Health\" aria-label=\"View directory entry for SLO County Behavioral Health\"><strong>SLO County Behavioral Health</strong></a></li>\n<li>Atascadero clinic closed as of July 1, 2025 (use Paso Robles clinic instead)</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Drug and Alcohol Services"
+    ]
+  },
+  "SLO-County-Health-Department": {
+    "title": "SLO County Health Department",
+    "content": "<h2><span>SLO County Health Department</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"SLO-County-Public-Health-Department\" aria-label=\"View directory entry for SLO County Public Health Department\"><strong>SLO County Public Health Department</strong></a></em></p>\n</blockquote>\n<ul>\n<li>Note: entry-point for the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "SLO County Health Department",
+      "**SLO County Public Health Department**"
+    ]
+  },
+  "SLO-County-Law-Library": {
+    "title": "SLO County Law Library",
+    "content": "<h2><span>SLO County Law Library</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocll.org/\" data-external-link=\"true\">slocll.org</a></li>\n<li><strong>Location:</strong> 1050 Monterey St., Room 125, SLO <a class=\"map-link\" data-lat=\"35.282680\" data-lon=\"-120.660770\" data-zoom=\"17\" data-label=\"SLO County Law Library\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5855\" aria-label=\"Call 805-781-5855\">805-781-5855</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slocll.org\" aria-label=\"Email info@slocll.org\">info@slocll.org</a> </li>\n<li><strong>Hours:</strong> M–W 9am–4pm, Th.–F 8:30am–1:30pm </li>\n</ul>\n",
+    "aliases": [
+      "SLO County Law Library"
+    ]
+  },
+  "SLO-County-Mental-Health-Services": {
+    "title": "SLO County Mental Health Services",
+    "content": "<h2><span>SLO County Mental Health Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/behavioral-health</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Serves</th>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Serves\">Adults</td>\n<td data-label=\"Location\">1350 E. Grand Ave. , Arroyo Grande<a href=\"#\" class=\"map-link\" data-lat=\"35.120967\" data-lon=\"-120.604497\" data-zoom=\"17\" data-label=\"SLO County Mental Health Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-2154\" aria-label=\"Call 805-474-2154\">805-474-2154</a></td>\n</tr>\n<tr>\n<td data-label=\"Serves\">Youths</td>\n<td data-label=\"Location\">354 S. Halcyon Rd., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.113647\" data-lon=\"-120.592282\" data-zoom=\"17\" data-label=\"SLO County Mental Health Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-473-7060\" aria-label=\"Call 805-473-7060\">805-473-7060</a></td>\n</tr>\n<tr>\n<td data-label=\"Serves\">Youths</td>\n<td data-label=\"Location\">1666 Ramona Ave., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.119877\" data-lon=\"-120.612731\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-473-7060\" aria-label=\"Call 805-473-7060\">805-473-7060</a></td>\n</tr>\n<tr>\n<td data-label=\"Serves\">Adults</td>\n<td data-label=\"Location\">2178 Johnson Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.275337\" data-lon=\"-120.646539\" data-zoom=\"17\" data-label=\"SLO County Mental Health Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-4700\" aria-label=\"Call 805-781-4700\">805-781-4700</a></td>\n</tr>\n<tr>\n<td data-label=\"Serves\">Youths</td>\n<td data-label=\"Location\">2975 McMillan Ave. Suite 160, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.263533\" data-lon=\"-120.648100\" data-zoom=\"17\" data-label=\"SLO County Mental Health Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-4179\" aria-label=\"Call 805-781-4179\">805-781-4179</a></td>\n</tr>\n<tr>\n<td data-label=\"Serves\">Children</td>\n<td data-label=\"Location\">2925 McMillan Ave. Suite 108, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.263382\" data-lon=\"-120.648288\" data-zoom=\"17\" data-label=\"SLO County Mental Health Services\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-4948\" aria-label=\"Call 805-781-4948\">805-781-4948</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-800-838-1381\" aria-label=\"Call 800-838-1381\">800-838-1381</a> (24hr) / <a href=\"tel:+1-805-540-6500\" aria-label=\"Call 805-540-6500\">805-540-6500</a></li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li><strong>How to access:</strong><ul>\n<li>Walk-ins OK at the Arroyo Grande adult clinic M/W 9–11am and at the SLO adult clinic Tu/Th 1–4:30pm </li>\n<li>For youths and children, call to make an appointment</li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Central access point for all <a href=\"#\" data-directory-link=\"Medi-Cal\" aria-label=\"View directory entry for Medi-Cal\"><strong>Medi-Cal</strong></a> mental health services</li>\n<li>Can refer you to the “Supported Employment” program</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Mental Health Services"
+    ]
+  },
+  "SLO-County-Office-of-Emergency-Services": {
+    "title": "SLO County Office of Emergency Services",
+    "content": "<h2><span>SLO County Office of Emergency Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/administrative-office/office-of-emergency-services/contact-us\" data-external-link=\"true\">slocounty.ca.gov/departments/administrative-office/office-of-emergency-services</a></li>\n<li><strong>Location:</strong> 1055 Monterey St. #D430, SLO <a class=\"map-link\" data-lat=\"35.282079\" data-lon=\"-120.660193\" data-zoom=\"17\" data-label=\"SLO County Clerk-Recorder\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5678\" aria-label=\"Call 805-781-5678\">805-781-5678</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:oes@co.slo.ca.us\" aria-label=\"Email oes@co.slo.ca.us\">oes@co.slo.ca.us</a> </li>\n<li>Notes: For emergency alert signup, visit <a href=\"https://alertslo.org\" data-external-link=\"true\">AlertSLO.org</a> or <a href=\"https://www.prepareslo.org/\" data-external-link=\"true\">PrepareSLO.org</a></li>\n</ul>\n",
+    "aliases": [
+      "SLO County Office of Emergency Services"
+    ]
+  },
+  "SLO-County-Parks": {
+    "title": "SLO County Parks",
+    "content": "<h2><span>SLO County Parks</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocountyparks.com/\" data-external-link=\"true\">slocountyparks.com</a></li>\n<li><strong>Location:</strong> 1144 Monterey St. #A, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.283374\" data-lon=\"-120.659376\" data-zoom=\"17\" data-label=\"SLO County Parks &amp; Recreation\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5930\" aria-label=\"Call 805-781-5930\">805-781-5930</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:sloparks@co.slo.ca.us\" aria-label=\"Email sloparks@co.slo.ca.us\">sloparks@co.slo.ca.us</a> </li>\n<li>See also:<ul>\n<li><a href=\"#\" data-directory-link=\"Coastal-Dunes\" aria-label=\"View directory entry for Coastal Dunes RV Park &amp; Campground\"><strong>Coastal Dunes RV Park &amp; Campground</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"El-Chorro-Regional-Park-Campground\" aria-label=\"View directory entry for El Chorro Regional Park Campground\"><strong>El Chorro Regional Park Campground</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Lopez-Lake-Recreation-Area\" aria-label=\"View directory entry for Lopez Lake Recreation Area\"><strong>Lopez Lake Recreation Area</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Oceano-Campground\" aria-label=\"View directory entry for Oceano Campground\"><strong>Oceano Campground</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Santa-Margarita-Lake-Recreation-Area\" aria-label=\"View directory entry for Santa Margarita Lake Recreation Area\"><strong>Santa Margarita Lake Recreation Area</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Parks"
+    ]
+  },
+  "SLO-County-Public-Health-Department": {
+    "title": "SLO County Public Health Department",
+    "content": "<h2><span>SLO County Public Health Department</span></h2>\n<blockquote>\n<p><em>See also <a href=\"#\" data-directory-link=\"SLO-County-Health-Department\" aria-label=\"View directory entry for SLO County Health Department\"><strong>SLO County Health Department</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/public-health\" data-external-link=\"true\">slocounty.ca.gov/departments/health-agency/public-health</a></li>\n<li><strong>Location:</strong><ul>\n<li>2180 Johnson Ave, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274940\" data-lon=\"-120.646298\" data-zoom=\"17\" data-label=\"SLO County Public Health Department\">Map</a> </li>\n<li>2191 Johnson Ave, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274391\" data-lon=\"-120.646730\" data-zoom=\"17\" data-label=\"SLO County Public Health Department\">Map</a> </li>\n<li>805 4th St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.618660\" data-lon=\"-120.689219\" data-zoom=\"17\" data-label=\"SLO County Behavioral Health\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-788-2903\" aria-label=\"Call 805-788-2903\">805-788-2903</a> (24-hour info line) </li>\n<li><a href=\"tel:+1-805-781-5506\" aria-label=\"Call 805-781-5506\">805-781-5506</a> (to make an appointment) </li>\n<li><a href=\"tel:+1-805-237-3050\" aria-label=\"Call 805-237-3050\">805-237-3050</a> (Paso Robles) </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm) </li>\n</ul>\n",
+    "aliases": [
+      "SLO County Public Health Department",
+      "**SLO County Health Department**"
+    ]
+  },
+  "SLO-County-Public-Libraries": {
+    "title": "SLO County Public Libraries",
+    "content": "<h2><span>SLO County Public Libraries</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slolibrary.org/\" data-external-link=\"true\">slolibrary.org</a></li>\n</ul>\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n<th>Hours</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">Arroyo Grande: 800 W. Branch St. <a href=\"#\" class=\"map-link\" data-lat=\"35.124445\" data-lon=\"-120.589730\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a> </td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-473-7161\" aria-label=\"Call 805-473-7161\">805-473-7161</a></td>\n<td data-label=\"Hours\">Tu/W 1–6pm, F/Sa 1–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Atascadero: 6555 Capistrano Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.489127\" data-lon=\"-120.663909\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-461-6161\" aria-label=\"Call 805-461-6161\">805-461-6161</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm, Th/Sa 9am–5pm, F 1–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Cambria: 1043 Main St. <a href=\"#\" class=\"map-link\" data-lat=\"35.564950\" data-lon=\"-121.096263\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-927-4336\" aria-label=\"Call 805-927-4336\">805-927-4336</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm, Th 9am–5pm, F 1–5pm, Sa 9am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Cayucos: 310 B St. <a href=\"#\" class=\"map-link\" data-lat=\"35.452277\" data-lon=\"-120.905580\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-995-3312\" aria-label=\"Call 805-995-3312\">805-995-3312</a></td>\n<td data-label=\"Hours\">Tu/W 9am–5pm (closed Noon–1pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Creston: 6290 Adams St. <a href=\"#\" class=\"map-link\" data-lat=\"35.518522\" data-lon=\"-120.523509\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-237-3010\" aria-label=\"Call 805-237-3010\">805-237-3010</a></td>\n<td data-label=\"Hours\">Tu 1–6pm, W/Th Noon–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Los Osos: 2075 Palisades Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.313232\" data-lon=\"-120.837558\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-528-1862\" aria-label=\"Call 805-528-1862\">805-528-1862</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm, Th 9am–5pm, F/Sa 1–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Morro Bay: 625 Harbor St. <a href=\"#\" class=\"map-link\" data-lat=\"35.367165\" data-lon=\"-120.846235\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-772-6394\" aria-label=\"Call 805-772-6394\">805-772-6394</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm, Th 9am–5pm, F 1–5pm, Sa 9am–1pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Nipomo: 918 W. Tefft St. <a href=\"#\" class=\"map-link\" data-lat=\"35.028904\" data-lon=\"-120.497031\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-929-3994\" aria-label=\"Call 805-929-3994\">805-929-3994</a></td>\n<td data-label=\"Hours\">Tu/W/Th 10am–6pm, F/Sa 10am–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Oceano: 1511 19th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.102919\" data-lon=\"-120.610154\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-474-7478\" aria-label=\"Call 805-474-7478\">805-474-7478</a></td>\n<td data-label=\"Hours\">Tu/W/Th 9am–1pm and 2–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">SLO: 995 Palm St. <a href=\"#\" class=\"map-link\" data-lat=\"35.282263\" data-lon=\"-120.662223\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-5991\" aria-label=\"Call 805-781-5991\">805-781-5991</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm, Th/Sa 9am–5pm, F 1–5pm</td>\n</tr>\n<tr>\n<td data-label=\"Location\">San Miguel: 254 13th St. <a href=\"#\" class=\"map-link\" data-lat=\"35.751188\" data-lon=\"-120.698263\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-467-3224\" aria-label=\"Call 805-467-3224\">805-467-3224</a></td>\n<td data-label=\"Hours\">W 11am–6pm (closed 12:30–1pm), Th 10am–5pm (closed 12:30–1pm), F 1–5pm, Sa 10am–5pm (closed 12:30–1pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Santa Margarita: 9630 Murphy Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.388044\" data-lon=\"-120.608302\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-438-5622\" aria-label=\"Call 805-438-5622\">805-438-5622</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm (closed 12:30–1pm), Sa 9am–5pm (closed 12:30–1pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Shandon: 195 N. 2nd St. <a href=\"#\" class=\"map-link\" data-lat=\"35.656573\" data-lon=\"-120.376358\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-237-3009\" aria-label=\"Call 805-237-3009\">805-237-3009</a></td>\n<td data-label=\"Hours\">Tu/W 10am–6pm (closed 12:30–1pm), Sa 9am–5pm (closed 12:30–1pm)</td>\n</tr>\n<tr>\n<td data-label=\"Location\">Shell Beach: 230 Leeward Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.154648\" data-lon=\"-120.669678\" data-zoom=\"17\" data-label=\"SLO County Public Library\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-773-2263\" aria-label=\"Call 805-773-2263\">805-773-2263</a></td>\n<td data-label=\"Hours\">Tu/W 10am–1pm and 2–6pm, Sa 9am–5pm</td>\n</tr>\n</tbody></table>\n<ul>\n<li><p>Note: <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for Transitions Mental Health Association (TMHA)\"><strong>Transitions Mental Health Association (TMHA)</strong></a> has a “Library Outreach Team” that connects library patrons who are experiencing homelessness with a social worker and case manager to help them overcome barriers to accessing crucial social services. You can meet the Library Outreach Team at the following library branches (this schedule is subject to change; contact <a href=\"mailto:mvargas@t-mha.org\" aria-label=\"Email mvargas@t-mha.org\">mvargas@t-mha.org</a> for the most up-to-date schedule):</p>\n<ul>\n<li>Atascadero: W 10:30am–Noon</li>\n<li>Arroyo Grande: Th 9:30–11am</li>\n<li>Los Osos: F 1–2:30pm</li>\n<li>Morro Bay: Th. 12:30–2pm</li>\n<li>SLO: Tu 10–11:30am &amp; 2:30–4pm</li>\n</ul>\n<p>You can also make an appointment to meet with the team by calling <a href=\"tel:+1-805-540-0057\" aria-label=\"Call 805-540-0057\">805-540-0057</a></p>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Public Libraries"
+    ]
+  },
+  "SLO-County-Small-Claims-Advisor": {
+    "title": "SLO County Small Claims Advisor",
+    "content": "<h2><span>SLO County Small Claims Advisor</span></h2>\n<ul>\n<li><strong>Location:</strong> County Government Center Room 223, SLO <a class=\"map-link\" data-lat=\"35.282192\" data-lon=\"-120.660230\" data-zoom=\"17\" data-label=\"SLO County Small Claims Advisor\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5856\" aria-label=\"Call 805-781-5856\">805-781-5856</a></li>\n<li><strong>Hours:</strong> M–F 9am–12pm</li>\n<li><strong>How to access:</strong> no appointment necessary\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "SLO County Small Claims Advisor"
+    ]
+  },
+  "SLO-County-UndocuSupport": {
+    "title": "SLO County UndocuSupport",
+    "content": "<h2><span>SLO County UndocuSupport</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.sloundocusupport.org/\" data-external-link=\"true\">sloundocusupport.org</a></li>\n<li><strong>Location:</strong> 981 Marsh St., SLO <a class=\"map-link\" data-lat=\"35.279892\" data-lon=\"-120.660341\" data-zoom=\"17\" data-label=\"SLO County Undocusupport\">Map</a></li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-543-5451\" aria-label=\"Call 805-543-5451\">805-543-5451</a></li>\n<li><a href=\"tel:+1-805-549-8989\" aria-label=\"Call 805-549-8989\">805-549-8989</a> (hotline)</li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:UndocuSupport@cfsloco.org\" aria-label=\"Email UndocuSupport@cfsloco.org\">UndocuSupport@cfsloco.org</a></li>\n<li><strong>Hours:</strong> W 1–4:15pm</li>\n</ul>\n",
+    "aliases": [
+      "SLO County UndocuSupport"
+    ]
+  },
+  "SLO-County-YMCA": {
+    "title": "SLO County YMCA",
+    "content": "<h2><span>SLO County YMCA</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ciymca.org/locations/san-luis-obispo-county-ymca\" data-external-link=\"true\">ciymca.org/locations/san-luis-obispo-county-ymca</a><ul>\n<li><a href=\"https://www.ciymca.org/open-doors-scholarship-application\" data-external-link=\"true\">Open Doors Scholarship application</a> for people with low incomes</li>\n</ul>\n</li>\n<li><strong>Location:</strong> 1020 Southwood Dr., SLO <a class=\"map-link\" data-lat=\"35.266421\" data-lon=\"-120.643242\" data-zoom=\"17\" data-label=\"SLO County YMCA\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-8235\" aria-label=\"Call 805-543-8235\">805-543-8235</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:slo.info@ciymca.org\" aria-label=\"Email slo.info@ciymca.org\">slo.info@ciymca.org</a></li>\n<li><strong>Hours:</strong> M–Th 5:30am–9pm, F 5:30am–7pm, Sa 7am–5pm, Su closed </li>\n</ul>\n",
+    "aliases": [
+      "SLO County YMCA"
+    ]
+  },
+  "SLO-Court-Self-Help-Services": {
+    "title": "SLO Court Self-Help Services",
+    "content": "<h2><span>SLO Court Self-Help Services</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slo.courts.ca.gov/self-help\" data-external-link=\"true\">slo.courts.ca.gov/self-help</a></li>\n<li><strong>Location:</strong> 1050 Monterey St., Room 220, SLO <a class=\"map-link\" data-lat=\"35.282680\" data-lon=\"-120.660770\" data-zoom=\"17\" data-label=\"SLO Court Self-Help Services\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-706-3617\" aria-label=\"Call 805-706-3617\">805-706-3617</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–4:30pm </li>\n<li><strong>How to access:</strong> Phone, or make an appointment at <a href=\"https://calendly.com/self-help-center/\" data-external-link=\"true\">calendly.com/self-help-center</a> </li>\n<li>Notes: Includes “Family Law Facilitator” and “Self-Help Center”</li>\n</ul>\n",
+    "aliases": [
+      "SLO Court Self-Help Services"
+    ]
+  },
+  "SLO-Credit-Union": {
+    "title": "SLO Credit Union",
+    "content": "<h2><span>SLO Credit Union</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slocu.com/\" data-external-link=\"true\">slocu.com</a></li>\n<li><strong>Location:</strong> 1220 Osos St., SLO <a class=\"map-link\" data-lat=\"35.280049\" data-lon=\"-120.659510\" data-zoom=\"17\" data-label=\"SLO Credit Union\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-5839\" aria-label=\"Call 805-543-5839\">805-543-5839</a> </li>\n<li><strong>Hours:</strong> M–F 9am–4:30pm (lobby closed noon–2pm) </li>\n</ul>\n",
+    "aliases": [
+      "SLO Credit Union"
+    ]
+  },
+  "SLO-Food-Bank": {
+    "title": "SLO Food Bank",
+    "content": "<h2><span>SLO Food Bank</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slofoodbank.org/\" data-external-link=\"true\">slofoodbank.org</a></li>\n<li><strong>Location:</strong> 1180 Kendall Rd., SLO <a class=\"map-link\" data-lat=\"35.237752\" data-lon=\"-120.630593\" data-zoom=\"17\" data-label=\"SLO Food Bank\">Map</a> <ul>\n<li>Also has <a href=\"https://slofoodbank.org/en/food-locator/#neighborhood-food-distributions\" data-external-link=\"true\">many food distribution sites around SLO County</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-238-4664\" aria-label=\"Call 805-238-4664\">805-238-4664</a> </li>\n<li><strong>Hours:</strong> M–F 9:30am–4pm <ul>\n<li>Food pantry: M/W/F Noon–5pm </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO Food Bank"
+    ]
+  },
+  "SLO-Grassroots": {
+    "title": "SLO Grassroots",
+    "content": "<h2><span>SLO Grassroots</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slograssroots.org/\" data-external-link=\"true\">slograssroots.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-540-1455\" aria-label=\"Call 805-540-1455\">805-540-1455</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slograssroots.com\" aria-label=\"Email info@slograssroots.com\">info@slograssroots.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO Grassroots"
+    ]
+  },
+  "SLO-Hub": {
+    "title": "SLO Hub",
+    "content": "<h2><span>SLO Hub</span></h2>\n<blockquote>\n<p><em>See also: <a href=\"#\" data-directory-link=\"40-Prado\" aria-label=\"View directory entry for 40 Prado Homeless Services Center\"><strong>40 Prado Homeless Services Center</strong></a></em></p>\n</blockquote>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/slo-hub/\" data-external-link=\"true\">capslo.org/slo-hub</a></li>\n<li><strong>Location:</strong> 40 Prado Rd., SLO <a class=\"map-link\" data-lat=\"35.256164\" data-lon=\"-120.672655\" data-zoom=\"17\" data-label=\"SLO Hub\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-441-6589\" aria-label=\"Call 805-441-6589\">805-441-6589</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:sreyes@capslo.org\" aria-label=\"Email sreyes@capslo.org\">sreyes@capslo.org</a> </li>\n<li><strong>Hours:</strong> M–F 9am–5pm</li>\n<li><strong>How to access:</strong> By appointment only</li>\n<li>Notes: a collaboration between <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for CAPSLO\"><strong>CAPSLO</strong></a> and <a href=\"#\" data-directory-link=\"Restorative-Partners\" aria-label=\"View directory entry for Restorative Partners\"><strong>Restorative Partners</strong></a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO Hub"
+    ]
+  },
+  "SLO-Legal-Assistance-Foundation": {
+    "title": "SLO Legal Assistance Foundation (SLOLAF)",
+    "content": "<h2><span>SLO Legal Assistance Foundation (SLOLAF)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slolaf.org/\" data-external-link=\"true\">slolaf.org</a></li>\n<li><strong>Locations:</strong><ul>\n<li>3232 S. Higuera St. #101D, SLO <a class=\"map-link\" data-lat=\"35.256866\" data-lon=\"-120.668734\" data-zoom=\"17\" data-label=\"SLO Legal Assistance Foundation\">Map</a> </li>\n<li>102 S. Vine St. #C, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.614368\" data-lon=\"-120.692636\" data-zoom=\"17\" data-label=\"Lumina Alliance\">Map</a> </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-5140\" aria-label=\"Call 805-543-5140\">805-543-5140</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slolaf.org\" aria-label=\"Email info@slolaf.org\">info@slolaf.org</a> </li>\n<li>Notes:<ul>\n<li>Operates <a href=\"#\" data-directory-link=\"Senior-Legal-Services-Project\" aria-label=\"View directory entry for Senior Legal Services Project\"><strong>Senior Legal Services Project</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO Legal Assistance Foundation (SLOLAF)"
+    ]
+  },
+  "SLO-Noor-Foundation": {
+    "title": "SLO Noor Foundation",
+    "content": "<h2><span>SLO Noor Foundation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slonoorfoundation.org/\" data-external-link=\"true\">slonoorfoundation.org</a></li>\n<li>Primary clinics<ul>\n<li><strong>Locations:</strong><ul>\n<li>1428 Phillips Lane #203, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.288103\" data-lon=\"-120.657544\" data-zoom=\"17\" data-label=\"SLO Noor Foundation primary and vision clinic\">Map</a> </li>\n<li>400 Oak Hill Rd., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.613052\" data-lon=\"-120.675974\" data-zoom=\"17\" data-label=\"SLO Noor Foundation\">Map</a></li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-1797\" aria-label=\"Call 805-439-1797\">805-439-1797</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slonoorfoundation.org\" aria-label=\"Email info@slonoorfoundation.org\">info@slonoorfoundation.org</a> </li>\n<li><strong>Hours:</strong> SLO M–Th 8am–5pm; Paso Robles W 8am–5pm </li>\n</ul>\n</li>\n<li>Vision clinic<ul>\n<li><strong>Location:</strong> 1428 Phillips Lane #203, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.288103\" data-lon=\"-120.657544\" data-zoom=\"17\" data-label=\"SLO Noor Foundation primary and vision clinic\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-1797\" aria-label=\"Call 805-439-1797\">805-439-1797</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slonoorfoundation.org\" aria-label=\"Email info@slonoorfoundation.org\">info@slonoorfoundation.org</a> </li>\n</ul>\n</li>\n<li>Dental care clinic<ul>\n<li><strong>Location:</strong> 3071 S. Higuera St. #110, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.258739\" data-lon=\"-120.668378\" data-zoom=\"17\" data-label=\"SLO Noor Foundation dental clinic\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-592-2240\" aria-label=\"Call 805-592-2240\">805-592-2240</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:dental@slonoorfoundation.org\" aria-label=\"Email dental@slonoorfoundation.org\">dental@slonoorfoundation.org</a> </li>\n</ul>\n</li>\n<li>Women’s mobile health unit<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-756-5089\" aria-label=\"Call 805-756-5089\">805-756-5089</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:ccmacedo@calpoly.edu\" aria-label=\"Email ccmacedo@calpoly.edu\">ccmacedo@calpoly.edu</a> </li>\n</ul>\n</li>\n<li>Primary mobile health unit<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-1797\" aria-label=\"Call 805-439-1797\">805-439-1797</a> </li>\n<li><strong>Locations:</strong> Atascadero, Nipomo, Oceano, Paso Robles </li>\n</ul>\n</li>\n<li><strong>How to access:</strong><ul>\n<li>By appointment only</li>\n<li>Bring proof of income and a copy of your most recent income tax return to your first appointment</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO Noor Foundation"
+    ]
+  },
+  "SLO-Partners": {
+    "title": "SLO Partners",
+    "content": "<h2><span>SLO Partners</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slopartners.org/\" data-external-link=\"true\">slopartners.org</a></li>\n<li><strong>Location:</strong> 3350 Education Dr. SLO <a class=\"map-link\" data-lat=\"35.334344\" data-lon=\"-120.742872\" data-zoom=\"17\" data-label=\"SLO Partners\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-782-7372\" aria-label=\"Call 805-782-7372\">805-782-7372</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slopartners.org\" aria-label=\"Email info@slopartners.org\">info@slopartners.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO Partners"
+    ]
+  },
+  "SLO-Public-Defenders": {
+    "title": "SLO Public Defenders",
+    "content": "<h2><span>SLO Public Defenders</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slodefend.com/\" data-external-link=\"true\">slodefend.com</a></li>\n<li><strong>Location:</strong> 991 Osos Street #A, SLO <a class=\"map-link\" data-lat=\"35.281851\" data-lon=\"-120.661598\" data-zoom=\"17\" data-label=\"SLO Public Defenders\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-5715\" aria-label=\"Call 805-541-5715\">805-541-5715</a> </li>\n<li><strong>Hours:</strong> M–Th 8:30am–Noon &amp; 1pm–5pm; F 8:30am–Noon &amp; 1pm–4pm </li>\n<li><strong>How to access:</strong> Appear at first court hearing and ask judge to appoint attorney; meetings by appointment only</li>\n</ul>\n",
+    "aliases": [
+      "SLO Public Defenders"
+    ]
+  },
+  "SLO-RTA": {
+    "title": "SLO Regional Transit Authority",
+    "content": "<h2><span>SLO Regional Transit Authority</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slorta.org/\" data-external-link=\"true\">slorta.org</a></li>\n<li><strong>Location:</strong> 253 Elks Lane, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.256974\" data-lon=\"-120.672616\" data-zoom=\"17\" data-label=\"SLO Regional Transit Authority\">Map</a> (offices) </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-4472\" aria-label=\"Call 805-781-4472\">805-781-4472</a><ul>\n<li>Info/Dispatch: <a href=\"tel:+1-805-541-2228\" aria-label=\"Call 805-541-2228\">805-541-2228</a> </li>\n<li>Access program (reduced fares for people with low incomes): <a href=\"tel:+1-805-541-8797\" aria-label=\"Call 805-541-8797\">805-541-8797</a></li>\n<li>Runabout Paratransit: <a href=\"tel:+1-805-781-4833\" aria-label=\"Call 805-781-4833\">805-781-4833</a></li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@slorta.org\" aria-label=\"Email info@slorta.org\">info@slorta.org</a> </li>\n<li>Hours (office): M–Th 8am–4pm; Friday by appointment only </li>\n<li>Notes: Also operates “Runabout Paratransit,” <a href=\"#\" data-directory-link=\"Senior-Go\" aria-label=\"View directory entry for Senior Go! Shuttle\"><strong>Senior Go! Shuttle</strong></a>, and “Dial-A-Ride”</li>\n</ul>\n",
+    "aliases": [
+      "SLO Regional Transit Authority"
+    ]
+  },
+  "SLO-Senior-Center": {
+    "title": "SLO Senior Center",
+    "content": "<h2><span>SLO Senior Center</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs\" data-external-link=\"true\">slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs</a></li>\n<li><strong>Location:</strong> 1445 Santa Rosa St., SLO <a class=\"map-link\" data-lat=\"35.278951\" data-lon=\"-120.657079\" data-zoom=\"17\" data-label=\"SLO Senior Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-7306\" aria-label=\"Call 805-781-7306\">805-781-7306</a> </li>\n<li><strong>Hours:</strong> M–F 9am–4pm </li>\n<li>Membership: Open to SLO city residents 55+; includes monthly newsletter, center access, free coffee</li>\n<li>Notes:<ul>\n<li>Part of <a href=\"#\" data-directory-link=\"City-of-SLO-Parks-and-Recreation\" aria-label=\"View directory entry for City of SLO Parks and Recreation\"><strong>City of SLO Parks and Recreation</strong></a></li>\n<li>Hosts <a href=\"#\" data-directory-link=\"HiCAP\" aria-label=\"View directory entry for HiCAP\"><strong>HiCAP</strong></a> (Thursdays Noon–3:30pm by appointment)</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO Senior Center"
+    ]
+  },
+  "SLO-Sobering-Center": {
+    "title": "SLO Sobering Center",
+    "content": "<h2><span>SLO Sobering Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/sobering-center\" data-external-link=\"true\">slocounty.gov/soberingcenter</a></li>\n<li><strong>Location:</strong> 2180 Johnson Ave., SLO <a class=\"map-link\" data-lat=\"35.274671\" data-lon=\"-120.646514\" data-zoom=\"17\" data-label=\"SLO Sobering Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-820-280-0415\" aria-label=\"Call 820-280-0415\">820-280-0415</a> </li>\n<li><strong>Hours:</strong> 24/7 </li>\n</ul>\n",
+    "aliases": [
+      "SLO Sobering Center"
+    ]
+  },
+  "SLO-Superior-Court": {
+    "title": "SLO Superior Court",
+    "content": "<h2><span>SLO Superior Court</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slo.courts.ca.gov/\" data-external-link=\"true\">slo.courts.ca.gov</a></li>\n<li><strong>Locations:</strong><ul>\n<li>Civil &amp; Family Law Branch: 1050 Monterey St. Rm 220, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.282680\" data-lon=\"-120.660770\" data-zoom=\"17\" data-label=\"SLO Superior Court\">Map</a> </li>\n<li>Criminal Branch: 1050 Monterey St. Rm 220, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.282680\" data-lon=\"-120.660770\" data-zoom=\"17\" data-label=\"SLO Superior Court\">Map</a> </li>\n<li>Grover Beach Branch: 214 S. 16th St., Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.119856\" data-lon=\"-120.612030\" data-zoom=\"17\" data-label=\"SLO Superior Court\">Map</a> </li>\n<li>Juvenile Services Center: 1050 Monterey St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.282680\" data-lon=\"-120.660770\" data-zoom=\"17\" data-label=\"SLO Superior Court\">Map</a> </li>\n<li>Juvenile Justice (Delinquency): 1065 Kansas Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.321279\" data-lon=\"-120.718836\" data-zoom=\"17\" data-label=\"PLACEHOLDER\">Map</a> </li>\n<li>Paso Robles Branch: 901 Park St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.624257\" data-lon=\"-120.690294\" data-zoom=\"17\" data-label=\"SLO Superior Court\">Map</a> </li>\n<li>Veteran’s Memorial Branch: 801 Grand Ave., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.288803\" data-lon=\"-120.652687\" data-zoom=\"17\" data-label=\"SLO Superior Court\">Map</a> (temporarily closed as of December 2025) </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-706-3600\" aria-label=\"Call 805-706-3600\">805-706-3600</a> (Civil &amp; Family Law Branch and Criminal Branch)</li>\n<li><strong>Hours:</strong><ul>\n<li>Phone: M–F 8:30am–Noon</li>\n<li>Counter: M–Th 8:30am–Noon (Juvenile Justice, M 8am only; Paso Robles branch W/F 8:30am–Noon)</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "SLO Superior Court"
+    ]
+  },
+  "SLO-Thrift": {
+    "title": "SLO Thrift",
+    "content": "<h2><span>SLO Thrift</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://slothrift.com/\" data-external-link=\"true\">slothrift.com</a></li>\n<li><strong>Location:</strong> 445 Higuera St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.275984\" data-lon=\"-120.668482\" data-zoom=\"17\" data-label=\"SLO Thrift\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-4434\" aria-label=\"Call 805-439-4434\">805-439-4434</a> </li>\n<li><strong>Hours:</strong> M–Sa 9am–5pm </li>\n<li>Note: Not yet open as of November 2025 (being remodeled)</li>\n</ul>\n",
+    "aliases": [
+      "SLO Thrift"
+    ]
+  },
+  "SLO-Transit": {
+    "title": "SLO Transit",
+    "content": "<h2><span>SLO Transit</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocity.org/government/department-directory/public-works/slo-transit-bus\" data-external-link=\"true\">slocity.org/government/department-directory/public-works/slo-transit-bus</a></li>\n<li><strong>Location</strong> (office): 1260 Chorro St. #B, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.278607\" data-lon=\"-120.661582\" data-zoom=\"17\" data-label=\"SLO Transit\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-594-8090\" aria-label=\"Call 805-594-8090\">805-594-8090</a> (main office) </li>\n<li><a href=\"tel:+1-805-541-2877\" aria-label=\"Call 805-541-2877\">805-541-2877</a> (dispatch) </li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:slotransit@slocity.org\" aria-label=\"Email slotransit@slocity.org\">slotransit@slocity.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "SLO Transit"
+    ]
+  },
+  "SLO-Vet-Center": {
+    "title": "SLO Vet Center",
+    "content": "<h2><span>SLO Vet Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.va.gov/san-luis-obispo-vet-center/\" data-external-link=\"true\">va.gov/san-luis-obispo-vet-center</a></li>\n<li><strong>Location:</strong> 1070 Southwood Dr., SLO <a class=\"map-link\" data-lat=\"35.265278\" data-lon=\"-120.640912\" data-zoom=\"17\" data-label=\"SLO Vet Center\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-782-9101\" aria-label=\"Call 805-782-9101\">805-782-9101</a> <ul>\n<li>24/7: <a href=\"tel:+1-877-927-8387\" aria-label=\"Call 877-927-8387\">877-927-8387</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–4:30pm </li>\n<li><strong>How to access:</strong> call to make an appointment</li>\n</ul>\n",
+    "aliases": [
+      "SLO Vet Center"
+    ]
+  },
+  "SmartShare-Housing-Solutions": {
+    "title": "SmartShare Housing Solutions",
+    "content": "<h2><span>SmartShare Housing Solutions</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.smartsharehousingsolutions.org/\" data-external-link=\"true\">smartsharehousingsolutions.org</a></li>\n<li><strong>Mailing address:</strong> PO Box 15034, SLO, CA 93406 </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-215-5474\" aria-label=\"Call 805-215-5474\">805-215-5474</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@smartsharehousingsolutions.org\" aria-label=\"Email info@smartsharehousingsolutions.org\">info@smartsharehousingsolutions.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "SmartShare Housing Solutions"
+    ]
+  },
+  "Social-Security-Administration": {
+    "title": "Social Security Administration",
+    "content": "<h2><span>Social Security Administration</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.ssa.gov/\" data-external-link=\"true\">ssa.gov</a></li>\n<li><strong>Location:</strong> 3240 S. Higuera St., SLO <a class=\"map-link\" data-lat=\"35.256200\" data-lon=\"-120.668801\" data-zoom=\"17\" data-label=\"Social Security Administration\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-855-207-4865\" aria-label=\"Call 855-207-4865\">855-207-4865</a> (TTY: <a href=\"tel:+1-800-325-0778\" aria-label=\"Call 800-325-0778\">800-325-0778</a>)</li>\n<li><strong>Hours:</strong> M–F 9am–4pm </li>\n<li><strong>How to access:</strong> Call to schedule an appointment</li>\n</ul>\n",
+    "aliases": [
+      "Social Security Administration"
+    ]
+  },
+  "Society-of-St-Vincent-de-Paul": {
+    "title": "Society of Saint Vincent de Paul",
+    "content": "<h2><span>Society of Saint Vincent de Paul</span></h2>\n<ul>\n<li><strong>Location:</strong> 751 Palm St., SLO <a class=\"map-link\" data-lat=\"35.280750\" data-lon=\"-120.665042\" data-zoom=\"17\" data-label=\"Society of Saint Vincent de Paul\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-544-7041\" aria-label=\"Call 805-544-7041\">805-544-7041</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>Tuesdays at Prado Center (43 Prado Rd., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.255032\" data-lon=\"-120.672742\" data-zoom=\"17\" data-label=\"Society of Saint Vincent de Paul\">Map</a>): 2–3:30pm </li>\n<li>Thursdays at Mission San Luis Obispo (751 Palm St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.280750\" data-lon=\"-120.665042\" data-zoom=\"17\" data-label=\"Society of Saint Vincent de Paul\">Map</a>): by appointment only </li>\n</ul>\n</li>\n<li><strong>How to access:</strong> drop-in at Prado, or call to schedule an appointment at the Mission</li>\n</ul>\n",
+    "aliases": [
+      "Society of Saint Vincent de Paul"
+    ]
+  },
+  "South-Bay-Community-Center": {
+    "title": "South Bay Community Center",
+    "content": "<h2><span>South Bay Community Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://southbaycommunitycenter.com/\" data-external-link=\"true\">southbaycommunitycenter.com</a></li>\n<li><strong>Location:</strong> 2180 Palisades Ave., Los Osos <a class=\"map-link\" data-lat=\"35.312984\" data-lon=\"-120.836284\" data-zoom=\"17\" data-label=\"South Bay Community Center\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-528-4169\" aria-label=\"Call 805-528-4169\">805-528-4169</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:sbcc@sbcommunitycenter.net\" aria-label=\"Email sbcc@sbcommunitycenter.net\">sbcc@sbcommunitycenter.net</a> </li>\n<li><strong>Hours:</strong> M/Tu/F 1–4pm (office) </li>\n<li>Notes:<ul>\n<li>Hosts Early Risers A.A. meetings </li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Meals-that-Connect\" aria-label=\"View directory entry for Meals that Connect\"><strong>Meals that Connect</strong></a> senior nutrition program </li>\n<li>Hosts <a href=\"#\" data-directory-link=\"Los-Osos-Cares\" aria-label=\"View directory entry for Los Osos Cares\"><strong>Los Osos Cares</strong></a> Community Dinner </li>\n<li><a href=\"#\" data-directory-link=\"South-Bay-Seniors-People-Helping-People\" aria-label=\"View directory entry for South Bay Seniors People Helping People\"><strong>South Bay Seniors People Helping People</strong></a> operates their food bank and medical equipment loan program from this facility (M/W/F 9am–1pm) </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "South Bay Community Center"
+    ]
+  },
+  "South-Bay-Seniors-People-Helping-People": {
+    "title": "South Bay Seniors People Helping People",
+    "content": "<h2><span>South Bay Seniors People Helping People</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://southbayseniorspeoplehelpingpeople.com/\" data-external-link=\"true\">southbayseniorspeoplehelpingpeople.com</a></li>\n<li><strong>Location:</strong> 2180 Palisades Ave., Los Osos <a class=\"map-link\" data-lat=\"35.312984\" data-lon=\"-120.836284\" data-zoom=\"17\" data-label=\"South Bay Seniors People Helping People\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-528-2626\" aria-label=\"Call 805-528-2626\">805-528-2626</a> </li>\n<li><strong>Hours:</strong> M/W/F 9am–1pm </li>\n</ul>\n",
+    "aliases": [
+      "South Bay Seniors People Helping People"
+    ]
+  },
+  "Steves-Recycling": {
+    "title": "Steve’s Recycling",
+    "content": "<h2><span>Steve’s Recycling</span></h2>\n\n\n<ul>\n<li><strong>Location:</strong> 1130 Los Osos Valley Rd., Los Osos <a class=\"map-link\" data-lat=\"35.311838\" data-lon=\"-120.829993\" data-zoom=\"17\" data-label=\"Steve’s Recycling — Los Osos\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-801-1627\" aria-label=\"Call 805-801-1627\">805-801-1627</a> </li>\n<li><strong>Hours:</strong> Sa 9am–11am </li>\n<li>Notes: CRV recycling for cash (5¢ for containers &lt;24oz, 10¢ for ≥24oz)</li>\n</ul>\n",
+    "aliases": [
+      "Steve’s Recycling"
+    ]
+  },
+  "Sunny-Acres": {
+    "title": "Sunny Acres",
+    "content": "<h2><span>Sunny Acres</span></h2>\n<p>“Sunny Acres” may refer to two different locations in the city of SLO:</p>\n<ol>\n<li>a former orphanage in the hills above Johnson Avenue that is now “Bishop Street Studios” operated by <a href=\"#\" data-directory-link=\"TMHA\" aria-label=\"View directory entry for Transitions Mental Health Association (TMHA)\"><strong>Transitions Mental Health Association (TMHA)</strong></a></li>\n<li>a former sober living compound near Laguna Lake that is now the <a href=\"#\" data-directory-link=\"Healing-and-Restoration-Campus\" aria-label=\"View directory entry for Healing and Restoration Campus\"><strong>Healing and Restoration Campus</strong></a> operated by <a href=\"#\" data-directory-link=\"Restorative-Partners\" aria-label=\"View directory entry for Restorative Partners\"><strong>Restorative Partners</strong></a></li>\n</ol>\n",
+    "aliases": [
+      "Sunny Acres"
+    ]
+  },
+  "Sun-Street-Centers": {
+    "title": "Sun Street Centers",
+    "content": "<h2><span>Sun Street Centers</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://sunstreetcenters.org/counseling/san-luis-obispo-residential-program/\" data-external-link=\"true\">sunstreetcenters.org/counseling/san-luis-obispo-residential-program</a></li>\n<li><strong>Location:</strong> 34 Prado Rd., SLO <a class=\"map-link\" data-lat=\"35.256247\" data-lon=\"-120.672862\" data-zoom=\"17\" data-label=\"Sun Street Centers\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-457-3331\" aria-label=\"Call 805-457-3331\">805-457-3331</a> / <a href=\"tel:+1-805-457-5150\" aria-label=\"Call 805-457-5150\">805-457-5150</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:atorrente@sunstreet.org\" aria-label=\"Email atorrente@sunstreet.org\">atorrente@sunstreet.org</a> </li>\n<li><strong>Hours:</strong> 24/7 (intake: M–F 8am–5pm) </li>\n<li><strong>How to access:</strong> Get a referral from <a href=\"#\" data-directory-link=\"SLO-County-Behavioral-Health\" aria-label=\"View directory entry for SLO County Behavioral Health\"><strong>SLO County Behavioral Health</strong></a>, from your healthcare provider, or from your health insurer; you can also refer yourself </li>\n</ul>\n",
+    "aliases": [
+      "Sun Street Centers"
+    ]
+  },
+  "Supportive-Services-for-Veteran-Families": {
+    "title": "Supportive Services for Veteran Families",
+    "content": "<h2><span>Supportive Services for Veteran Families</span></h2>\n\n<ul>\n<li>5 Cities:<ul>\n<li><strong>Website:</strong> <a href=\"https://5chc.org/programs/ssvf-supportive-services-for-veteran-families\" data-external-link=\"true\">5chc.org/programs/ssvf-supportive-services-for-veteran-families</a></li>\n<li><strong>Location:</strong> 150 S. 6th St. #A-B, Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.121072\" data-lon=\"-120.624206\" data-zoom=\"17\" data-label=\"Supportive Services for Veteran Families\">Map</a> </li>\n</ul>\n \n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-574-1638\" aria-label=\"Call 805-574-1638\">805-574-1638</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-202-3056\" aria-label=\"Call 805-202-3056\">805-202-3056</a> </li>\n</ul>\n</li>\n<li>North County:<ul>\n<li><strong>Location:</strong> 935 Riverside Ave. #6, Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.624229\" data-lon=\"-120.687359\" data-zoom=\"17\" data-label=\"Supportive Services for Veteran Families\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-237-0352\" aria-label=\"Call 805-237-0352\">805-237-0352</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:jrogers@capslo.org\" aria-label=\"Email jrogers@capslo.org\">jrogers@capslo.org</a></li>\n</ul>\n</li>\n<li>SLO:<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/ssvf/\" data-external-link=\"true\">capslo.org/ssvf</a></li>\n<li><strong>Location:</strong> 265 South St. #H, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.269139\" data-lon=\"-120.666800\" data-zoom=\"17\" data-label=\"Supportive Services for Veteran Families\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-534-1698\" aria-label=\"Call 805-534-1698\">805-534-1698</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:jerwin@capslo.org\" aria-label=\"Email jerwin@capslo.org\">jerwin@capslo.org</a></li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo\"><strong>Community Action Partnership San Luis Obispo</strong></a> </li>\n<li>Operated by <a href=\"#\" data-directory-link=\"5CHC\" aria-label=\"View directory entry for 5Cities Homeless Coalition\"><strong>5Cities Homeless Coalition</strong></a> with <a href=\"#\" data-directory-link=\"Good-Samaritan-Shelter\" aria-label=\"View directory entry for Good Samaritan Shelter\"><strong>Good Samaritan Shelter</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Supportive Services for Veteran Families"
+    ]
+  },
+  "Teen-Wellness": {
+    "title": "Teen Wellness",
+    "content": "<h2><span>Teen Wellness</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://capslo.org/teen-programs-2/\" data-external-link=\"true\">capslo.org/teen-programs-2</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-602-2883\" aria-label=\"Call 805-602-2883\">805-602-2883</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:teenwellness@capslo.org\" aria-label=\"Email teenwellness@capslo.org\">teenwellness@capslo.org</a> </li>\n<li>Notes:<ul>\n<li>A program of <a href=\"#\" data-directory-link=\"CAPSLO\" aria-label=\"View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)\"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></li>\n<li>Focus on enhancing youth mental health in SLO and Northern Santa Barbara Counties</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Teen Wellness"
+    ]
+  },
+  "Templeton-Adult-School": {
+    "title": "Templeton Adult School",
+    "content": "<h2><span>Templeton Adult School</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.templetonusd.org/schools/tae/tas\" data-external-link=\"true\">templetonusd.org/schools/tae/tas</a></li>\n<li><strong>Location:</strong> 964 Old Country Road, Templeton <a href=\"#\" class=\"map-link\" data-lat=\"35.545208\" data-lon=\"-120.710961\" data-zoom=\"17\" data-label=\"Templeton Adult School\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-434-5827\" aria-label=\"Call 805-434-5827\">805-434-5827</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:clondon@templetonusd.org\" aria-label=\"Email clondon@templetonusd.org\">clondon@templetonusd.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Templeton Adult School"
+    ]
+  },
+  "TMHA": {
+    "title": "Transitions Mental Health Association (TMHA)",
+    "content": "<h2><span>Transitions Mental Health Association (TMHA)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.t-mha.org\" data-external-link=\"true\">www.t-mha.org</a></li>\n</ul>\n<table>\n<thead>\n<tr>\n<th>Office</th>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Office\">Main</td>\n<td data-label=\"Location\">784 High Street, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.272462\" data-lon=\"-120.656466\" data-zoom=\"17\" data-label=\"Transitions Mental Health Association (TMHA)\">Map</a> </td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-540-6500\" aria-label=\"Call 805-540-6500\">805-540-6500</a> </td>\n</tr>\n<tr>\n<td data-label=\"Office\">SLO</td>\n<td data-label=\"Location\">1306 Nipomo St. <a href=\"#\" class=\"map-link\" data-lat=\"35.276666\" data-lon=\"-120.663904\" data-zoom=\"17\" data-label=\"Transitions Mental Health Association (TMHA)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-541-6813\" aria-label=\"Call 805-541-6813\">805-541-6813</a> / <a href=\"tel:+1-805-801-3536\" aria-label=\"Call 805-801-3536\">805-801-3536</a></td>\n</tr>\n<tr>\n<td data-label=\"Office\">Arroyo Grande</td>\n<td data-label=\"Location\">203 Bridge St. <a href=\"#\" class=\"map-link\" data-lat=\"35.121565\" data-lon=\"-120.577572\" data-zoom=\"17\" data-label=\"Transitions Mental Health Association (TMHA)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-305-3724\" aria-label=\"Call 805-305-3724\">805-305-3724</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-540-6500\" aria-label=\"Call 805-540-6500\">805-540-6500</a><ul>\n<li><a href=\"tel:+1-800-783-0607\" aria-label=\"Call 800-783-0607\">800-783-0607</a> (24/7 crisis line) </li>\n<li><a href=\"tel:+1-805-540-0057\" aria-label=\"Call 805-540-0057\">805-540-0057</a> (library outreach team)</li>\n<li><a href=\"tel:+1-805-540-6576\" aria-label=\"Call 805-540-6576\">805-540-6576</a> (behavioral health care system navigation help)</li>\n<li><a href=\"tel:+1-805-540-6551\" aria-label=\"Call 805-540-6551\">805-540-6551</a> (Supported Employment program)</li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@t-mha.org\" aria-label=\"Email info@t-mha.org\">info@t-mha.org</a> <ul>\n<li><a href=\"mailto:mmurchison@t-mha.org\" aria-label=\"Email mmurchison@t-mha.org\">mmurchison@t-mha.org</a> (Supported Employment program)</li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–5pm</li>\n<li>Notes:<ul>\n<li>also runs “Wellness Centers” with a variety of programs <ul>\n<li>See <a href=\"https://www.t-mha.org/wellness-calendars.php\" data-external-link=\"true\">t-mha.org/wellness-calendars.php</a> for a schedule:</li>\n</ul>\n</li>\n<li>operates <a href=\"#\" data-directory-link=\"BHBH\" aria-label=\"View directory entry for Behavioral Health Bridge Housing (BHBH) Program\"><strong>Behavioral Health Bridge Housing (BHBH) Program</strong></a></li>\n<li>operates “Bishop Street Studios” </li>\n<li>operates “Growing Grounds Downtown,” “Growing Grounds Farm,” and “Growing Grounds Nursery” </li>\n<li>operates “Library Outreach Team” (see <a href=\"#\" data-directory-link=\"SLO-County-Public-Libraries\" aria-label=\"View directory entry for SLO County Public Libraries\"><strong>SLO County Public Libraries</strong></a>)</li>\n<li>operates the “Supported Employment” program </li>\n<li>operates “T-MHA Community Residential Housing” </li>\n<li>operates “VetWell”</li>\n<li>entry-point for the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Transitions Mental Health Association (TMHA)"
+    ]
+  },
+  "Tri-Counties-Regional-Center": {
+    "title": "Tri Counties Regional Center",
+    "content": "<h2><span>Tri Counties Regional Center</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.tri-counties.org\" data-external-link=\"true\">tri-counties.org</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">(main office) 520 E. Montecito St., Santa Barbara <a href=\"#\" class=\"map-link\" data-lat=\"34.420363\" data-lon=\"-119.686756\" data-zoom=\"17\" data-label=\"Tri Counties Regional Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-962-7881\" aria-label=\"Call 805-962-7881\">805-962-7881</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">7305 Morro Rd. #101, Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.478709\" data-lon=\"-120.666798\" data-zoom=\"17\" data-label=\"Tri Counties Regional Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-461-7402\" aria-label=\"Call 805-461-7402\">805-461-7402</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">1146 Farmhouse Ln., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.239987\" data-lon=\"-120.634147\" data-zoom=\"17\" data-label=\"Tri Counties Regional Center\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-543-2833\" aria-label=\"Call 805-543-2833\">805-543-2833</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Hours:</strong> M–F 8:30am–5pm </li>\n<li><strong>How to access:</strong> Apply at <a href=\"https://www.tri-counties.org/our-services/apply/\" data-external-link=\"true\">tri-counties.org/our-services/apply/</a></li>\n</ul>\n",
+    "aliases": [
+      "Tri Counties Regional Center"
+    ]
+  },
+  "Trinity-United-Methodist-Church": {
+    "title": "Trinity United Methodist Church (Los Osos)",
+    "content": "<h2><span>Trinity United Methodist Church (Los Osos)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://trinitylososos.org/\" data-external-link=\"true\">trinitylososos.org</a></li>\n<li><strong>Location:</strong> 490 Los Osos Valley Rd., Los Osos <a class=\"map-link\" data-lat=\"35.313346\" data-lon=\"-120.845536\" data-zoom=\"17\" data-label=\"Trinity United Methodist Church (Los Osos)\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-528-1649\" aria-label=\"Call 805-528-1649\">805-528-1649</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:church@trinitylososos.org\" aria-label=\"Email church@trinitylososos.org\">church@trinitylososos.org</a> </li>\n<li>Hours (food pantry): Tu/F 10am–Noon </li>\n</ul>\n",
+    "aliases": [
+      "Trinity United Methodist Church (Los Osos)"
+    ]
+  },
+  "Tri-County-GLAD": {
+    "title": "Tri-County GLAD",
+    "content": "<h2><span>Tri-County GLAD</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://tcglad.org/\" data-external-link=\"true\">tcglad.org</a></li>\n<li><strong>Location:</strong> 702 County Square Dr. #101, Ventura <a href=\"#\" class=\"map-link\" data-lat=\"34.269044\" data-lon=\"-119.214757\" data-zoom=\"17\" data-label=\"Tri-County GLAD\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-256-1053\" aria-label=\"Call 805-256-1053\">805-256-1053</a> (videophone) </li>\n<li><a href=\"tel:+1-805-644-6323\" aria-label=\"Call 805-644-6323\">805-644-6323</a> (TTY) </li>\n<li><a href=\"tel:+1-805-644-6322\" aria-label=\"Call 805-644-6322\">805-644-6322</a> (voice)</li>\n</ul>\n</li>\n<li><strong>Email:</strong> <a href=\"mailto:info@tcglad.org\" aria-label=\"Email info@tcglad.org\">info@tcglad.org</a> </li>\n<li><strong>Hours:</strong> M–F 8:30am–5pm (closed Noon–1pm) </li>\n</ul>\n",
+    "aliases": [
+      "Tri-County GLAD"
+    ]
+  },
+  "TranzCentralCoast": {
+    "title": "TranzCentralCoast",
+    "content": "<h2><span>TranzCentralCoast</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.tranzcentralcoast.org/\" data-external-link=\"true\">tranzcentralcoast.org</a> {not working as of 2 Dec 2025}</li>\n<li><strong>Location:</strong> 1060 Palm St., SLO <a class=\"map-link\" data-lat=\"35.283421\" data-lon=\"-120.661309\" data-zoom=\"17\" data-label=\"TranzCentralCoast\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-242-3821\" aria-label=\"Call 805-242-3821\">805-242-3821</a> { Source: <a href=\"https://www.facebook.com/tranz.coast/\" data-external-link=\"true\">https://www.facebook.com/tranz.coast/</a> }</li>\n<li><strong>Email:</strong> <a href=\"mailto:TranzCentralCoast@gmail.com\" aria-label=\"Email TranzCentralCoast@gmail.com\">TranzCentralCoast@gmail.com</a> { Source: <a href=\"https://www.facebook.com/tranz.coast/\" data-external-link=\"true\">https://www.facebook.com/tranz.coast/</a> }\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "TranzCentralCoast"
+    ]
+  },
+  "UC-Cooperative-Extension": {
+    "title": "U.C. Cooperative Extension — SLO County",
+    "content": "<h2><span>U.C. Cooperative Extension — SLO County</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://cesanluisobispo.ucanr.edu/\" data-external-link=\"true\">cesanluisobispo.ucanr.edu</a></li>\n<li><strong>Location:</strong> 2156 Sierra Way #C, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274187\" data-lon=\"-120.647553\" data-zoom=\"17\" data-label=\"U.C. Cooperative Extension\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5940\" aria-label=\"Call 805-781-5940\">805-781-5940</a> </li>\n<li>Notes: Research-based educational programs including Master Gardener Program, Master Food Preserver Program, Forest Stewardship Workshops, agriculture, and horticulture; cost varies by program</li>\n</ul>\n",
+    "aliases": [
+      "U.C. Cooperative Extension — SLO County"
+    ]
+  },
+  "UUSLO": {
+    "title": "Unitarian Universalists San Luis Obispo",
+    "content": "<h2><span>Unitarian Universalists San Luis Obispo</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://uuslo.org/\" data-external-link=\"true\">uuslo.org</a></li>\n<li><strong>Location:</strong> 2201 Lawton Avenue <a class=\"map-link\" data-lat=\"35.269386\" data-lon=\"-120.657033\" data-zoom=\"17\" data-label=\"Unitarian Universalists San Luis Obispo\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-439-0188\" aria-label=\"Call 805-439-0188\">805-439-0188</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:minister.uuslo@gmail.com\" aria-label=\"Email minister.uuslo@gmail.com\">minister.uuslo@gmail.com</a> </li>\n<li><strong>Hours:</strong><ul>\n<li>We Care Foodshare food pantry: W 3–4:30pm </li>\n<li>Refugee and Immigrant Services Education: first &amp; third Sunday each month, 12:30–2:30pm </li>\n</ul>\n</li>\n<li><strong>How to access:</strong><ul>\n<li>We Care Foodshare food pantry: arrive during hours of operation </li>\n<li>Minister’s Discretionary Fund: email with a specific request </li>\n<li>Refugee and Immigrant Services Education: arrive during hours of operation (no appointment necessary) </li>\n</ul>\n</li>\n<li>Notes:<ul>\n<li>operates the “Minister’s Discretionary Fund,” “Refugee and Immigrant Services Education,” and “We Care Foodshare” </li>\n<li>hosts <a href=\"#\" data-directory-link=\"Shower-the-People\" aria-label=\"View directory entry for Shower the People\"><strong>Shower the People</strong></a> on Tuesdays and Thursdays </li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Unitarian Universalists San Luis Obispo"
+    ]
+  },
+  "UnitedHealthcare-Childrens-Foundation": {
+    "title": "UnitedHealthcare Children’s Foundation",
+    "content": "<h2><span>UnitedHealthcare Children’s Foundation</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.uhccf.org/\" data-external-link=\"true\">uhccf.org</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-855-698-4223\" aria-label=\"Call 855-698-4223\">855-698-4223</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:uhccfcustomerservice@uhc.com\" aria-label=\"Email uhccfcustomerservice@uhc.com\">uhccfcustomerservice@uhc.com</a> </li>\n</ul>\n",
+    "aliases": [
+      "UnitedHealthcare Children’s Foundation"
+    ]
+  },
+  "United-Voluntary-Services-Thrift": {
+    "title": "United Voluntary Services Thrift",
+    "content": "<h2><span>United Voluntary Services Thrift</span></h2>\n<ul>\n<li><strong>Location:</strong> 474 Marsh St., SLO <a class=\"map-link\" data-lat=\"35.276489\" data-lon=\"-120.667039\" data-zoom=\"17\" data-label=\"United Voluntary Services Thrift\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-1545\" aria-label=\"Call 805-543-1545\">805-543-1545</a> </li>\n<li><strong>Hours:</strong> M–Sa 11am–3pm </li>\n</ul>\n",
+    "aliases": [
+      "United Voluntary Services Thrift"
+    ]
+  },
+  "United-Way": {
+    "title": "United Way",
+    "content": "<h2><span>United Way</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://unitedwayslo.org/\" data-external-link=\"true\">unitedwayslo.org</a><ul>\n<li><a href=\"https://unitedwayslo.org/family-financial-stability/taxes/\" data-external-link=\"true\">tax return assistance program</a></li>\n</ul>\n</li>\n<li><strong>Location:</strong> 1288 Morro St. #10, SLO <a class=\"map-link\" data-lat=\"35.279286\" data-lon=\"-120.660392\" data-zoom=\"17\" data-label=\"United Way\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-541-1234\" aria-label=\"Call 805-541-1234\">805-541-1234</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@unitedwayslo.org\" aria-label=\"Email info@unitedwayslo.org\">info@unitedwayslo.org</a> <ul>\n<li>tax return assistance program: <a href=\"mailto:taxes@unitedwayslo.org\" aria-label=\"Email taxes@unitedwayslo.org\">taxes@unitedwayslo.org</a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "United Way"
+    ]
+  },
+  "Urgent-Care": {
+    "title": "Urgent Care",
+    "content": "<h2><span>Urgent Care</span></h2>\n<p>There are several urgent care options, including:</p>\n<ul>\n<li><a href=\"#\" data-directory-link=\"CHC\" aria-label=\"View directory entry for Community Health Center\"><strong>Community Health Center</strong></a> (Arroyo Grande)</li>\n<li><a href=\"#\" data-directory-link=\"Carbon-Health-Urgent-Care-Atascadero\" aria-label=\"View directory entry for Carbon Health Urgent Care\"><strong>Carbon Health Urgent Care</strong></a> (Atascadero)</li>\n<li><a href=\"#\" data-directory-link=\"Dignity-Health-Urgent-Care\" aria-label=\"View directory entry for Dignity Health Urgent Care\"><strong>Dignity Health Urgent Care</strong></a> (Atascadero)</li>\n<li><a href=\"#\" data-directory-link=\"Urgent-Care-of-Atascadero\" aria-label=\"View directory entry for Urgent Care of Atascadero\"><strong>Urgent Care of Atascadero</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Urgent-Care-of-Morro-Bay\" aria-label=\"View directory entry for Urgent Care of Morro Bay\"><strong>Urgent Care of Morro Bay</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Carbon-Health-Urgent-Care-Paso-Robles\" aria-label=\"View directory entry for Carbon Health Urgent Care\"><strong>Carbon Health Urgent Care</strong></a> (Paso Robles)</li>\n<li><a href=\"#\" data-directory-link=\"CHC\" aria-label=\"View directory entry for Community Health Center\"><strong>Community Health Center</strong></a> (Paso Robles)</li>\n<li><a href=\"#\" data-directory-link=\"North-County-Care\" aria-label=\"View directory entry for North County Care Minor Emergency Services\"><strong>North County Care Minor Emergency Services</strong></a> (Paso Robles)</li>\n<li><a href=\"#\" data-directory-link=\"Dignity-Health-Urgent-Care\" aria-label=\"View directory entry for Dignity Health Urgent Care\"><strong>Dignity Health Urgent Care</strong></a> (Pismo Beach)</li>\n<li><a href=\"#\" data-directory-link=\"Urgent-Care-Pismo-Beach\" aria-label=\"View directory entry for Urgent Care Pismo Beach\"><strong>Urgent Care Pismo Beach</strong></a></li>\n<li><a href=\"#\" data-directory-link=\"Cottage-Urgent-Care\" aria-label=\"View directory entry for Cottage Urgent Care\"><strong>Cottage Urgent Care</strong></a> (SLO)</li>\n<li><a href=\"#\" data-directory-link=\"Family-and-Industrial-Medical-Center\" aria-label=\"View directory entry for Family and Industrial Medical Center\"><strong>Family and Industrial Medical Center</strong></a> (SLO)</li>\n<li><a href=\"#\" data-directory-link=\"MedStop\" aria-label=\"View directory entry for MedStop\"><strong>MedStop</strong></a> (SLO)</li>\n<li><a href=\"#\" data-directory-link=\"CHC\" aria-label=\"View directory entry for Community Health Center\"><strong>Community Health Center</strong></a> (Templeton)</li>\n</ul>\n",
+    "aliases": [
+      "Urgent Care"
+    ]
+  },
+  "Urgent-Care-of-Atascadero": {
+    "title": "Urgent Care of Atascadero",
+    "content": "<h2><span>Urgent Care of Atascadero</span></h2>\n<ul>\n<li><strong>Location:</strong> 9700 El Camino Real #100, Atascadero <a class=\"map-link\" data-lat=\"35.464970\" data-lon=\"-120.648491\" data-zoom=\"17\" data-label=\"Urgent Care of Atascadero\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-466-1330\" aria-label=\"Call 805-466-1330\">805-466-1330</a> </li>\n<li><strong>Hours:</strong> M–Sa 7am–6:30pm, Su 8am–3:30pm </li>\n<li><strong>How to access:</strong> Walk-ins accepted until 30 minutes before closing</li>\n<li>Notes: Accepts Medicare and Medi-Cal; most insurances accepted — call to verify coverage</li>\n</ul>\n",
+    "aliases": [
+      "Urgent Care of Atascadero"
+    ]
+  },
+  "Urgent-Care-of-Morro-Bay": {
+    "title": "Urgent Care of Morro Bay",
+    "content": "<h2><span>Urgent Care of Morro Bay</span></h2>\n<ul>\n<li><strong>Location:</strong> 783 Quintana Rd., Morro Bay <a class=\"map-link\" data-lat=\"35.367708\" data-lon=\"-120.842253\" data-zoom=\"17\" data-label=\"Urgent Care of Morro Bay\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-771-0108\" aria-label=\"Call 805-771-0108\">805-771-0108</a> </li>\n<li><strong>Hours:</strong> M–Sa 7am–6:30pm, Su 8am–3:30pm </li>\n<li>Notes: Accepts Medicare and Medi-Cal</li>\n</ul>\n",
+    "aliases": [
+      "Urgent Care of Morro Bay"
+    ]
+  },
+  "Urgent-Care-Pismo-Beach": {
+    "title": "Urgent Care Pismo Beach",
+    "content": "<h2><span>Urgent Care Pismo Beach</span></h2>\n<ul>\n<li><strong>Location:</strong> 2 James Way #214, Pismo Beach <a class=\"map-link\" data-lat=\"35.138798\" data-lon=\"-120.632225\" data-zoom=\"17\" data-label=\"Urgent Care Pismo Beach\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-295-6594\" aria-label=\"Call 805-295-6594\">805-295-6594</a> </li>\n<li><strong>Hours:</strong> M–Sa. 7am–6:30pm, Su. 8am–3:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Urgent Care Pismo Beach"
+    ]
+  },
+  "Veterans-Administration-Outpatient-Clinic": {
+    "title": "Veterans Administration Outpatient Clinic",
+    "content": "<h2><span>Veterans Administration Outpatient Clinic</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.va.gov/greater-los-angeles-health-care/locations/san-luis-obispo-va-clinic/\" data-external-link=\"true\">va.gov/greater-los-angeles-health-care/locations/san-luis-obispo-va-clinic</a></li>\n<li><strong>Location:</strong> 1288 Morro St. #200, SLO <a class=\"map-link\" data-lat=\"35.279286\" data-lon=\"-120.660392\" data-zoom=\"17\" data-label=\"Veterans Administration Outpatient Clinic\">Map</a> </li>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-543-1233\" aria-label=\"Call 805-543-1233\">805-543-1233</a> (main) </li>\n<li><a href=\"tel:+1-877-252-4866\" aria-label=\"Call 877-252-4866\">877-252-4866</a> (VA health connect) </li>\n<li><a href=\"tel:+1-877-251-7295\" aria-label=\"Call 877-251-7295\">877-251-7295</a> (mental health) </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–F 8am–4:30pm </li>\n</ul>\n",
+    "aliases": [
+      "Veterans Administration Outpatient Clinic"
+    ]
+  },
+  "Veterans-Services": {
+    "title": "Veterans Services (SLO County)",
+    "content": "<h2><span>Veterans Services (SLO County)</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/veterans-services\" data-external-link=\"true\">slocounty.ca.gov/Departments/Veterans-Services</a></li>\n<li><strong>Locations:</strong><ul>\n<li>800 West Branch St., Arroyo Grande <a href=\"#\" class=\"map-link\" data-lat=\"35.124547\" data-lon=\"-120.589385\" data-zoom=\"17\" data-label=\"Veterans Services\">Map</a> (currently closed for renovations) </li>\n<li>240 Scott St., Paso Robles <a href=\"#\" class=\"map-link\" data-lat=\"35.608124\" data-lon=\"-120.655868\" data-zoom=\"17\" data-label=\"Veterans Services\">Map</a> (Tu–Th 8am–5pm) </li>\n<li>801 Grand Ave., SLO <a class=\"map-link\" data-lat=\"35.288803\" data-lon=\"-120.652687\" data-zoom=\"17\" data-label=\"Veterans Services\">Map</a> (daily 8am–5pm) </li>\n</ul>\n</li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5766\" aria-label=\"Call 805-781-5766\">805-781-5766</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:slovets@co.slo.ca.us\" aria-label=\"Email slovets@co.slo.ca.us\">slovets@co.slo.ca.us</a></li>\n<li><strong>How to access:</strong> In-person and phone appointments only; no walk-ins; book appointments <a href=\"https://sanluisobispocountyveteransservices.as.me/schedule/970de54e\" data-external-link=\"true\">online</a> or by phone</li>\n<li>Notes: SLO office has a small <a href=\"https://www.slocounty.ca.gov/departments/veterans-services/veterans-services-food-pantry\" data-external-link=\"true\">food pantry</a></li>\n</ul>\n",
+    "aliases": [
+      "Veterans Services (SLO County)"
+    ]
+  },
+  "Veterans-Transportation-Service": {
+    "title": "Veterans Transportation Service",
+    "content": "<h2><span>Veterans Transportation Service</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.vetride.va.gov/\" data-external-link=\"true\">vetride.va.gov</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-1233\" aria-label=\"Call 805-543-1233\">805-543-1233</a></li>\n</ul>\n\n\n",
+    "aliases": [
+      "Veterans Transportation Service"
+    ]
+  },
+  "Veterans-Volunteer-Services": {
+    "title": "Veterans Volunteer Services",
+    "content": "<h2><span>Veterans Volunteer Services</span></h2>\n<ul>\n<li><strong>Location:</strong> Arroyo Grande <a class=\"map-link\" data-lat=\"35.123537\" data-lon=\"-120.578580\" data-zoom=\"17\" data-label=\"Veterans Volunteer Services\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-481-2622\" aria-label=\"Call 805-481-2622\">805-481-2622</a></li>\n<li><strong>How to access:</strong> No walk-ins; call to make an appointment\n--&gt;</li>\n</ul>\n",
+    "aliases": [
+      "Veterans Volunteer Services"
+    ]
+  },
+  "Victim-Witness-Assistance-Program": {
+    "title": "Victim Witness Assistance Program",
+    "content": "<h2><span>Victim Witness Assistance Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center\" data-external-link=\"true\">slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center</a></li>\n<li><strong>Location:</strong> 1050 Monterey St. (Courthouse Annex Room 384), SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.282937\" data-lon=\"-120.661267\" data-zoom=\"17\" data-label=\"Victim Witness Assistance Program\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-781-5821\" aria-label=\"Call 805-781-5821\">805-781-5821</a> (toll-free: <a href=\"tel:+1-866-781-5821\" aria-label=\"Call 866-781-5821\">866-781-5821</a>) </li>\n</ul>\n",
+    "aliases": [
+      "Victim Witness Assistance Program"
+    ]
+  },
+  "Vituity-Cares-Mobile-Clinic": {
+    "title": "Vituity Cares Mobile Clinic",
+    "content": "<h2><span>Vituity Cares Mobile Clinic</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://vituitycares.org/\" data-external-link=\"true\">vituitycares.org</a></li>\n<li><strong>Location:</strong> 995 Palm St., SLO <a class=\"map-link\" data-lat=\"35.282263\" data-lon=\"-120.662223\" data-zoom=\"17\" data-label=\"Vituity Cares Mobile Clinic\">Map</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-480-828-4319\" aria-label=\"Call 480-828-4319\">480-828-4319</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:vituitycares@gmail.com\" aria-label=\"Email vituitycares@gmail.com\">vituitycares@gmail.com</a> </li>\n<li><strong>Hours:</strong> Second Sunday of the month, 12:30–3:30 pm</li>\n</ul>\n",
+    "aliases": [
+      "Vituity Cares Mobile Clinic"
+    ]
+  },
+  "Helping-Friends-Program": {
+    "title": "Voice for the Animals Helping Friends Program",
+    "content": "<h2><span>Voice for the Animals Helping Friends Program</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.vftafoundation.org/helping_friends\" data-external-link=\"true\">www.vftafoundation.org/helping_friends</a></li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-310-392-5153\" aria-label=\"Call 310-392-5153\">310-392-5153</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:info@vftafoundation.org\" aria-label=\"Email info@vftafoundation.org\">info@vftafoundation.org</a> </li>\n</ul>\n",
+    "aliases": [
+      "Voice for the Animals Helping Friends Program"
+    ]
+  },
+  "Womenade": {
+    "title": "Womenade",
+    "content": "<h2><span>Womenade</span></h2>\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Website</th>\n<th>Location</th>\n<th>Phone</th>\n<th>Email</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">SLO city</td>\n<td data-label=\"Website\"><a href=\"https://www.womenadeslo.org/\" data-external-link=\"true\">womenadeslo.org</a></td>\n<td data-label=\"Location\">6099 Marshall Way, SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.213169\" data-lon=\"-120.622298\" data-zoom=\"17\" data-label=\"Womenade\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-674-9450\" aria-label=\"Call 805-674-9450\">805-674-9450</a></td>\n<td data-label=\"Email\"><a href=\"mailto:elaine@womenadeslo.org\" aria-label=\"Email elaine@womenadeslo.org\">elaine@womenadeslo.org</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">South SLO County</td>\n<td data-label=\"Website\"><a href=\"https://www.sslocw.org/\" data-external-link=\"true\">sslocw.org</a></td>\n<td data-label=\"Location\">1793 Farroll Road, Grover Beach <a href=\"#\" class=\"map-link\" data-lat=\"35.112441\" data-lon=\"-120.609956\" data-zoom=\"17\" data-label=\"Womenade\">Map</a></td>\n<td data-label=\"Phone\"></td>\n<td data-label=\"Email\"><a href=\"mailto:sslocwomenade@gmail.com\" aria-label=\"Email sslocwomenade@gmail.com\">sslocwomenade@gmail.com</a></td>\n</tr>\n</tbody></table>\n",
+    "aliases": [
+      "Womenade"
+    ]
+  },
+  "Waterman-Village": {
+    "title": "Waterman Village",
+    "content": "<h2><span>Waterman Village</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.smartsharehousingsolutions.org/co-living-collaborative\" data-external-link=\"true\">smartsharehousingsolutions.org/co-living-collaborative</a></li>\n<li><strong>Location:</strong> 466 Dana St., SLO <a class=\"map-link\" data-lat=\"35.278012\" data-lon=\"-120.669144\" data-zoom=\"17\" data-label=\"Waterman Village\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-215-5474\" aria-label=\"Call 805-215-5474\">805-215-5474</a> </li>\n<li>Notes: A project of <a href=\"#\" data-directory-link=\"SmartShare-Housing-Solutions\" aria-label=\"View directory entry for SmartShare Housing Solutions\"><strong>SmartShare Housing Solutions</strong></a></li>\n</ul>\n",
+    "aliases": [
+      "Waterman Village"
+    ]
+  },
+  "Welcome-Home-Village": {
+    "title": "Welcome Home Village",
+    "content": "<h2><span>Welcome Home Village</span></h2>\n\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/welcomehomevillage.aspx\" data-external-link=\"true\">slocounty.ca.gov/welcomehomevillage</a></li>\n<li><strong>Location:</strong> Health Agency Campus, intersection of Johnson Ave. &amp; Bishop St., SLO <a href=\"#\" class=\"map-link\" data-lat=\"35.274108\" data-lon=\"-120.645697\" data-zoom=\"17\" data-label=\"Welcome Home Village\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-591-4544\" aria-label=\"Call 805-591-4544\">805-591-4544</a> (Margaret Shepard-Moore, Program Manager) </li>\n<li><strong>Email:</strong> <a href=\"mailto:mshepard-moore@co.slo.ca.us\" aria-label=\"Email mshepard-moore@co.slo.ca.us\">mshepard-moore@co.slo.ca.us</a> </li>\n<li><strong>How to access:</strong> Through the <a href=\"#\" data-directory-link=\"CES\" aria-label=\"View directory entry for Coordinated Entry System (CES)\"><strong>Coordinated Entry System (CES)</strong></a> or contact City of SLO Homelessness Response Team for outreach</li>\n<li>Notes:<ul>\n<li>Operated by <a href=\"#\" data-directory-link=\"Good-Samaritan-Shelter\" aria-label=\"View directory entry for Good Samaritan Shelter\"><strong>Good Samaritan Shelter</strong></a></li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Welcome Home Village"
+    ]
+  },
+  "WIC": {
+    "title": "Women, Infants, and Children (WIC)",
+    "content": "<h2><span>Women, Infants, and Children (WIC)</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-promotion/women,-infants-and-children-%28wic%29\" data-external-link=\"true\">Slocountygov/wic</a></li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">Atascadero: 5575 Hospital Dr. <a href=\"#\" class=\"map-link\" data-lat=\"35.492648\" data-lon=\"-120.662938\" data-zoom=\"17\" data-label=\"Women, Infants, and Children (WIC)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-237-3065\" aria-label=\"Call 805-237-3065\">805-237-3065</a> or <a href=\"tel:+1-805-781-5570\" aria-label=\"Call 805-781-5570\">805-781-5570</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Grover Beach: 286 S. 16th St. #B <a href=\"#\" class=\"map-link\" data-lat=\"35.119277\" data-lon=\"-120.611998\" data-zoom=\"17\" data-label=\"Women, Infants, and Children (WIC)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-473-7130\" aria-label=\"Call 805-473-7130\">805-473-7130</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">Paso Robles: 805 4th St. #B <a href=\"#\" class=\"map-link\" data-lat=\"35.618660\" data-lon=\"-120.689219\" data-zoom=\"17\" data-label=\"Women, Infants, and Children (WIC)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-237-3065\" aria-label=\"Call 805-237-3065\">805-237-3065</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">SLO: 2191 Johnson Ave. <a href=\"#\" class=\"map-link\" data-lat=\"35.274391\" data-lon=\"-120.646730\" data-zoom=\"17\" data-label=\"Women, Infants, and Children (WIC)\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-781-5570\" aria-label=\"Call 805-781-5570\">805-781-5570</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Phone:</strong><ul>\n<li><a href=\"tel:+1-805-781-5570\" aria-label=\"Call 805-781-5570\">805-781-5570</a> </li>\n<li>Text: <a href=\"sms:+1-888-417-6180\">888-417-6180</a> </li>\n</ul>\n</li>\n<li><strong>Hours:</strong> M–Th 8am–5pm; Fri. 8am–4:30pm (closed on the last Wednesday of the month) </li>\n<li><strong>How to access:</strong> by appointment only (call or text to make an appointment) </li>\n<li>Eligibility: This program is restricted to people for whom both of the following requirements are true:<ul>\n<li>You are pregnant, breastfeeding, gave birth or had a pregnancy loss in the past six months, or you care for a child under the age of five</li>\n<li>And you live in California and have income below a certain threshold, or receive Medi-Cal, <a href=\"#\" data-directory-link=\"CalWORKs\" aria-label=\"View directory entry for CalWORKs\">CalWORKs</a>, or CalFresh benefits.</li>\n</ul>\n</li>\n</ul>\n",
+    "aliases": [
+      "Women, Infants, and Children (WIC)"
+    ]
+  },
+  "Woods-Humane-Society": {
+    "title": "Woods Humane Society",
+    "content": "<h2><span>Woods Humane Society</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://woodshumanesociety.org/\" data-external-link=\"true\">woodshumanesociety.org</a><ul>\n<li><a href=\"https://woodshumanesociety.org/pet-pantry/\" data-external-link=\"true\">Pet Pantry</a></li>\n</ul>\n</li>\n</ul>\n\n<table>\n<thead>\n<tr>\n<th>Location</th>\n<th>Phone</th>\n</tr>\n</thead>\n<tbody><tr>\n<td data-label=\"Location\">2300 Ramona Rd., Atascadero <a href=\"#\" class=\"map-link\" data-lat=\"35.510264\" data-lon=\"-120.698978\" data-zoom=\"17\" data-label=\"Woods Humane Society\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-466-5403\" aria-label=\"Call 805-466-5403\">805-466-5403</a></td>\n</tr>\n<tr>\n<td data-label=\"Location\">875 Oklahoma Ave, SLO <a class=\"map-link\" data-lat=\"35.318418\" data-lon=\"-120.715209\" data-zoom=\"17\" data-label=\"Woods Human Society\">Map</a></td>\n<td data-label=\"Phone\"><a href=\"tel:+1-805-543-9316\" aria-label=\"Call 805-543-9316\">805-543-9316</a></td>\n</tr>\n</tbody></table>\n<ul>\n<li><strong>Email:</strong> <a href=\"mailto:rcoleman@woodshumanesociety.org\" aria-label=\"Email rcoleman@woodshumanesociety.org\">rcoleman@woodshumanesociety.org</a> (Robin Coleman, Community Engagement Manager)</li>\n<li><strong>Hours:</strong> (adoption) daily 11am–4pm (Atascadero) or daily Noon–4pm (SLO) </li>\n</ul>\n",
+    "aliases": [
+      "Woods Humane Society"
+    ]
+  },
+  "Zion-Lutheran-Church": {
+    "title": "Zion Lutheran Church",
+    "content": "<h2><span>Zion Lutheran Church</span></h2>\n<ul>\n<li><strong>Website:</strong> <a href=\"https://www.zionslo.com/\" data-external-link=\"true\">zionslo.com</a></li>\n<li><strong>Location:</strong> 1010 Foothill Blvd., SLO <a class=\"map-link\" data-lat=\"35.294563\" data-lon=\"-120.667386\" data-zoom=\"17\" data-label=\"Zion Lutheran Church\">Map</a> </li>\n<li><strong>Phone:</strong> <a href=\"tel:+1-805-543-8327\" aria-label=\"Call 805-543-8327\">805-543-8327</a> </li>\n<li><strong>Email:</strong> <a href=\"mailto:zion@zionslo.com\" aria-label=\"Email zion@zionslo.com\">zion@zionslo.com</a> </li>\n<li><strong>Hours</strong> (food pantry): W 9:30–11:30am </li>\n</ul>\n",
+    "aliases": [
+      "Zion Lutheran Church"
+    ]
+  }
+}

--- a/web-app/public/processed/directory.html
+++ b/web-app/public/processed/directory.html
@@ -1,0 +1,5055 @@
+<h1><span><a id="directory">Directory</a></span></h1>
+<h2><span><a id="40-Prado">40 Prado Homeless Services Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/40-prado/" data-external-link="true">capslo.org/40-prado</a></li>
+<li><strong>Location:</strong> 40 Prado Road, SLO <a href="#" class="map-link" data-lat="35.256218" data-lon="-120.672031" data-zoom="17" data-label="40 Prado Homeless Services Center">Map</a></li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-544-4004;ext=2" aria-label="Call 805-544-4004 x2">805-544-4004 x2</a> (general services) </li>
+<li><a href="tel:+1-805-544-4004;ext=100" aria-label="Call 805-544-4004 x100">805-544-4004 x100</a> (more information)</li>
+<li><a href="tel:+1-805-459-1073" aria-label="Call 805-459-1073">805-459-1073</a> (questions about on-site safe parking)</li>
+</ul>
+</li>
+<li><strong>Hours:</strong> every day, 8am–2:30pm and 4:30pm–7am (closed 2:30pm–4:30pm and 7–8am) <ul>
+<li>Overnight shelter intake: M–Th 9am–2pm, Fridays by appointment only  (Intake is a one-time registration process where you provide personal information, complete paperwork, and get added to the shelter system)</li>
+<li>Laundry services: 8am–2:30pm</li>
+<li>Day services: 8am–4pm </li>
+<li>Breakfast: before 9am </li>
+<li>Lunch: Noon–12:30pm (open to all) </li>
+<li>Overnight shelter check-in: daily, 4:30–6pm (Check-in is done each day you want a bed; you must arrive during check-in hours to secure a spot for that night)</li>
+<li>Dinner: 5–5:30pm (overnight shelter and cooling center residents only)</li>
+<li>Warming Center: 7pm–8am (only when warming center is in operation) </li>
+<li>Cooling Center: 8am–6pm (only when cooling center is in operation) </li>
+<li>Safe Parking: 6pm–7pm </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> come to the shelter during intake hours<ul>
+<li>To use the shelter, you must be homeless, you must have a valid photo ID, and you must not have a P.C. 290 sex offender criminal record. You must be able to care for yourself independently (bathing, feeding, dressing, etc.). There are a limited number of beds; priority is given to SLO county residents.</li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>operates <a href="#" data-directory-link="Rotating-Overnight-Safe-Parking-Program" aria-label="View directory entry for Rotating Overnight Safe Parking Program"><strong>Rotating Overnight Safe Parking Program</strong></a></li>
+<li>operates <a href="#" data-directory-link="SLO-Hub" aria-label="View directory entry for SLO Hub"><strong>SLO Hub</strong></a> </li>
+<li>operates the “Mid County Warming and Cooling Center” </li>
+<li>operates the “40 Prado Safe Parking Program” </li>
+<li><a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> takes place at 40 Prado</li>
+<li><a href="#" data-directory-link="Peoples-Kitchen-SLO" aria-label="View directory entry for People’s Kitchen"><strong>People’s Kitchen</strong></a> takes place at 43 Prado </li>
+<li><a href="#" data-directory-link="Recuperative-Care-Program" aria-label="View directory entry for Recuperative Care Program"><strong>Recuperative Care Program</strong></a> takes place at 40 Prado </li>
+</ul>
+</li>
+</ul>
+<h2><span>50 Now</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Housing-Now" aria-label="View directory entry for Housing Now"><strong>Housing Now</strong></a></em></p>
+</blockquote>
+<h2><span><a id="5CHC">5Cities Homeless Coalition (5CHC)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://5chc.org/" data-external-link="true">5chc.org</a></li>
+<li><strong>Location:</strong> 100 South 4th St., Grover Beach <a href="#" class="map-link" data-lat="35.1212032" data-lon="-120.6267386" data-zoom="17" data-label="5Cities Homeless Coalition">Map</a> <ul>
+<li>Warming Center: 1023 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.118597" data-lon="-120.594462" data-zoom="17" data-label="5Cities Homeless Coalition Warming Center">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-574-1638" aria-label="Call 805-574-1638">805-574-1638</a> </li>
+<li><a href="tel:+1-805-202-3615" aria-label="Call 805-202-3615">805-202-3615</a> (warming center hotline) </li>
+<li><a href="tel:+1-805-295-1501" aria-label="Call 805-295-1501">805-295-1501</a> (warming center) </li>
+<li><a href="sms:+1-805-295-1501?&amp;body=Add%20Me">805-295-1501</a> (warming center automatic text updates) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@5chc.org" aria-label="Email info@5chc.org">info@5chc.org</a> <ul>
+<li><a href="mailto:shelter@5chc.org" aria-label="Email shelter@5chc.org">shelter@5chc.org</a> (warming center) </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>operates <a href="#" data-directory-link="Cabins-for-Change" aria-label="View directory entry for Cabins for Change"><strong>Cabins for Change</strong></a> and “Balay Ko on Barka” a.k.a. “My Home for Hope”</li>
+<li>operates <a href="#" data-directory-link="Supportive-Services-for-Veteran-Families" aria-label="View directory entry for Supportive Services for Veteran Families"><strong>Supportive Services for Veteran Families</strong></a></li>
+<li>operates “Homeless Youth Outreach”</li>
+<li>hosts the “Pet Resource Center” of <a href="#" data-directory-link="C.A.R.E.4Paws" aria-label="View directory entry for C.A.R.E.4Paws"><strong>C.A.R.E.4Paws</strong></a> </li>
+<li>entry-point for the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span>70 Now</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Housing-Now" aria-label="View directory entry for Housing Now"><strong>Housing Now</strong></a></em></p>
+</blockquote>
+<h2><span><a id="805-Street-Outreach">805 Street Outreach</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://805streetoutreach.org/" data-external-link="true">805streetoutreach.org</a></li>
+<li><strong>Email:</strong> <a href="mailto:izzy@805streetoutreach.org" aria-label="Email izzy@805streetoutreach.org">izzy@805streetoutreach.org</a> </li>
+<li>Shower program:<ul>
+<li><strong>Location:</strong> Morro Bay Public Library parking lot, 625 Harbor St., Morro Bay <a href="#" class="map-link" data-lat="35.3671654" data-lon="-120.8462354" data-zoom="17" data-label="Morro Bay Public Library (805 Street Outreach)">Map</a> </li>
+<li><strong>Hours:</strong> Every Monday, 12pm–3pm </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Abundance-Shop">Abundance Shop</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.stbenslososos.org/abundance-shop/" data-external-link="true">stbenslososos.org/abundance-shop</a></li>
+<li><strong>Location:</strong> 2025 9th St., Los Osos <a href="#" class="map-link" data-lat="35.3144169" data-lon="-120.8335942" data-zoom="17" data-label="Abundance Shop">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-528-1370" aria-label="Call 805-528-1370">805-528-1370</a> </li>
+<li><strong>Email:</strong> <a href="mailto:office@stbenslososos.org" aria-label="Email office@stbenslososos.org">office@stbenslososos.org</a></li>
+<li><strong>Hours:</strong> Th–Sa 11am–4pm </li>
+</ul>
+<h2><span><a id="AARP-Tax-Aide">AARP Tax-Aide Program (Central Coast Tax-Aide)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ccfreetax.org/" data-external-link="true">ccfreetax.org</a></li>
+<li><strong>Location:</strong> Various locations, see <a href="https://www.ccfreetax.org/appointment.html" data-external-link="true">Appointments</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-931-6308" aria-label="Call 805-931-6308">805-931-6308</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@ccfreetax.org" aria-label="Email info@ccfreetax.org">info@ccfreetax.org</a> </li>
+</ul>
+<h2><span><a id="Access-Central-Coast">Access Central Coast</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="CCADRC" aria-label="View directory entry for Central Coast Aging &amp; Disability Resource Center"><strong>Central Coast Aging &amp; Disability Resource Center</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://accesscentralcoast.org/" data-external-link="true">accesscentralcoast.org</a></li>
+<li><strong>Location:</strong> 51 Zaca Ln. #140, SLO <a href="#" class="map-link" data-lat="35.2508747" data-lon="-120.6726201" data-zoom="17" data-label="Access Central Coast">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-462-1162" aria-label="Call 805-462-1162">805-462-1162</a> (videophone: <a href="tel:+1-805-464-3203" aria-label="Call 805-464-3203">805-464-3203</a>) </li>
+<li><strong>Email:</strong> <a href="mailto:info@accesscentralcoast.org" aria-label="Email info@accesscentralcoast.org">info@accesscentralcoast.org</a> </li>
+<li><strong>Hours:</strong> M–F: 9am–noon &amp; 1–5pm (but closed every other Friday)</li>
+<li>Note: Formerly known as the “Independent Living Resource Center”</li>
+</ul>
+<h2><span><a id="ASN">Access Support Network (ASN)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://accesssupportnetwork.org/san-luis-obispo/" data-external-link="true">accesssupportnetwork.org/san-luis-obispo</a></li>
+<li><strong>Location:</strong> 1320 Nipomo St., SLO <a href="#" class="map-link" data-lat="35.2764744" data-lon="-120.6639145" data-zoom="17" data-label="Access Support Network">Map</a> <ul>
+<li>Also has a mobile outreach van:<ul>
+<li>Every other Monday, 1:30–4pm at <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado"><strong>40 Prado</strong></a> in SLO <a href="#" class="map-link" data-lat="35.256495" data-lon="-120.672000" data-zoom="17" data-label="Access Support Network">Map</a> </li>
+<li>Tuesdays 9:30–11:30am at 1320 Nipomo St. in SLO <a href="#" class="map-link" data-lat="35.013497" data-lon="-120.488581" data-zoom="17" data-label="Access Support Network">Map</a> </li>
+<li>Wednesdays 11:30am–1:30pm at Paso Robles <a href="#" data-directory-link="ECHO" aria-label="View directory entry for ECHO"><strong>ECHO</strong></a> Shelter (1134 Black Oak Dr. <a href="#" class="map-link" data-lat="35.645387" data-lon="-120.687569" data-zoom="17" data-label="El Camino Homeless Organization">Map</a>) </li>
+<li>Wednesdays 3–6pm at Atascadero <a href="#" data-directory-link="ECHO" aria-label="View directory entry for ECHO"><strong>ECHO</strong></a> Shelter (6370 Atascadero Ave. <a href="#" class="map-link" data-lat="35.486312" data-lon="-120.670295" data-zoom="17" data-label="El Camino Homeless Organization">Map</a>)  </li>
+<li>Second Sunday of the Month at the SLO library on Palm St. <a href="#" class="map-link" data-lat="35.282806" data-lon="-120.661426" data-zoom="17" data-label="Access Support Network">Map</a> </li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-3660" aria-label="Call 805-781-3660">805-781-3660</a> </li>
+<li><strong>Email:</strong> <a href="mailto:theasnsupp@gmail.com" aria-label="Email theasnsupp@gmail.com">theasnsupp@gmail.com</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5pm </li>
+</ul>
+<h2><span><a id="Achievement-House-Thrift-Store">Achievement House Thrift Stores</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.achievementhouse.org/pages/thrift-stores" data-external-link="true">achievementhouse.org/pages/thrift-stores</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1446 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.1208561" data-lon="-120.6056542" data-zoom="17" data-label="Achievement House Thrift Store (Arroyo Grande)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-202-3068" aria-label="Call 805-202-3068">805-202-3068</a></td>
+<td data-label="Hours">Daily 9:30am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">730 Morro Bay Blvd., Morro Bay <a href="#" class="map-link" data-lat="35.3657373" data-lon="-120.8447987" data-zoom="17" data-label="Achievement House Thrift Store (Morro Bay)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-772-6744" aria-label="Call 805-772-6744">805-772-6744</a></td>
+<td data-label="Hours">Daily 9:30am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">553 Higuera St., SLO <a href="#" class="map-link" data-lat="35.277251" data-lon="-120.667015" data-zoom="17" data-label="Bargain Botique">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-543-0412" aria-label="Call 805-543-0412">805-543-0412</a></td>
+<td data-label="Hours">Daily 9:30am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">3003 Cuesta College Rd., SLO <a href="#" class="map-link" data-lat="35.3243286" data-lon="-120.7449265" data-zoom="17" data-label="Achievement House Thrift Store (SLO)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-543-9383" aria-label="Call 805-543-9383">805-543-9383</a></td>
+<td data-label="Hours">M–Sa 9am–4pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:info@achievementhouse.org" aria-label="Email info@achievementhouse.org">info@achievementhouse.org</a> </li>
+</ul>
+<h2><span><a id="ACLU">ACLU of Southern California</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.aclusocal.org/" data-external-link="true">aclusocal.org</a></li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-213-977-9500" aria-label="Call 213-977-9500">213-977-9500</a> (main) </li>
+<li><a href="tel:+1-213-977-5253" aria-label="Call 213-977-5253">213-977-5253</a> (legal intake)</li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 10am–7pm</li>
+</ul>
+<h2><span><a id="Adult-Protective-Services">Adult Protective Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/social-services/adult-services/services/adult-protective-services-program-%28aps%29" data-external-link="true">Slocounty.ca.gov/APS</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Arroyo Grande: 1086 E. Grand Ave. <a href="#" class="map-link" data-lat="35.1197593" data-lon="-120.5956380" data-zoom="17" data-label="Adult Protective Services (Arroyo Grande)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-2000" aria-label="Call 805-474-2000">805-474-2000</a></td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero: 9630 El Camino Real <a href="#" class="map-link" data-lat="35.4657747" data-lon="-120.6485702" data-zoom="17" data-label="Adult Protective Services (Atascadero)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-461-6000" aria-label="Call 805-461-6000">805-461-6000</a></td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay: 600 Quintana Rd. <a href="#" class="map-link" data-lat="35.3692734" data-lon="-120.8447261" data-zoom="17" data-label="Adult Protective Services (Morro Bay)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-772-6405" aria-label="Call 805-772-6405">805-772-6405</a></td>
+</tr>
+<tr>
+<td data-label="Location">Nipomo: 681 W. Tefft St. #1 <a href="#" class="map-link" data-lat="35.0336188" data-lon="-120.4879843" data-zoom="17" data-label="Adult Protective Services (Nipomo)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-931-1800" aria-label="Call 805-931-1800">805-931-1800</a></td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles: 406 Spring St. <a href="#" class="map-link" data-lat="35.6185648" data-lon="-120.6903449" data-zoom="17" data-label="Adult Protective Services (Paso Robles)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-3110" aria-label="Call 805-237-3110">805-237-3110</a></td>
+</tr>
+<tr>
+<td data-label="Location">SLO: 3433 S. Higuera St. <a href="#" class="map-link" data-lat="35.2536551" data-lon="-120.6687249" data-zoom="17" data-label="Adult Protective Services (SLO)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-1600" aria-label="Call 805-781-1600">805-781-1600</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-1790" aria-label="Call 805-781-1790">805-781-1790</a> (M–F 8am–5pm); <a href="tel:+1-844-729-8011" aria-label="Call 844-729-8011">844-729-8011</a> (after hours); <a href="tel:+1-911" aria-label="Call 911">911</a> (emergency) </li>
+<li><strong>Hours:</strong> M–F 8am–4pm (and by appointment only 4–5pm) </li>
+<li>Notes:<ul>
+<li>Can make referrals to <a href="#" data-directory-link="Medically-Fragile-Homeless-Program" aria-label="View directory entry for Medically Fragile Homeless Program"><strong>Medically Fragile Homeless Program</strong></a></li>
+<li>Can make referrals to <a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening (CFS)"><strong>Center for Family Strengthening (CFS)</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span>Adult School</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="San-Luis-Coastal-Adult-School" aria-label="View directory entry for San Luis Coastal Adult School"><strong>San Luis Coastal Adult School</strong></a> and <a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> and <a href="#" data-directory-link="Templeton-Adult-School" aria-label="View directory entry for Templeton Adult School"><strong>Templeton Adult School</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Adventist-Health-Sierra-Vista">Adventist Health Sierra Vista</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.adventisthealth.org/central-coast/locations/sierra-vista-regional-medical-center" data-external-link="true">adventisthealth.org/central-coast/locations/sierra-vista-regional-medical-center</a></li>
+<li><strong>Location:</strong> 1010 Murray Ave., SLO <a href="#" class="map-link" data-lat="35.2924045" data-lon="-120.6659071" data-zoom="17" data-label="Adventist Health Sierra Vista">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-546-7600" aria-label="Call 805-546-7600">805-546-7600</a> </li>
+<li><strong>Hours:</strong> 24/7 </li>
+<li>Note: hosts <a href="#" data-directory-link="Liberty-Tattoo-Removal-Program" aria-label="View directory entry for Liberty Tattoo Removal Program"><strong>Liberty Tattoo Removal Program</strong></a></li>
+</ul>
+<h2><span><a id="Adventist-Health-Twin-Cities">Adventist Health Twin Cities</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.adventisthealth.org/central-coast/locations/twin-cities-community-hospital" data-external-link="true">adventisthealth.org/central-coast/locations/twin-cities-community-hospital</a></li>
+<li><strong>Location:</strong> 1100 Las Tablas Rd., Templeton <a href="#" class="map-link" data-lat="35.5551414" data-lon="-120.7200585" data-zoom="17" data-label="Adventist Health Twin Cities">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-434-3500" aria-label="Call 805-434-3500">805-434-3500</a> </li>
+<li><strong>Hours:</strong> 24/7 </li>
+</ul>
+<h2><span><a id="Aegis-Treatment-Centers">Aegis Treatment Centers</a></span></h2>
+<h3><span>Atascadero</span></h3>
+<ul>
+<li><strong>Website:</strong> <a href="https://pinnacletreatment.com/location/california/atascadero/aegis-treatment-centers-atascadero/" data-external-link="true">pinnacletreatment.com/location/california/atascadero/aegis-treatment-centers-atascadero</a></li>
+<li><strong>Location:</strong> 6500 Morro Rd. Suites C &amp; D, Atascadero <a href="#" class="map-link" data-lat="35.4472115" data-lon="-120.7045496" data-zoom="17" data-label="Aegis Treatment Centers (Atascadero)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-461-5212" aria-label="Call 805-461-5212">805-461-5212</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Medication services:<ul>
+<li>M–Th: 6am–10am, 11am–3:30pm </li>
+<li>F: 6am–10am, 11am–1:30pm </li>
+<li>Sa/Su/Holidays: 7am–11am </li>
+</ul>
+</li>
+<li>Administrative:<ul>
+<li>M–Th: 6am–4pm </li>
+<li>F: 6am–2:30pm </li>
+<li>Sa/Su/Holidays: 7am–11am </li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>How to access:</strong> Walk-ins welcome; same-day admissions available </li>
+</ul>
+<h3><span>SLO city</span></h3>
+<ul>
+<li><strong>Website:</strong> <a href="https://pinnacletreatment.com/location/california/san-luis-obispo/aegis-san-luis-obispo-med-unit/" data-external-link="true">pinnacletreatment.com/location/california/san-luis-obispo/aegis-san-luis-obispo-med-unit</a></li>
+<li><strong>Location:</strong> 1551 Bishop St. #520, SLO <a href="#" class="map-link" data-lat="35.2740882" data-lon="-120.6464189" data-zoom="17" data-label="Aegis Treatment Centers (SLO)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-461-5212" aria-label="Call 805-461-5212">805-461-5212</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Medication services:<ul>
+<li>M–F: 6am–10am, 11am–1:30pm </li>
+<li>Sa/Su/Holidays: 6am–10am </li>
+</ul>
+</li>
+<li>Administrative:<ul>
+<li>M–F: 6am–2:30pm </li>
+<li>Sa/Su/Holidays: 6am–10am </li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>How to access:</strong> Schedule a visit <a href="https://book.ptc.care/CA-SANLUISOBISPO-OTP" data-external-link="true">here</a></li>
+</ul>
+<h2><span><a id="Aevum">Aevum Home Health and Aevum Hospice Care</a></span></h2>
+<ul>
+<li><strong>Websites:</strong><ul>
+<li>Home Health: <a href="https://www.aevumhomehealth.com/" data-external-link="true">aevumhomehealth.com</a></li>
+<li>Hospice Care: <a href="https://aevumhospice.com/" data-external-link="true">aevumhospice.com</a></li>
+</ul>
+</li>
+<li><strong>Location:</strong> 1302 Marsh St., SLO <a href="#" class="map-link" data-lat="35.283249" data-lon="-120.655908" data-zoom="17" data-label="Aevum Home Health">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li>Home Health: <a href="tel:+1-805-586-2033" aria-label="Call 805-586-2033">805-586-2033</a> </li>
+<li>Hospice Care: <a href="tel:+1-805-465-2492" aria-label="Call 805-465-2492">805-465-2492</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong><ul>
+<li>Home Health: <a href="mailto:info@aevumhomehealth.com" aria-label="Email info@aevumhomehealth.com">info@aevumhomehealth.com</a> </li>
+<li>Hospice Care: <a href="mailto:info@aevumhospice.com" aria-label="Email info@aevumhospice.com">info@aevumhospice.com</a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Agape-Church">Agape Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://agapeslo.church/" data-external-link="true">agapeslo.church</a></li>
+<li><strong>Location:</strong> 950 Laureate Lane, SLO <a href="#" class="map-link" data-lat="35.2857149" data-lon="-120.7097524" data-zoom="17" data-label="Agape Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-0777" aria-label="Call 805-541-0777">805-541-0777</a> </li>
+<li><strong>Email:</strong> <a href="mailto:adminslo@agape.church" aria-label="Email adminslo@agape.church">adminslo@agape.church</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Office: M–Th 9am–4pm </li>
+<li>Food pantry: Tu 10–10:30am, Su Noon–12:30pm</li>
+</ul>
+</li>
+<li>Note: “Men of Agape” serve a free meal at Meadow Park, SLO <a href="#" class="map-link" data-lat="35.269063" data-lon="-120.658325" data-zoom="17" data-label="Men of Agape">Map</a>, Thursdays at 11am</li>
+</ul>
+<h2><span>Aging &amp; Disability Resource Center (ADRC)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CCADRC" aria-label="View directory entry for Central Coast Aging &amp; Disability Resource Center"><strong>Central Coast Aging &amp; Disability Resource Center</strong></a></em></p>
+</blockquote>
+<h2><span><a id="AGS-Recycling">AGS Recycling</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://agsreciclyng.com/" data-external-link="true">agsreciclyng.com</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Arroyo Grande: 564 Mesa View Dr., Arroyo Grande <a href="#" class="map-link" data-lat="35.0814297" data-lon="-120.5863837" data-zoom="17" data-label="AGS Recycling (Arroyo Grande)">Map</a> </li>
+<li>Morro Bay: 2650 Main Street, Morro Bay <a href="#" class="map-link" data-lat="35.3899509" data-lon="-120.8572476" data-zoom="17" data-label="AGS Recycling (Morro Bay)">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-598-6285" aria-label="Call 805-598-6285">805-598-6285</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Arroyo Grande: Tu–Sa 9am–5pm (closed Noon–12:30pm) </li>
+<li>Morro Bay: Tu–Sa 9am–5pm (closed Noon–12:30pm) </li>
+</ul>
+</li>
+</ul>
+<h2><span>AIDS Support Network</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="ASN" aria-label="View directory entry for Access Support Network"><strong>Access Support Network</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Alano-Club">Alano Club</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://sloalanoclub.org" data-external-link="true">sloalanoclub.org</a></li>
+<li><strong>Location:</strong> 3075 Broad Street, SLO <a href="#" class="map-link" data-lat="35.2619723" data-lon="-120.6505945" data-zoom="17" data-label="Alano Club">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-9817" aria-label="Call 805-543-9817">805-543-9817</a> </li>
+<li><strong>Email:</strong> <a href="mailto:sloalanoclub@gmail.com" aria-label="Email sloalanoclub@gmail.com">sloalanoclub@gmail.com</a> </li>
+<li><strong>Hours:</strong> Open 7 days/week (see <a href="https://sloalanoclub.org/meeting-schedule" data-external-link="true">meeting schedule</a> for specific meeting times)</li>
+</ul>
+
+
+<h2><span><a id="AA">Alcoholics Anonymous</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://sloaa.org/" data-external-link="true">sloaa.org</a></li>
+<li><strong>Location:</strong> 1333 Van Beurden Dr. #102, Los Osos </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-3211" aria-label="Call 805-541-3211">805-541-3211</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@sloaa.org" aria-label="Email info@sloaa.org">info@sloaa.org</a></li>
+<li><strong>Hours:</strong><ul>
+<li>Central Coast Intergroup office: M–F Noon–6pm, Sa 1–4pm </li>
+<li>Individual meetings: <a href="https://www.sloaa.org/meetings/" data-external-link="true">many hours and locations</a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="APA">Alliance for Pharmaceutical Access</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://apameds.org/for-clients/" data-external-link="true">apameds.org/for-clients</a></li>
+</ul>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">345 S. Halcyon Rd. (Arroyo Grande) <a class="map-link" data-lat="35.113326" data-lon="-120.590433" data-zoom="17" data-label="Alliance for Pharmaceutical Access">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-489-4261;ext=4267" aria-label="Call 805-489-4261 x4267">805-489-4261 x4267</a></td>
+<td data-label="Hours">Mo. 1pm–7pm</td>
+</tr>
+<tr>
+<td data-label="Location">1428 Phillips Lane #B4 (SLO, inside Noor Clinic) <a href="#" class="map-link" data-lat="35.288103" data-lon="-120.657544" data-zoom="17" data-label="Alliance for Pharmaceutical Access">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-548-0894" aria-label="Call 805-548-0894">805-548-0894</a></td>
+<td data-label="Hours">Tu. 1pm–5pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:Advocates@apameds.org" aria-label="Email Advocates@apameds.org">Advocates@apameds.org</a> </li>
+</ul>
+<h2><span>American Academy of Ophthalmology</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="EyeCare-America" aria-label="View directory entry for EyeCare America"><strong>EyeCare America</strong></a></em></p>
+</blockquote>
+<h2><span><a id="American-Cancer-Society">American Cancer Society</a></span></h2>
+<ul>
+<li>Patient Lodging Programs: <a href="https://www.cancer.org/support-programs-and-services/patient-lodging.html" data-external-link="true">cancer.org/support-programs-and-services/patient-lodging.html</a></li>
+<li>Road to Recovery (transportation to medical appointments): <a href="https://www.cancer.org/support-programs-and-services/road-to-recovery.html" data-external-link="true">cancer.org/support-programs-and-services/road-to-recovery.html</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-227-2345" aria-label="Call 800-227-2345">800-227-2345</a> </li>
+</ul>
+<h2><span><a id="American-Legion-Post-66">American Legion Post 66</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://post66slo.org/" data-external-link="true">post66slo.org</a></li>
+<li><strong>Location:</strong> 1661 Mill St., SLO <a href="#" class="map-link" data-lat="35.288680" data-lon="-120.653533" data-zoom="17" data-label="American Legion Post 66">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-6445" aria-label="Call 805-543-6445">805-543-6445</a> </li>
+<li>Notes: For <a href="#" data-directory-link="Boyd-Bristol-Medical-Equipment-Program" aria-label="View directory entry for Boyd Bristol Medical Equipment Program"><strong>Boyd Bristol Medical Equipment Program</strong></a> hours, call to make an appointment</li>
+</ul>
+<h2><span>America’s Job Center of California</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Cal-Careers-Center" aria-label="View directory entry for SLO Cal Careers Center"><strong>SLO Cal Careers Center</strong></a></em></p>
+</blockquote>
+<h2><span>Animal Services</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Animal-Services" aria-label="View directory entry for SLO County Animal Services"><strong>SLO County Animal Services</strong></a></em></p>
+</blockquote>
+<h2><span>Anna’s Home</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></em></p>
+</blockquote>
+<h2><span>Area Agency on Aging</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Central-Coast-Commission-for-Senior-Citizens" aria-label="View directory entry for Central Coast Commission for Senior Citizens"><strong>Central Coast Commission for Senior Citizens</strong></a></em></p>
+</blockquote>
+
+
+<h2><span><a id="Arise-Central-Coast">Arise Central Coast</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://arisevineyard.com/" data-external-link="true">arisevineyard.com</a></li>
+<li><strong>Location:</strong> 1775 Calle Joaquin, SLO <a href="#" class="map-link" data-lat="35.241754" data-lon="-120.688113" data-zoom="15" data-label="Arise Central Coast">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-3162" aria-label="Call 805-543-3162">805-543-3162</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Office: M–Th 9am–4pm </li>
+<li>Food pantry: M 2:30–4:30pm</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Arroyo-Grande-Community-Hospital">Arroyo Grande Community Hospital</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="Dignity-Health" aria-label="View directory entry for Dignity Health"><strong>Dignity Health</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.dignityhealth.org/central-coast/locations/arroyo-grande" data-external-link="true">dignityhealth.org/central-coast/locations/arroyo-grande</a></li>
+<li><strong>Location:</strong> 345 S. Halcyon Rd., Arroyo Grande <a class="map-link" data-lat="35.113326" data-lon="-120.590433" data-zoom="17" data-label="Arroyo Grande Community Hospital">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li>Front desk: <a href="tel:+1-805-489-4261" aria-label="Call 805-489-4261">805-489-4261</a> </li>
+<li>ER: <a href="tel:+1-805-473-7626" aria-label="Call 805-473-7626">805-473-7626</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong> 24/7 </li>
+</ul>
+<h2><span><a id="Arroyo-Grande-Recreation-Services">Arroyo Grande Recreation Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://arroyogrande.org/168/Recreation-Services" data-external-link="true">arroyogrande.org/168/Recreation-Services</a></li>
+<li><strong>Location:</strong> 1221 Ash St., Arroyo Grande <a class="map-link" data-lat="35.114628" data-lon="-120.600829" data-zoom="17" data-label="Arroyo Grande Recreation Services">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-473-5474" aria-label="Call 805-473-5474">805-473-5474</a> </li>
+<li><strong>Email:</strong> <a href="mailto:agrec@arroyogrande.org" aria-label="Email agrec@arroyogrande.org">agrec@arroyogrande.org</a></li>
+<li><strong>Hours:</strong> M–Th 9am–5pm, F 9am–1pm  (walk-in registration available)</li>
+</ul>
+<h2><span>ASN</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="ASN" aria-label="View directory entry for Access Support Network"><strong>Access Support Network</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Aspire-Counseling-Service">Aspire Counseling Service</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://aspirecounselingservice.com/san-luis-obispo/" data-external-link="true">aspirecounselingservice.com/san-luis-obispo</a></li>
+<li><strong>Location:</strong> 865 Aerovista Pl. #130, SLO <a href="#" class="map-link" data-lat="35.242312" data-lon="-120.640925" data-zoom="17" data-label="Aspire Counseling Service">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-329-5595" aria-label="Call 805-329-5595">805-329-5595</a> (main) </li>
+<li><a href="tel:+1-888-585-7373" aria-label="Call 888-585-7373">888-585-7373</a> (24/7 call or text) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@aspirecounselingservice.com" aria-label="Email info@aspirecounselingservice.com">info@aspirecounselingservice.com</a> </li>
+<li><strong>Hours:</strong> M–F 9am–9pm, Sa. 9am–1pm </li>
+<li>Notes: Hosts <a href="#" data-directory-link="Recovery-Dharma" aria-label="View directory entry for Recovery Dharma"><strong>Recovery Dharma</strong></a></li>
+</ul>
+<h2><span>Assistive Technology Center</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CCATC" aria-label="View directory entry for Central Coast Assistive Technology Center"><strong>Central Coast Assistive Technology Center</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Auntie-Isabell-Foundation">Auntie Isabell Foundation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.auntieisabellfoundation.org/" data-external-link="true">auntieisabellfoundation.org</a></li>
+<li><strong>Email:</strong> <a href="mailto:info@auntieisabellfoundation.org" aria-label="Email info@auntieisabellfoundation.org">info@auntieisabellfoundation.org</a> </li>
+<li>Service Area: Paso Robles and SLO County</li>
+</ul>
+<h2><span><a id="Assistance-League-of-SLO-County">Assistance League of SLO County</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.assistanceleague.org/san-luis-obispo-county/" data-external-link="true">assistanceleague.org/san-luis-obispo-county</a></li>
+<li><strong>Location:</strong> 667A Marsh St., SLO <a href="#" class="map-link" data-lat="35.277358" data-lon="-120.663899" data-zoom="17" data-label="Assistance League">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-782-0824" aria-label="Call 805-782-0824">805-782-0824</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@alslocounty.org" aria-label="Email info@alslocounty.org">info@alslocounty.org</a> </li>
+<li>Notes:<ul>
+<li>Operates <a href="#" data-directory-link="Assistance-League-Thrift-Store" aria-label="View directory entry for Assistance League Thrift Store"><strong>Assistance League Thrift Store</strong></a> </li>
+<li>Operates “Operation School Bell” </li>
+<li>Operates “Access to Career Education (ACE)” </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Assistance-League-Thrift-Store">Assistance League Thrift Store</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.assistanceleague.org/san-luis-obispo-county/thrift-shop/" data-external-link="true">assistanceleague.org/san-luis-obispo-county/thrift-shop</a></li>
+<li><strong>Location:</strong> 667A Marsh St., SLO <a href="#" class="map-link" data-lat="35.277358" data-lon="-120.663899" data-zoom="17" data-label="Assistance League">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-782-0824" aria-label="Call 805-782-0824">805-782-0824</a> </li>
+<li><strong>Hours:</strong> Tu–Sa 11am–4pm </li>
+</ul>
+<h2><span><a id="Atascadero-Senior-Center">Atascadero Senior Center</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://atascaderoseniorcenter.org/" data-external-link="true">atascaderoseniorcenter.org</a></li>
+<li><strong>Location:</strong> 5905 East Mall, Atascadero <a class="map-link" data-lat="35.488783" data-lon="-120.667081" data-zoom="17" data-label="Atascadero Senior Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-4674" aria-label="Call 805-466-4674">805-466-4674</a>  </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:seniorcitizensunitedinc@outlook.com" aria-label="Email seniorcitizensunitedinc@outlook.com">seniorcitizensunitedinc@outlook.com</a> </li>
+<li><a href="mailto:seniorcenter93422@gmail.com" aria-label="Email seniorcenter93422@gmail.com">seniorcenter93422@gmail.com</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M 11am–1pm, Tu–F 11am–3pm (some activities at other times) </li>
+<li><strong>How to access:</strong> Most activities free for members ($2 for guests); membership ($20/year minimum) open to people 50+</li>
+<li>Notes:<ul>
+<li>A lunch site for <a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Atascadero-Parks-and-Recreation">Atascadero Parks &amp; Recreation</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.atascadero.org/recreation" data-external-link="true">atascadero.org/recreation</a></li>
+<li><strong>Location:</strong> Colony Park Community Center, 5599 Traffic Way, Atascadero <a class="map-link" data-lat="35.494778" data-lon="-120.666963" data-zoom="17" data-label="Atascadero Parks &amp; Recreation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-470-3360" aria-label="Call 805-470-3360">805-470-3360</a> </li>
+<li><strong>Email:</strong> <a href="mailto:recreation@atascadero.org" aria-label="Email recreation@atascadero.org">recreation@atascadero.org</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5pm</li>
+</ul>
+<h2><span>Autism Spectrum Center</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Central-Coast-Autism-Spectrum-Center" aria-label="View directory entry for Central Coast Autism Spectrum Center"><strong>Central Coast Autism Spectrum Center</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Balay-Ko-on-Barka">Balay Ko on Barka</a></span></h2>
+<blockquote>
+<p><em>a.k.a. “My Home for Hope”</em></p>
+</blockquote>
+<ul>
+<li><strong>Location:</strong> Barka St. in Grover Beach <a href="#" class="map-link" data-lat="35.111238" data-lon="-120.623521" data-zoom="17" data-label="Balay Ko on Barka">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-305-3031" aria-label="Call 805-305-3031">805-305-3031</a></li>
+<li><strong>Email:</strong> <a href="mailto:shelter@5chc.org" aria-label="Email shelter@5chc.org">shelter@5chc.org</a></li>
+<li><strong>How to access:</strong> Apply through <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> to get on waiting list</li>
+</ul>
+<h2><span><a id="Bargain-Boutique">Bargain Boutique</a></span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Achievement-House-Thrift-Store" aria-label="View directory entry for Achievement House Thrift Stores">Achievement House Thrift Stores</a></em></p>
+</blockquote>
+
+
+<h2><span>Behavioral Health</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a></em></p>
+</blockquote>
+<h2><span><a id="BHBH">Behavioral Health Bridge Housing (BHBH) Program</a></span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/justice-services/behavioral-health-bridge-housing" data-external-link="true">www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/justice-services/behavioral-health-bridge-housing</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-540-6500" aria-label="Call 805-540-6500">805-540-6500</a> (Mark Lamore, Director of Homeless Services at <a href="#" data-directory-link="TMHA" aria-label="View directory entry for TMHA"><strong>TMHA</strong></a>) </li>
+<li><strong>Email:</strong> <a href="mailto:mtorell@co.slo.ca.us" aria-label="Email mtorell@co.slo.ca.us">mtorell@co.slo.ca.us</a> and <a href="mailto:jmprice@co.slo.ca.us" aria-label="Email jmprice@co.slo.ca.us">jmprice@co.slo.ca.us</a> </li>
+<li><strong>How to access:</strong> must be referred by another agency; call to ask for details </li>
+</ul>
+<h2><span><a id="Bella-Vista-by-the-Sea">Bella Vista by the Sea</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.bellavistabythesea.com/" data-external-link="true">bellavistabythesea.com</a></li>
+<li><strong>Location:</strong> 350 N. Ocean Ave., Cayucos <a class="map-link" data-lat="35.451070" data-lon="-120.908597" data-zoom="17" data-label="Bella Vista by the Sea">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-995-3644" aria-label="Call 805-995-3644">805-995-3644</a> </li>
+<li><strong>Email:</strong> <a href="mailto:bellavistamhp@tprop.net" aria-label="Email bellavistamhp@tprop.net">bellavistamhp@tprop.net</a> </li>
+<li><strong>Hours:</strong> (office hours) M–F 10am–4pm </li>
+</ul>
+<h2><span><a id="Bike-Kitchen">Bike Kitchen</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://bikeslocounty.org/programs/kitchen/" data-external-link="true">bikeslocounty.org/programs/kitchen</a></li>
+<li><strong>Location:</strong> 860 Pacific St. #105, SLO <a href="#" class="map-link" data-lat="35.279103" data-lon="-120.660620" data-zoom="17" data-label="Bike Kitchen">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-547-2055" aria-label="Call 805-547-2055">805-547-2055</a> </li>
+<li><strong>Hours:</strong> Th–Su 12–5pm (DIY repair), Tu–W 12–5pm (shopping only), M closed </li>
+</ul>
+<h2><span><a id="Blessed-to-Serve">Blessed to Serve</a></span></h2>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">12150 Los Osos Valley Road, SLO <a href="#" class="map-link" data-lat="35.250659" data-lon="-120.684721" data-zoom="17" data-label="Blessed to Serve">Map</a> (Nissan dealership)</td>
+<td data-label="Hours">M 5pm</td>
+</tr>
+<tr>
+<td data-label="Location">1251 Calle Joaquin, SLO <a href="#" class="map-link" data-lat="35.251051" data-lon="-120.679879" data-zoom="17" data-label="Blessed to Serve">Map</a> (BMW dealership)</td>
+<td data-label="Hours">Th 5pm</td>
+</tr>
+</tbody></table>
+<h2><span><a id="Boyd-Bristol-Medical-Equipment-Program">Boyd Bristol Medical Equipment Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://post66slo.org/serving-veterans/" data-external-link="true">post66slo.org/serving-veterans</a></li>
+<li><strong>Location:</strong> 1161 Mill St., SLO <a href="#" class="map-link" data-lat="35.284710" data-lon="-120.660546" data-zoom="17" data-label="Boyd Bristol Medical Equipment Program">Map</a><ul>
+<li>Note: delivery can also be arranged </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-6445" aria-label="Call 805-543-6445">805-543-6445</a> </li>
+<li><strong>How to access:</strong> Only for veterans and veterans’ dependents. By appointment only; call to make an appointment.</li>
+</ul>
+<h2><span>The Bridge Cafe</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Brookside-Thrift">Brookside Thrift</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 9330 El Camino Real, Atascadero <a class="map-link" data-lat="35.467930" data-lon="-120.651700" data-zoom="17" data-label="North County Christian Thrift Shop">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-1679" aria-label="Call 805-466-1679">805-466-1679</a> </li>
+<li><strong>Email:</strong> <a href="mailto:nccts9330@gmail.com" aria-label="Email nccts9330@gmail.com">nccts9330@gmail.com</a> </li>
+<li><strong>Hours:</strong> M–Sa 9am–6pm</li>
+<li>Notes: formerly known as “North County Christian Thrift”</li>
+</ul>
+<h2><span>Business and Career One Stop</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Cal-Careers-Center" aria-label="View directory entry for SLO Cal Careers Center"><strong>SLO Cal Careers Center</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Cabins-for-Change">Cabins for Change</a></span></h2>
+<ul>
+<li><strong>Location:</strong> Rockaway Ave. at 16th St. in Grover Beach <a href="#" class="map-link" data-lat="35.119777" data-lon="-120.612577" data-zoom="17" data-label="Cabins for Change">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-305-3031" aria-label="Call 805-305-3031">805-305-3031</a> </li>
+<li><strong>Text:</strong> <a href="sms:+1-805-634-9906">805-634-9906</a> </li>
+<li><strong>Email:</strong> <a href="mailto:shelter@5chc.org" aria-label="Email shelter@5chc.org">shelter@5chc.org</a> </li>
+<li><strong>How to access:</strong> Apply through <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> to get on waiting list</li>
+</ul>
+<h2><span>Cal Poly Community Counseling Service</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Cal-Poly-Community-Counseling-Service" aria-label="View directory entry for San Luis Obispo Counseling Service at Cal Poly"><strong>San Luis Obispo Counseling Service at Cal Poly</strong></a></em></p>
+</blockquote>
+<h2><span><a id="California-Cool-Thrift-Store">California Cool Thrift Store</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 737 W. Grand Ave., Grover Beach <a class="map-link" data-lat="35.121863" data-lon="-120.622164" data-zoom="17" data-label="California Cool Thrift Store">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-481-3071" aria-label="Call 805-481-3071">805-481-3071</a> </li>
+<li><strong>Hours:</strong> Daily 10am–5pm </li>
+</ul>
+<h2><span><a id="California-Childrens-Services">California Children’s Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://dhcs.ca.gov/services/ccs" data-external-link="true">dhcs.ca.gov/services/ccs</a></li>
+<li><strong>Location:</strong> 2925 McMillan Ave. #108, SLO <a href="#" class="map-link" data-lat="35.263382" data-lon="-120.648288" data-zoom="17" data-label="California Children’s Services">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5527" aria-label="Call 805-781-5527">805-781-5527</a> </li>
+<li><strong>Email:</strong> <a href="mailto:PublicHealth.CMS@co.slo.ca.us" aria-label="Email PublicHealth.CMS@co.slo.ca.us">PublicHealth.CMS@co.slo.ca.us</a> </li>
+<li><strong>Hours:</strong> M–F 8am–5pm by appointment only </li>
+</ul>
+<h2><span><a id="California-Civil-Rights-Department">California Civil Rights Department</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://calcivilrights.ca.gov" data-external-link="true">calcivilrights.ca.gov</a><ul>
+<li>Housing discrimination office: <a href="https://calcivilrights.ca.gov/housing/" data-external-link="true">calcivilrights.ca.gov/housing</a></li>
+</ul>
+</li>
+<li><strong>Location:</strong> 651 Bannon Street #200, Sacramento, CA 95811 <a href="#" class="map-link" data-lat="38.594598" data-lon="-121.497249" data-zoom="17" data-label="California Civil Rights Department">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-800-884-1684" aria-label="Call 800-884-1684">800-884-1684</a> (voice) </li>
+<li><a href="tel:+1-800-700-2320" aria-label="Call 800-700-2320">800-700-2320</a> (TTY) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:contact.center@calcivilrights.ca.gov" aria-label="Email contact.center@calcivilrights.ca.gov">contact.center@calcivilrights.ca.gov</a> </li>
+<li><strong>How to access:</strong> via the <a href="https://ccrs.calcivilrights.ca.gov/s/" data-external-link="true">California Civil Rights System</a> on-line platform</li>
+</ul>
+<h2><span><a id="California-Connect">California Connect</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://caconnect.org/" data-external-link="true">caconnect.org</a></li>
+<li><strong>Location:</strong> 3426 Empresa Dr. #120, SLO <a href="#" class="map-link" data-lat="35.253573" data-lon="-120.667102" data-zoom="17" data-label="California Connect">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-806-1191" aria-label="Call 800-806-1191">800-806-1191</a>  (TTY: <a href="tel:+1-800-806-4474" aria-label="Call 800-806-4474">800-806-4474</a>) </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:info@caconnect.org" aria-label="Email info@caconnect.org">info@caconnect.org</a> </li>
+<li><a href="mailto:ddtp@cpuc.ca.gov" aria-label="Email ddtp@cpuc.ca.gov">ddtp@cpuc.ca.gov</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–5pm </li>
+</ul>
+<h2><span><a id="California-Department-of-Rehabilitation">California Department of Rehabilitation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.dor.ca.gov/" data-external-link="true">dor.ca.gov</a></li>
+<li><strong>Location:</strong> 3320 S. Higuera #102, SLO <a href="#" class="map-link" data-lat="35.255033" data-lon="-120.668947" data-zoom="17" data-label="California Department of Rehabilitation">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li>Local office:<ul>
+<li><a href="tel:+1-805-594-6100" aria-label="Call 805-594-6100">805-594-6100</a></li>
+<li><a href="tel:+1-805-549-3361" aria-label="Call 805-549-3361">805-549-3361</a> (for ages 16–21) </li>
+<li><a href="tel:+1-805-544-7367" aria-label="Call 805-544-7367">805-544-7367</a> (TTY)</li>
+</ul>
+</li>
+<li>Statewide:<ul>
+<li><a href="tel:+1-800-952-5544" aria-label="Call 800-952-5544">800-952-5544</a> (voice) </li>
+<li><a href="tel:+1-916-324-1313" aria-label="Call 916-324-1313">916-324-1313</a> (voice) </li>
+<li><a href="tel:+1-916-558-5673" aria-label="Call 916-558-5673">916-558-5673</a> (TTY) </li>
+<li>Source: <a href="https://www.dor.ca.gov/Home/ContactUs" data-external-link="true">dor.ca.gov</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>How to access:</strong> No walk-ins. Call them to schedule an Orientation, or complete a form on their website.</li>
+<li>Notes:<ul>
+<li>Can refer you to the “Supported Employment” program</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="California-DMV">California DMV</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.dmv.ca.gov/" data-external-link="true">dmv.ca.gov</a></li>
+<li><strong>Location:</strong> 3190 S. Higuera St., SLO <a href="#" class="map-link" data-lat="35.257436" data-lon="-120.669167" data-zoom="17" data-label="Department of Motor Vehicles">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-777-0133" aria-label="Call 800-777-0133">800-777-0133</a> (for appointments)</li>
+<li><strong>Hours:</strong> M/Tu/Th/F/Sa 8am–5pm, W 9am–5pm </li>
+</ul>
+<h2><span><a id="California-Rural-Legal-Assistance">California Rural Legal Assistance (CRLA)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.crla.org/" data-external-link="true">crla.org</a></li>
+<li><strong>Location:</strong> 1880 Santa Barbara Ave. #240, SLO <a href="#" class="map-link" data-lat="35.275127" data-lon="-120.656168" data-zoom="17" data-label="California Rural Legal Assistance">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-7994" aria-label="Call 805-544-7994">805-544-7994</a> </li>
+<li><strong>Hours:</strong> M–Th 9am–12pm &amp; 1pm–5pm, F 1pm–5pm</li>
+</ul>
+<h2><span>California Telephone Access Program (CTAP)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="California-Connect" aria-label="View directory entry for California Connect"><strong>California Connect</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Cal-Poly-Doggy-Days">Cal Poly “Doggy Days” Veterinary Clinics</a></span></h2>
+<ul>
+<li><strong>Social media:</strong><ul>
+<li>Facebook: <a href="https://www.facebook.com/calpolydoggydays/" data-external-link="true">facebook.com/calpolydoggydays</a></li>
+<li>Instagram: <a href="https://instagram.com/cpdoggydays" data-external-link="true">@cpdoggydays</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-756-2419" aria-label="Call 805-756-2419">805-756-2419</a> (Cal Poly Animal Science Department)</li>
+<li><strong>Email:</strong> <a href="mailto:calpolydoggydays@gmail.com" aria-label="Email calpolydoggydays@gmail.com">calpolydoggydays@gmail.com</a> </li>
+</ul>
+<h2><span><a id="Cal-Poly-Food-Pantry">Cal Poly Food Pantry</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://basicneeds.calpoly.edu/foodpantry" data-external-link="true">basicneeds.calpoly.edu/foodpantry</a></li>
+<li><strong>Location:</strong> Cal Poly campus, building 27, room 10 <a href="#" class="map-link" data-lat="35.298148" data-lon="-120.660616" data-zoom="17" data-label="Cal Poly Food Pantry">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-756-7818" aria-label="Call 805-756-7818">805-756-7818</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>M–F 8:30am–6pm (Cal Poly students) </li>
+<li>F 8:30am–6pm (Cal Poly employees) </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> all Cal Poly students and employees welcome; no additional eligibility requirements </li>
+</ul>
+<h2><span><a id="CalJOBS">CalJOBS</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.caljobs.ca.gov/" data-external-link="true">caljobs.ca.gov</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-758-0398" aria-label="Call 800-758-0398">800-758-0398</a> </li>
+<li>Note: Can access locally via <a href="#" data-directory-link="SLO-Cal-Careers-Center" aria-label="View directory entry for SLO Cal Careers Center"><strong>SLO Cal Careers Center</strong></a></li>
+</ul>
+<h2><span><a id="CalWORKs">CalWORKs Homeless Assistance Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance" data-external-link="true">slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance</a></li>
+<li><strong>Locations:</strong> See <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-1600" aria-label="Call 805-781-1600">805-781-1600</a></li>
+<li><strong>Hours:</strong> M–F 8am–4pm (4–5pm by appointment only)</li>
+<li><strong>How to access:</strong> Contact <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></li>
+</ul>
+<h2><span><a id="Cambria-Recycling-Center">Cambria Recycling Center</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 1275 Tamson St., Cambria <a href="#" class="map-link" data-lat="35.563214" data-lon="-121.091796" data-zoom="17" data-label="Cambria Recycling Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-550-5489" aria-label="Call 805-550-5489">805-550-5489</a> </li>
+<li><strong>Hours:</strong> Tu–Sa 10am–4pm </li>
+</ul>
+<h2><span><a id="Cambria-Vineyard-Church">Cambria Vineyard Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://cambriavineyardchurch.org/" data-external-link="true">cambriavineyardchurch.org</a></li>
+<li><strong>Location:</strong> 1617 Main St., Cambria <a href="#" class="map-link" data-lat="35.563774" data-lon="-121.087216" data-zoom="17" data-label="Cambria Vineyard">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-927-5550" aria-label="Call 805-927-5550">805-927-5550</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@cambriavineyard.org" aria-label="Email info@cambriavineyard.org">info@cambriavineyard.org</a></li>
+<li><strong>Hours</strong> (food pantry): Second &amp; fourth Thursdays, Noon–2pm </li>
+<li>Notes: Operates “Re·Create Thrift Store” at 1601 Main St., Cambria (M/Th/F/Sa 10am–4pm) </li>
+</ul>
+<h2><span><a id="Cambrias-Anonymous-Neighbors">Cambria’s Anonymous Neighbors (CAN)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.joslynrec.org/CAN/index.html" data-external-link="true">joslynrec.org/CAN</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-927-5673" aria-label="Call 805-927-5673">805-927-5673</a> </li>
+</ul>
+<h2><span>CAPSLO</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Captive-Hearts">Captive Hearts</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://captivehearts.org/" data-external-link="true">captivehearts.org</a></li>
+<li><strong>Location:</strong> 882 W. Grand Ave., Grover Beach <a class="map-link" data-lat="35.121358" data-lon="-120.620550" data-zoom="17" data-label="Captive Hearts">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-481-4500" aria-label="Call 805-481-4500">805-481-4500</a> (before 3pm) </li>
+<li><strong>Email:</strong> <a href="mailto:info@captivehearts.org" aria-label="Email info@captivehearts.org">info@captivehearts.org</a> </li>
+<li>Notes: operates <a href="#" data-directory-link="Second-Chances-Thrift-Store" aria-label="View directory entry for Second Chances Thrift Store">Second Chances Thrift Store</a></li>
+</ul>
+<h2><span><a id="C.A.R.E.4Paws">C.A.R.E.4Paws</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://care4paws.org/" data-external-link="true">care4paws.org</a></li>
+<li><strong>Location:</strong> mobile clinics<ul>
+<li>Pet Resource Center: 100 S. 4th St., Grover Beach <a href="#" class="map-link" data-lat="35.121203" data-lon="-120.626739" data-zoom="17" data-label="C.A.R.E.4Paws">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-968-2273" aria-label="Call 805-968-CARE">805-968-CARE</a> </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:info@care4paws.org" aria-label="Email info@care4paws.org">info@care4paws.org</a> </li>
+<li><a href="mailto:outreach@care4paws.org" aria-label="Email outreach@care4paws.org">outreach@care4paws.org</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong><ul>
+<li><a href="https://care4paws.org/clinics" data-external-link="true">Mobile Clinics Schedule</a></li>
+<li>Pet Resource Center: M–Th 9am–5pm, F 11am–5pm </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Partners with “The Street Dog Coalition”</li>
+<li>Operates the “Pet Resource Center” with <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Carbon-Health-Urgent-Care-Atascadero">Carbon Health Urgent Care (Atascadero)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://carbonhealth.com/en/locations/atascadero-ca" data-external-link="true">carbonhealth.com/en/locations/atascadero-ca</a></li>
+<li><strong>Location:</strong> 7330 El Camino Real, Atascadero <a class="map-link" data-lat="35.482467" data-lon="-120.659886" data-zoom="17" data-label="Carbon Health Urgent Care (Atascadero)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-831-621-1184" aria-label="Call 831-621-1184">831-621-1184</a> </li>
+<li><strong>Hours:</strong> Every day 8am–6pm </li>
+<li>Notes: Accepts Medicare but not Medi-Cal; walk-ins welcome, same-day appointments available</li>
+</ul>
+<h2><span><a id="Carbon-Health-Urgent-Care-Paso-Robles">Carbon Health Urgent Care (Paso Robles)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://carbonhealth.com/en/locations/paso-robles-ca" data-external-link="true">carbonhealth.com/en/locations/paso-robles-ca</a></li>
+<li><strong>Location:</strong> 500 1st St., Paso Robles <a href="#" class="map-link" data-lat="35.614953" data-lon="-120.692442" data-zoom="17" data-label="Carbon Health Urgent Care">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-831-621-1449" aria-label="Call 831-621-1449">831-621-1449</a> </li>
+<li><strong>Hours:</strong> Every day 8am–6pm </li>
+<li>Notes: Accepts Medicare but not Medi-Cal; walk-ins welcome, same-day appointments available</li>
+</ul>
+<h2><span><a id="CASA">CASA (Court Appointed Special Advocates)</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://slocasa.org/" data-external-link="true">slocasa.org</a></li>
+<li><strong>Location:</strong> 75 Higuera St. #180, SLO <a href="#" class="map-link" data-lat="35.268096" data-lon="-120.670195" data-zoom="17" data-label="CASA">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-6542" aria-label="Call 805-541-6542">805-541-6542</a> </li>
+<li><strong>Email:</strong> <a href="mailto:staff@slocasa.org" aria-label="Email staff@slocasa.org">staff@slocasa.org</a> </li>
+</ul>
+<h2><span><a id="Casa-Solana">Casa Solana</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://casasolanainc.org/" data-external-link="true">casasolanainc.org</a></li>
+<li><strong>Location:</strong> 383 S. 13th St., Grover Beach <a class="map-link" data-lat="35.118384" data-lon="-120.615202" data-zoom="17" data-label="Casa Solana">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-481-8555" aria-label="Call 805-481-8555">805-481-8555</a> (9am–4pm) </li>
+<li><strong>Email:</strong> <a href="mailto:casasolanainc@gmail.com" aria-label="Email casasolanainc@gmail.com">casasolanainc@gmail.com</a> </li>
+<li>Notes: also known as “Sunshine House”</li>
+</ul>
+<h2><span><a id="Catholic-Charities">Catholic Charities (Diocese of Monterey)</a></span></h2>
+
+
+<ul>
+<li><strong>Website:</strong> <a href="https://catholiccharitiesdom.org/" data-external-link="true">catholiccharitiesdom.org</a><ul>
+<li><a href="https://catholiccharitiesdom.org/immigration-citizenship/" data-external-link="true">Immigration and Citizenship Program</a></li>
+<li><a href="https://catholiccharitiesdom.org/tattoo-removal-program" data-external-link="true">Tattoo Removal Program</a></li>
+</ul>
+</li>
+<li><strong>Locations:</strong><ul>
+<li>Main office: 3250 S. Higuera St. #D, SLO <a href="#" class="map-link" data-lat="35.255397" data-lon="-120.669515" data-zoom="17" data-label="Catholic Charities">Map</a> </li>
+<li>Financial assistance: 3592 Broad Street #104, SLO <a href="#" class="map-link" data-lat="35.254868" data-lon="-120.645111" data-zoom="17" data-label="Catholic Charities">Map</a> </li>
+<li>Behind the Mission: 715 Palm St., SLO <a href="#" class="map-link" data-lat="35.280845" data-lon="-120.665176" data-zoom="17" data-label="Catholic Charities">Map</a></li>
+<li>Paso Robles satellite: St. Rose of Lima Church, 642 Trigo Ln., Paso Robles <a href="#" class="map-link" data-lat="35.622914" data-lon="-120.690742" data-zoom="17" data-label="Catholic Charities">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li>Main: <a href="tel:+1-805-541-9110" aria-label="Call 805-541-9110">805-541-9110</a> </li>
+<li>Paso Robles: <a href="tel:+1-805-541-9120" aria-label="Call 805-541-9120">805-541-9120</a> (to schedule appointments) </li>
+<li>Immigration and Citizenship Program: <a href="tel:+1-831-722-2675" aria-label="Call 831-722-2675">831-722-2675</a></li>
+<li>Tattoo Removal: <a href="tel:+1-831-316-9121" aria-label="Call 831-316-9121">831-316-9121</a> (Note: Tattoo removal office is in Santa Cruz, not SLO) </li>
+</ul>
+</li>
+<li><strong>Hours:</strong><ul>
+<li>SLO offices: M–F 8am–5pm (call to confirm hours for specific location)</li>
+<li>Paso Robles: Second Wednesday of every month, 1–5pm</li>
+</ul>
+</li>
+</ul>
+
+
+<h2><span><a id="Cayucos-Community-Church">Cayucos Community Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.cayucoschurch.org/" data-external-link="true">cayucoschurch.org</a></li>
+<li><strong>Location:</strong> 60 S. 3rd St., Cayucos <a class="map-link" data-lat="35.445457" data-lon="-120.898613" data-zoom="17" data-label="Cayucos Community Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-995-3821" aria-label="Call 805-995-3821">805-995-3821</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@cayucoschurch.com" aria-label="Email info@cayucoschurch.com">info@cayucoschurch.com</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Office: Tu–Th 10am–2pm (closed Fridays and holidays)</li>
+<li>Food pantry (“Harvest Bag”): First, third, fourth, &amp; fifth Wednesdays at 10:30am </li>
+<li>USDA food distribution: Second Wednesday at 10:30am </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="CenCal">CenCal Health</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal"><strong>Medi-Cal</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://cencalhealth.org/" data-external-link="true">Cencalhealth.org</a></li>
+<li><strong>Locations:</strong> See <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> </li>
+<li><strong>Phone:</strong><ul>
+<li>Business office: <a href="tel:+1-800-421-2560" aria-label="Call 800-421-2560">800-421-2560</a> or <a href="tel:+1-805-685-9525" aria-label="Call 805-685-9525">805-685-9525</a> </li>
+<li>Enrollment: <a href="tel+1-877-227-3051">877-227-3051</a> </li>
+<li>Member services: <a href="tel:+1-877-814-1861" aria-label="Call 877-814-1861">877-814-1861</a> (M–F, 8am–5pm) </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> You can submit an application online via <a href="https://www.coveredca.com/" data-external-link="true">Covered California</a> or <a href="https://www.mybenefitscalwin.org/" data-external-link="true">My Benefits CalWIN</a> or you can get help applying from the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> </li>
+<li>Note: for CenCal Shuttle, <em>See <a href="#" data-directory-link="Ride-On-Transportation" aria-label="View directory entry for Ride-On Transportation"><strong>Ride-On Transportation</strong></a></em></li>
+</ul>
+<h2><span>CenCal Health Transportation</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Ride-On-Transportation" aria-label="View directory entry for Ride-On Transportation"><strong>Ride-On Transportation</strong></a></em></p>
+</blockquote>
+<h2><span><a id="CARD">Center for Autism &amp; Related Disorders</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://centerforautism.com/locations/san-luis-obispo-california/" data-external-link="true">centerforautism.com</a></li>
+<li><strong>Location:</strong> 1212 Marsh St. #1, SLO <a href="#" class="map-link" data-lat="35.282685" data-lon="-120.657396" data-zoom="17" data-label="CARD">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-703-2120" aria-label="Call 805-703-2120">805-703-2120</a> </li>
+<li><strong>Email:</strong> <a href="mailto:Info@centerforautism.com" aria-label="Email Info@centerforautism.com">Info@centerforautism.com</a> </li>
+<li><strong>Hours:</strong> M–F 8am–7pm (weekend hours vary) </li>
+<li><strong>How to access:</strong><ul>
+<li>Enroll at <a href="https://admissions.centerforautism.com/" data-external-link="true">this web page</a></li>
+<li>or call <a href="tel:+1-877-448-4747;ext=2" aria-label="Call 877-448-4747 x2">877-448-4747 x2</a> </li>
+<li>or email <a href="mailto:cardenrollment@centerforautism.com" aria-label="Email cardenrollment@centerforautism.com">cardenrollment@centerforautism.com</a> </li>
+</ul>
+</li>
+<li>Notes: Accepts CenCal Health and most other insurance providers </li>
+</ul>
+<h2><span><a id="CFS">Center for Family Strengthening (CFS)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://cfsslo.org/" data-external-link="true">cfsslo.org</a></li>
+<li><strong>Location:</strong> 1428 Phillips Lane #203, SLO <a href="#" class="map-link" data-lat="35.288103" data-lon="-120.657544" data-zoom="17" data-label="Center for Family Strengthening">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-1994" aria-label="Call 805-439-1994">805-439-1994</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@cfsslo.org" aria-label="Email info@cfsslo.org">info@cfsslo.org</a> </li>
+<li><strong>Hours:</strong> By appointment (call or email to schedule) </li>
+<li>Notes:<ul>
+<li>make referrals via <a href="#" data-directory-link="Adult-Protective-Services" aria-label="View directory entry for Adult Protective Services"><strong>Adult Protective Services</strong></a></li>
+<li>operates <a href="#" data-directory-link="Medically-Fragile-Homeless-Program" aria-label="View directory entry for Medically Fragile Homeless Program"><strong>Medically Fragile Homeless Program</strong></a></li>
+<li>operates <a href="#" data-directory-link="Parent-Connection-of-SLO-County" aria-label="View directory entry for Parent Connection of SLO County"><strong>Parent Connection of SLO County</strong></a></li>
+<li>operates <a href="#" data-directory-link="Link-Family-Resource-Center" aria-label="View directory entry for The Link Family Resource Center"><strong>The Link Family Resource Center</strong></a> (Atascadero and Paso Robles locations)</li>
+<li>partner in <a href="#" data-directory-link="SLO-County-UndocuSupport" aria-label="View directory entry for SLO County UndocuSupport"><strong>SLO County UndocuSupport</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="The-Center">The Center for Health &amp; Prevention</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/the-center/" data-external-link="true">capslo.org/the-center</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1152 E. Grand Ave. (Arroyo Grande) <a href="#" class="map-link" data-lat="35.120865" data-lon="-120.597299" data-zoom="17" data-label="The Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-489-4026" aria-label="Call 805-489-4026">805-489-4026</a> (Arroyo Grande)</td>
+<td data-label="Hours">M–F 8:30am–5:30m </td>
+</tr>
+<tr>
+<td data-label="Location">705 Grand Ave. (SLO) <a href="#" class="map-link" data-lat="35.290116" data-lon="-120.653550" data-zoom="17" data-label="The Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-544-2498;ext=211" aria-label="Call 805-544-2498 x211">805-544-2498 x211</a> (SLO)</td>
+<td data-label="Hours">M–F 8:30am–5:30pm </td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-422-2498;ext=121" aria-label="Call 805-422-2498&nbsp;x121">805-422-2498&nbsp;x121</a> (info line) </li>
+<li><a href="tel:+1-805-544-2409;ext=111" aria-label="Call 805-544-2409&nbsp;x111">805-544-2409&nbsp;x111</a> (mobile reproductive health clinic info) </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> Walk-ins OK, but appointments recommended. </li>
+<li>Note:<ul>
+<li>Operated by <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></li>
+<li>Teen clinic Tuesday 3–6pm, Friday 3–5:30pm in Arroyo Grande</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="CCADRC">Central Coast Aging &amp; Disability Resource Center (CCADRC)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://centralcoastseniors.org/aging-and-disability-resource-center/" data-external-link="true">centralcoastseniors.org/aging-and-disability-resource-center</a></li>
+<li><strong>Location:</strong> 528 S. Broadway, Santa Maria <a href="#" class="map-link" data-lat="34.948009" data-lon="-120.436107" data-zoom="17" data-label="CCADRC">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-928-2552" aria-label="Call 805-928-2552">805-928-2552</a> / <a href="tel:+1-800-510-2020" aria-label="Call 800-510-2020">800-510-2020</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@centralcoastseniors.org" aria-label="Email info@centralcoastseniors.org">info@centralcoastseniors.org</a> </li>
+<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm)</li>
+<li><strong>How to access:</strong> Walk-ins OK.</li>
+<li>Notes:<ul>
+<li>partner in <a href="#" data-directory-link="Access-Central-Coast" aria-label="View directory entry for Access Central Coast"><strong>Access Central Coast</strong></a></li>
+<li>operated by <a href="#" data-directory-link="Central-Coast-Commission-for-Senior-Citizens" aria-label="View directory entry for Central Coast Commission for Senior Citizens"><strong>Central Coast Commission for Senior Citizens</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="CCATC">Central Coast Assistive Technology Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://ccatc.org/" data-external-link="true">ccatc.org</a></li>
+<li><strong>Location:</strong> 11491 Los Osos Valley Rd. #202, SLO <a href="#" class="map-link" data-lat="35.258145" data-lon="-120.692577" data-zoom="17" data-label="CCATC">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-549-7420" aria-label="Call 805-549-7420">805-549-7420</a>  (TTY: <a href="tel:+1-805-549-7424" aria-label="Call 805-549-7424">805-549-7424</a>)</li>
+<li><strong>How to access:</strong> call to make an appointment</li>
+</ul>
+<h2><span><a id="Central-Coast-Autism-Spectrum-Center">Central Coast Autism Spectrum Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://sloautism.org/" data-external-link="true">sloautism.org</a></li>
+<li><strong>Mailing address:</strong> P.O. Box 3417, SLO, CA 93403 </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-763-1100" aria-label="Call 805-763-1100">805-763-1100</a> </li>
+<li><strong>Email:</strong> <a href="mailto:contact@sloautism.org" aria-label="Email contact@sloautism.org">contact@sloautism.org</a> </li>
+</ul>
+
+
+<h2><span><a id="Central-Coast-Coalition-for-Undocumented-Student-Success">Central Coast Coalition for Undocumented Student Success</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ccc-uss.org/" data-external-link="true">ccc-uss.org</a></li>
+<li><strong>Mailing address:</strong> P.O. Box 15759, SLO, CA 93406 </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:ccc.undocu@gmail.com" aria-label="Email ccc.undocu@gmail.com">ccc.undocu@gmail.com</a> </li>
+</ul>
+</li>
+</ul>
+
+<ul>
+<li>Notes:<ul>
+<li>Cal Poly DREAM Center contact: Vania Agama Ramirez</li>
+<li>Cuesta Monarch DREAM Center: <a href="tel:+1-805-546-3109" aria-label="Call 805-546-3109">805-546-3109</a></li>
+<li>Allan Hancock: <a href="tel:+1-805-922-6966;ext=3177" aria-label="Call 805-922-6966 x3177">805-922-6966 x3177</a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Central-Coast-Commission-for-Senior-Citizens">Central Coast Commission for Senior Citizens</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.centralcoastseniors.org/" data-external-link="true">centralcoastseniors.org</a></li>
+<li><strong>Location:</strong> 528 S. Broadway, Santa Maria <a href="#" class="map-link" data-lat="34.948009" data-lon="-120.436107" data-zoom="17" data-label="Central Coast Commission for Senior Citizens">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-925-9554" aria-label="Call 805-925-9554">805-925-9554</a> </li>
+<li><a href="tel:+1-800-434-0222" aria-label="Call 800-434-0222">800-434-0222</a></li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@centralcoastseniors.org" aria-label="Email info@centralcoastseniors.org">info@centralcoastseniors.org</a></li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li>Notes:<ul>
+<li>the local “Area Agency on Aging” </li>
+<li>operates <a href="#" data-directory-link="Senior-Connection" aria-label="View directory entry for Senior Connection"><strong>Senior Connection</strong></a></li>
+<li>operates <a href="#" data-directory-link="HiCAP" aria-label="View directory entry for HiCAP"><strong>HiCAP</strong></a></li>
+<li>operates <a href="#" data-directory-link="CCADRC" aria-label="View directory entry for Central Coast Aging &amp; Disability Resource Center"><strong>Central Coast Aging &amp; Disability Resource Center</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="CCDS">Central Coast Dental Society</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.centralcoastdentalsociety.org/" data-external-link="true">centralcoastdentalsociety.org</a></li>
+<li><strong>Location:</strong> 1356 Marsh St., SLO <a href="#" class="map-link" data-lat="35.283784" data-lon="-120.655128" data-zoom="17" data-label="Central Coast Dental Society">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-1113" aria-label="Call 805-544-1113">805-544-1113</a> </li>
+<li><strong>Email:</strong> <a href="mailto:ccds@charter.net" aria-label="Email ccds@charter.net">ccds@charter.net</a> </li>
+</ul>
+<h2><span><a id="Central-Coast-Home-Health">Central Coast Home Health and Hospice</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://centralcoasthomehealth.com/" data-external-link="true">centralcoasthomehealth.com</a></li>
+<li><strong>Location:</strong> 253 Granada Dr. #D, SLO <a href="#" class="map-link" data-lat="35.250819" data-lon="-120.666897" data-zoom="17" data-label="Central Coast Home Health and Hospice">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-543-2244" aria-label="Call 805-543-2244">805-543-2244</a> (Home Health) </li>
+<li><a href="tel:+1-805-540-6020" aria-label="Call 805-540-6020">805-540-6020</a> (Hospice) </li>
+<li><a href="tel:+1-855-240-2530" aria-label="Call 855-240-2530">855-240-2530</a> (Medi-Cal verification and financial assistance)</li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@cchh08.com" aria-label="Email info@cchh08.com">info@cchh08.com</a> </li>
+<li><strong>Hours:</strong> 24/7 (Monday–Sunday)</li>
+<li>Notes: Accepts Medicare; call <a href="tel:+1-855-240-2530" aria-label="Call 855-240-2530">855-240-2530</a> to verify Medi-Cal acceptance and discuss financial assistance options</li>
+</ul>
+<h2><span><a id="CCPAW">Central Coast Partnership for Animal Welfare</a></span></h2>
+<ul>
+<li><strong>Locations:</strong> (pet food distribution)<ul>
+<li>946 Rockaway Ave., Grover Beach (<a href="#" data-directory-link="Lifepoint-Church" aria-label="View directory entry for Lifepoint Church"><strong>Lifepoint Church</strong></a>) <a href="#" class="map-link" data-lat="35.120091" data-lon="-120.619796" data-zoom="17" data-label="Central Coast Partnership for Animal Welfare">Map</a></li>
+<li>parking lot at 1710 Ocean St., Oceano <a href="#" class="map-link" data-lat="35.100069" data-lon="-120.612256" data-zoom="17" data-label="Central Coast Partnership for Animal Welfare">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-574-0563" aria-label="Call 805-574-0563">805-574-0563</a><ul>
+<li>Emergency Pet Care: <a href="tel:+1-775-841-7463" aria-label="Call 775-841-7463">775-841-7463</a></li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:mamagack@hotmail.com" aria-label="Email mamagack@hotmail.com">mamagack@hotmail.com</a></li>
+<li><strong>Hours:</strong><ul>
+<li>Grover Beach: M–F, 2–3:30pm</li>
+<li>Oceano: W 1–2pm</li>
+</ul>
+</li>
+<li><strong>How to access:</strong><ul>
+<li>For pet food distributions, come to locations during operating hours, or call them for delivery options</li>
+<li>For emergency pet care, call, then a case manager conducts interview for Emergency Vet Care Program qualification and vet referrals</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Central-Coast-Senior-Center">Central Coast Senior Center (Oceano)</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 1580 Railroad St., Oceano <a class="map-link" data-lat="35.101131" data-lon="-120.617666" data-zoom="17" data-label="Central Coast Senior Center (Oceano)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-481-7886" aria-label="Call 805-481-7886">805-481-7886</a> </li>
+<li><strong>Hours:</strong> M–F, 9am–3pm </li>
+<li>Notes:<ul>
+<li>Open to seniors 50+; for more information call <a href="#" data-directory-link="Senior-Connection" aria-label="View directory entry for Senior Connection"><strong>Senior Connection</strong></a></li>
+<li>Activities cost $2 for members, $3 for non-members (membership is $30 for individuals, $40 for couples)</li>
+<li>A lunch site for meals offered through <a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span>Central Coast Tax-Aide</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="AARP-Tax-Aide" aria-label="View directory entry for AARP Tax-Aide Program"><strong>AARP Tax-Aide Program</strong></a></em></p>
+</blockquote>
+
+
+<h2><span>CHC</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Child-Care-Resource-Connection">Child Care Resource Connection</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/child-care-resource-connection/" data-external-link="true">capslo.org/child-care-resource-connection</a></li>
+<li><strong>Location:</strong> 805A Fiero Ln., SLO <a href="#" class="map-link" data-lat="35.244059" data-lon="-120.642200" data-zoom="17" data-label="Child Care Resource Connection">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-888-727-2272" aria-label="Call 888-727-2272">888-727-2272</a> </li>
+<li><a href="tel:+1-805-541-2272" aria-label="Call 805-541-2272">805-541-2272</a> (SLO) </li>
+<li><a href="tel:+1-805-474-2062" aria-label="Call 805-474-2062">805-474-2062</a> (South County)</li>
+<li><a href="tel:+1-805-226-3249" aria-label="Call 805-226-3249">805-226-3249</a> (North County)</li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F, 8am–5pm</li>
+<li><strong>How to access:</strong> walk-ins OK<ul>
+<li>get a referral from the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>operated by <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo"><strong>Community Action Partnership San Luis Obispo</strong></a></li>
+<li>there is often a waiting list for some services</li>
+<li>toy lending library by appointment only</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Child-Development-Resource-Center">Child Development Resource Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.childrensresource.org/" data-external-link="true">childrensresource.org</a></li>
+<li><strong>Location:</strong> 1720 Bishop St., SLO <a href="#" class="map-link" data-lat="35.275653" data-lon="-120.644484" data-zoom="17" data-label="Child Development Resource Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-0801" aria-label="Call 805-544-0801">805-544-0801</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slocdc.org" aria-label="Email info@slocdc.org">info@slocdc.org</a></li>
+<li><strong>How to access:</strong> Complete <a href="https://www.childrensresource.org/regristration" data-external-link="true">an application</a> or get a referral from child welfare services or from a legal, medical, social services, or emergency shelter provider. Tuition is on a sliding scale based on income. Financial aid is available.</li>
+</ul>
+
+
+<h2><span><a id="Child-Support-Services">Child Support Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/child-support" data-external-link="true">slocounty.ca.gov/departments/child-support</a></li>
+<li><strong>Location:</strong> 1200 Monterey St., SLO <a href="#" class="map-link" data-lat="35.283704" data-lon="-120.658514" data-zoom="17" data-label="Child Support Services">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-866-901-3212" aria-label="Call 866-901-3212">866-901-3212</a> </li>
+<li><strong>Email:</strong> <a href="mailto:css@co.slo.ca.us" aria-label="Email css@co.slo.ca.us">css@co.slo.ca.us</a> </li>
+<li><strong>Hours:</strong> M–F 8am–4:30pm </li>
+</ul>
+<h2><span><a id="Childrens-Resource-Network-of-the-Central-Coast">Children’s Resource Network of the Central Coast</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.childrensresourcenetwork.org" data-external-link="true">childrensresourcenetwork.org</a> </li>
+<li><strong>Location:</strong> 1212 Farroll Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.111293" data-lon="-120.602116" data-zoom="17" data-label="Children’s Resource Network of the Central Coast">Map</a> </li>
+<li><strong>Mailing address:</strong> P.O. Box 454, Pismo Beach, CA 93448-0454</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-709-8673" aria-label="Call 805-709-8673">805-709-8673</a> </li>
+<li><strong>Email:</strong> <a href="mailto:lisa@childrensresourcenetwork.org" aria-label="Email lisa@childrensresourcenetwork.org">lisa@childrensresourcenetwork.org</a> </li>
+<li>Notes: Operates “Outreach Apparel” and “The Teen’s Closet”</li>
+</ul>
+<h2><span>Children’s Services</span></h2>
+<blockquote>
+<p>*See <a href="#" data-directory-link="California-Childrens-Services" aria-label="View directory entry for California Children’s Services"><strong>California Children’s Services</strong></a></p>
+</blockquote>
+<h2><span><a id="City-of-SLO-Parks-and-Recreation">City of SLO Parks and Recreation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocity.org/government/department-directory/parks-and-recreation" data-external-link="true">slocity.org/government/department-directory/parks-and-recreation</a></li>
+<li><strong>Location:</strong> 1341 Nipomo St., SLO <a href="#" class="map-link" data-lat="35.276384" data-lon="-120.664500" data-zoom="17" data-label="City of SLO Parks and Recreation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-7300" aria-label="Call 805-781-7300">805-781-7300</a> </li>
+<li><strong>Email:</strong> <a href="mailto:recreation@slocity.org" aria-label="Email recreation@slocity.org">recreation@slocity.org</a> </li>
+<li><strong>Hours:</strong> M–F 8am–4pm </li>
+</ul>
+<h2><span>Coalition for Undocumented Student Success</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Central-Coast-Coalition-for-Undocumented-Student-Success" aria-label="View directory entry for Central Coast Coalition for Undocumented Student Success"><strong>Central Coast Coalition for Undocumented Student Success</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Coastal-Dunes">Coastal Dunes RV Park &amp; Campground</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocountyparks.com/camp/coastal-dunes/" data-external-link="true">slocountyparks.com/camp/coastal-dunes</a></li>
+<li><strong>Location:</strong> 1001 Pacific Blvd. <a href="#" class="map-link" data-lat="35.113119" data-lon="-120.625704" data-zoom="16" data-label="Coastal Dunes RV Park">Map</a></li>
+<li><strong>Phone:</strong><ul>
+<li>Park ranger office <a href="tel:+1-805-781-4900" aria-label="Call 805-781-4900">805-781-4900</a>  M–Th 8am–4:30pm; F–Su 8am–6pm</li>
+<li>Reservations: <a href="tel:+1-805-781-5930" aria-label="Call 805-781-5930">805-781-5930</a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="CoastHills-Credit-Union">CoastHills Credit Union</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://coasthills.coop/" data-external-link="true">coasthills.coop</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1360 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.121113" data-lon="-120.604811" data-zoom="17" data-label="CoastHills Credit Union">Map</a></td>
+<td data-label="Hours">M–Th 9am–5pm, F 9am–6pm, Sa. 10am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">8900 Pueblo Ave., Atascadero <a href="#" class="map-link" data-lat="35.479914" data-lon="-120.658349" data-zoom="17" data-label="CoastHills Credit Union">Map</a></td>
+<td data-label="Hours">M–Th 9am–5pm, F 9am–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">671 W. Tefft St. #6, Nipomo <a href="#" class="map-link" data-lat="35.036884" data-lon="-120.487468" data-zoom="17" data-label="CoastHills Credit Union">Map</a></td>
+<td data-label="Hours">M–Th 9am–5pm, F 9am–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">1402 Spring St., Paso Robles <a href="#" class="map-link" data-lat="35.629040" data-lon="-120.691354" data-zoom="17" data-label="CoastHills Credit Union">Map</a></td>
+<td data-label="Hours">M–Th 9am–5pm, F 9am–6pm, Sa. 10am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">751 Marsh St., SLO <a href="#" class="map-link" data-lat="35.278378" data-lon="-120.662853" data-zoom="17" data-label="CoastHills Credit Union">Map</a></td>
+<td data-label="Hours">M–Th 9am–5pm, F 9am–6pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-733-7600" aria-label="Call 805-733-7600">805-733-7600</a> / <a href="tel:+1-800-262-4488" aria-label="Call 800-262-4488">800-262-4488</a> </li>
+</ul>
+<h2><span>Commission for Senior Citizens</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Central-Coast-Commission-for-Senior-Citizens" aria-label="View directory entry for Central Coast Commission for Senior Citizens"><strong>Central Coast Commission for Senior Citizens</strong></a></em></p>
+</blockquote>
+<h2><span><a id="CAPSLO">Community Action Partnership San Luis Obispo (CAPSLO)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/" data-external-link="true">capslo.org</a></li>
+<li><strong>Location:</strong><ul>
+<li>Main Office: 1030 Southwood Dr., SLO <a href="#" class="map-link" data-lat="35.266202" data-lon="-120.642336" data-zoom="17" data-label="CAPSLO">Map</a> </li>
+<li>Homeless Services: 40 Prado Rd., SLO <a href="#" class="map-link" data-lat="35.256218" data-lon="-120.672031" data-zoom="17" data-label="40 Prado Homeless Services Center">Map</a> </li>
+<li>Energy Office: 3970 Short St. #110, SLO <a href="#" class="map-link" data-lat="35.245356" data-lon="-120.672187" data-zoom="17" data-label="CAPSLO Home and Energy Services">Map</a> (no walk-ins) </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li>Hotline: <a href="tel:+1-805-706-8663" aria-label="Call 805-706-8663">805-706-8663</a> </li>
+<li>Administration: <a href="tel:+1-805-544-4355" aria-label="Call 805-544-4355">805-544-4355</a> </li>
+<li>Homeless Services Center: <a href="tel:+1-805-544-4004" aria-label="Call 805-544-4004">805-544-4004</a></li>
+<li>Low Income Home Energy Assistance Program: <a href="tel:+1-805-541-4122;ext=2125" aria-label="Call 805-541-4122&nbsp;x2125">805-541-4122&nbsp;x2125</a> or <a href="tel:+1-800-495-0501;ext=2114" aria-label="Call 800-495-0501&nbsp;x2114">800-495-0501&nbsp;x2114</a></li>
+<li>Energy Office: <a href="tel:+1-805-541-4122" aria-label="Call 805-541-4122">805-541-4122</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:hotline@capslo.org" aria-label="Email hotline@capslo.org">hotline@capslo.org</a> <ul>
+<li>Low Income Home Energy Assistance Program: <a href="mailto:HEAP@capslo.org" aria-label="Email HEAP@capslo.org">HEAP@capslo.org</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 9am–5pm<ul>
+<li>Energy Office: M–F 8am–Noon &amp; 1pm–4pm (no walk-ins)</li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>operates <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a></li>
+<li>operates <a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health &amp; Prevention"><strong>The Center for Health &amp; Prevention</strong></a></li>
+<li>operates “Child Care Resource Connection (CCRC)”</li>
+<li>operates <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+<li>operates “Head Start”</li>
+<li>operates “Home and Energy Services”</li>
+<li>operates <a href="#" data-directory-link="Liberty-Tattoo-Removal-Program" aria-label="View directory entry for Liberty Tattoo Removal Program"><strong>Liberty Tattoo Removal Program</strong></a></li>
+<li>operates “Low Income Home Energy Assistance Program (LIHEAP)”</li>
+<li>operates <a href="#" data-directory-link="Outreach-and-Engagement-Services" aria-label="View directory entry for Outreach &amp; Engagement Services"><strong>Outreach &amp; Engagement Services</strong></a></li>
+<li>operates <a href="#" data-directory-link="Rotating-Overnight-Safe-Parking-Program" aria-label="View directory entry for Rotating Overnight Safe Parking Program"><strong>Rotating Overnight Safe Parking Program</strong></a></li>
+<li>operates “Senior Health Screening”</li>
+<li>operates <a href="#" data-directory-link="Supportive-Services-for-Veteran-Families" aria-label="View directory entry for Supportive Services for Veteran Families"><strong>Supportive Services for Veteran Families</strong></a></li>
+<li>operates “Teen Wellness”</li>
+<li>partner in <a href="#" data-directory-link="SLO-Hub" aria-label="View directory entry for SLO Hub"><strong>SLO Hub</strong></a></li>
+<li>partner in <a href="#" data-directory-link="SLO-County-UndocuSupport" aria-label="View directory entry for SLO County UndocuSupport"><strong>SLO County UndocuSupport</strong></a></li>
+<li>entry-point for the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+<li>entry-point for the <a href="#" data-directory-link="Enhanced-Care-Management" aria-label="View directory entry for Enhanced Care Management"><strong>Enhanced Care Management</strong></a></li>
+<li>on board of “Emergency Food and Shelter Program”</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Community-Counseling-Center">Community Counseling Center</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="Cal-Poly-Community-Counseling-Service" aria-label="View directory entry for Cal Poly Community Counseling Service"><strong>Cal Poly Community Counseling Service</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.cccslo.org/what-we-do.php" data-external-link="true">cccslo.org/what-we-do.php</a></li>
+<li><strong>Location:</strong> 676 Pismo St., SLO <a href="#" class="map-link" data-lat="35.276497" data-lon="-120.662980" data-zoom="17" data-label="Community Counseling Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-7969" aria-label="Call 805-543-7969">805-543-7969</a> </li>
+<li><strong>Hours:</strong> M–F 9am–6pm </li>
+<li><strong>How to access:</strong> Call to make an appointment or use their <a href="https://www.cccslo.org/locations.php" data-external-link="true">contact form</a> </li>
+</ul>
+<h2><span>Community Counseling Service</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Cal-Poly-Community-Counseling-Service" aria-label="View directory entry for Cal Poly Community Counseling Service"><strong>Cal Poly Community Counseling Service</strong></a></em></p>
+</blockquote>
+<h2><span>Community Foundation of SLO County</span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.cfsloco.org/" data-external-link="true">cfsloco.org</a></li>
+<li><strong>Location:</strong> 550 Dana St., SLO <a href="#" class="map-link" data-lat="35.278881" data-lon="-120.667651" data-zoom="17" data-label="Community Foundation of SLO County">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-2323" aria-label="Call 805-543-2323">805-543-2323</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@cfsloco.org" aria-label="Email info@cfsloco.org">info@cfsloco.org</a> </li>
+</ul>
+
+<ul>
+<li>Note: partner in <a href="#" data-directory-link="SLO-County-UndocuSupport" aria-label="View directory entry for SLO County UndocuSupport"><strong>SLO County UndocuSupport</strong></a></li>
+</ul>
+<h2><span><a id="CHC">Community Health Centers of the Central Coast</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.communityhealthcenters.org/" data-external-link="true">communityhealthcenters.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">260 Station Way, Arroyo Grande <a href="#" class="map-link" data-lat="35.119769" data-lon="-120.578564" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-573-6201" aria-label="Call 805-573-6201">805-573-6201</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">1057 Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.118759" data-lon="-120.595400" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-270-1700" aria-label="Call 805-270-1700">805-270-1700</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">1205 E. Grand Ave. #H, Arroyo Grande <a href="#" class="map-link" data-lat="35.120369" data-lon="-120.600572" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-994-2300" aria-label="Call 805-994-2300">805-994-2300</a></td>
+<td data-label="Notes">(“urgent care”; walk-ins OK; M–F 8am–8pm, Sa/Su 9am–5pm)</td>
+</tr>
+<tr>
+<td data-label="Location">7512 Morro Rd., Atascadero <a href="#" class="map-link" data-lat="35.477246" data-lon="-120.667898" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-792-1400" aria-label="Call 805-792-1400">805-792-1400</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">1276 Tamsen Dr., Cambria <a href="#" class="map-link" data-lat="35.565935" data-lon="-121.079680" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-927-5292" aria-label="Call 805-927-5292">805-927-5292</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">150 Tejas Place, Nipomo <a href="#" class="map-link" data-lat="35.027106" data-lon="-120.499120" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-929-3211" aria-label="Call 805-929-3211">805-929-3211</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">2120 Cienaga St., Oceano <a href="#" class="map-link" data-lat="35.097852" data-lon="-120.608650" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-994-2100" aria-label="Call 805-994-2100">805-994-2100</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">2800 Riverside Ave. #101, Paso Robles <a href="#" class="map-link" data-lat="35.643630" data-lon="-120.688162" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-238-7250" aria-label="Call 805-238-7250">805-238-7250</a></td>
+<td data-label="Notes">(“immediate care”; walk-ins OK; M–Sa 8am–Noon &amp; 1pm–5pm)</td>
+</tr>
+<tr>
+<td data-label="Location">1385 Mission St., San Miguel <a href="#" class="map-link" data-lat="35.752573" data-lon="-120.696391" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-467-2344" aria-label="Call 805-467-2344">805-467-2344</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">1551 Bishop St. #240, SLO <a href="#" class="map-link" data-lat="35.273443" data-lon="-120.644957" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-549-0402" aria-label="Call 805-549-0402">805-549-0402</a></td>
+<td data-label="Notes">(specializes in women’s health)</td>
+</tr>
+<tr>
+<td data-label="Location">77 Casa St., SLO <a href="#" class="map-link" data-lat="35.292914" data-lon="-120.665307" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-269-1500" aria-label="Call 805-269-1500">805-269-1500</a></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">40 Prado, SLO <a href="#" class="map-link" data-lat="35.256495" data-lon="-120.672000" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-269-1500" aria-label="Call 805-269-1500">805-269-1500</a></td>
+<td data-label="Notes">(<a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a>)</td>
+</tr>
+<tr>
+<td data-label="Location">1330 Las Tablas Rd., Templeton <a href="#" class="map-link" data-lat="35.554714" data-lon="-120.723803" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-542-6700" aria-label="Call 805-542-6700">805-542-6700</a></td>
+<td data-label="Notes">(“immediate care”; walk-ins OK; M–Th 8am–6pm)</td>
+</tr>
+<tr>
+<td data-label="Location">292 Posada Ln., Templeton <a href="#" class="map-link" data-lat="35.553046" data-lon="-120.721773" data-zoom="17" data-label="Community Health Centers of the Central Coast">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-542-6701" aria-label="Call 805-542-6701">805-542-6701</a></td>
+<td data-label="Notes"></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-866-614-4636" aria-label="Call 866-614-4636">866-614-4636</a> <ul>
+<li>Text: <a href="sms:+1-805-361-8400">805-361-8400</a> </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> “Immediate care” or “urgent care” centers accept walk-ins. Otherwise, make an appointment.<ul>
+<li>Accepts private pay, full- and partially-insured, Medi-Cal, and Medicare. Also offers a sliding fee scale based on income and family size to people without any health insurance. </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Also operates <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> at the <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a></li>
+<li>“CHC Transportation Services” is a door-to-door ride service to appointments (<a href="tel:+1-877-743-3242" aria-label="Call 877-743-3242">877-743-3242</a>)</li>
+</ul>
+</li>
+</ul>
+
+
+<h2><span><a id="Community-Partners-in-Caring">Community Partners in Caring</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://partnersincaring.org/" data-external-link="true">partnersincaring.org</a></li>
+<li><strong>Location:</strong> 120 E. Jones St. #130, Santa Maria <a href="#" class="map-link" data-lat="34.945579" data-lon="-120.434639" data-zoom="17" data-label="Community Partners in Caring">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-925-8000" aria-label="Call 805-925-8000">805-925-8000</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@partnersincaring.org" aria-label="Email info@partnersincaring.org">info@partnersincaring.org</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–5pm </li>
+<li><strong>How to access:</strong> Complete the client onboarding forms (which can be done via their website) to access the services. </li>
+<li>Notes: operates in Nipomo and the Five Cities area, in addition to Santa Barbara County</li>
+</ul>
+<h2><span>Community Safe Parking Program</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Rotating-Overnight-Safe-Parking-Program" aria-label="View directory entry for Rotating Overnight Safe Parking Program"><strong>Rotating Overnight Safe Parking Program</strong></a></em></p>
+</blockquote>
+<h2><span><a id="CES">Coordinated Entry System (CES)</a></span></h2>
+<ul>
+<li><strong>How to access:</strong><ul>
+<li>South County: Contact <a href="Directory#5CHC"><strong>5Cities Homeless Coalition</strong></a></li>
+<li>County-wide: Contact <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></li>
+<li>Or initiate contact via other participating agencies like <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a>, <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a>, <a href="#" data-directory-link="Good-Samaritan-Shelter" aria-label="View directory entry for Good Samaritan Shelter"><strong>Good Samaritan Shelter</strong></a>, <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>, <a href="#" data-directory-link="SLO-County-Health-Department" aria-label="View directory entry for SLO County Health Department"><strong>SLO County Health Department</strong></a></li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Point of entry for <a href="#" data-directory-link="Housing-Now" aria-label="View directory entry for Housing Now"><strong>Housing Now</strong></a>, (at least some of) <a href="#" data-directory-link="Peoples-Self-Help-Housing" aria-label="View directory entry for Peoples’ Self-Help Housing"><strong>Peoples’ Self-Help Housing</strong></a>, <a href="#" data-directory-link="Welcome-Home-Village" aria-label="View directory entry for Welcome Home Village"><strong>Welcome Home Village</strong></a></li>
+<li>Overseen by “Homeless Services Oversight Council (HSOC)”</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Cottage-Urgent-Care">Cottage Urgent Care</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.cottagehealth.org/urgent-care/" data-external-link="true">cottagehealth.org/urgent-care</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Marigold Center: 3970 Broad Street Suite 2, SLO <a href="#" class="map-link" data-lat="35.249334" data-lon="-120.643117" data-zoom="17" data-label="Cottage Urgent Care">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-762-4996" aria-label="Call 805-762-4996">805-762-4996</a></td>
+<td data-label="Hours">Every day: 8am–8pm</td>
+</tr>
+<tr>
+<td data-label="Location">Foothill Plaza: 777 E. Foothill Blvd., SLO <a href="#" class="map-link" data-lat="35.292930" data-lon="-120.671889" data-zoom="17" data-label="Cottage Urgent Care">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-762-4348" aria-label="Call 805-762-4348">805-762-4348</a></td>
+<td data-label="Hours">Every day 8am–8pm</td>
+</tr>
+</tbody></table>
+<h2><span>County of San Luis Obispo Public Libraries</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a></em></p>
+</blockquote>
+
+
+<h2><span>Court Appointed Special Advocates (CASA)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CASA" aria-label="View directory entry for CASA (Court Appointed Special Advocates)"><strong>CASA (Court Appointed Special Advocates)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="CSF-Medical-Non-Profit-Foundation">CSF Medical Non Profit Foundation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://csffoundation.org/" data-external-link="true">csffoundation.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-661-404-4748" aria-label="Call 661-404-4748">661-404-4748</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@csffoundation.org" aria-label="Email info@csffoundation.org">info@csffoundation.org</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5:30pm </li>
+</ul>
+<h2><span><a id="Cuesta-College">Cuesta College</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.cuesta.edu/" data-external-link="true">cuesta.edu</a></li>
+<li><strong>Locations:</strong><ul>
+<li>SLO Campus: 3000 Education Dr., SLO (at Highway 1) <a href="#" class="map-link" data-lat="35.329042" data-lon="-120.740620" data-zoom="15" data-label="Cuesta College">Map</a> </li>
+<li>North County Campus: 2800 Buena Vista Dr., Paso Robles <a href="#" class="map-link" data-lat="35.650499" data-lon="-120.670746" data-zoom="15" data-label="Cuesta College">Map</a> </li>
+<li>South County Center: A.G. High School office, room 900, corner of Orchard St. &amp; W. Cherry Ave, Arroyo Grande <a href="#" class="map-link" data-lat="35.117021" data-lon="-120.577601" data-zoom="15" data-label="Cuesta College">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-546-3100" aria-label="Call 805-546-3100">805-546-3100</a> (SLO Campus) </li>
+<li><a href="tel:+1-805-591-6200" aria-label="Call 805-591-6200">805-591-6200</a> (North County Campus) </li>
+<li><a href="tel:+1-805-474-3913" aria-label="Call 805-474-3913">805-474-3913</a> (South County Center) </li>
+<li><a href="tel:+1-805-591-6273" aria-label="Call 805-591-6273">805-591-6273</a> (Continuing Education Office)</li>
+<li>English as a Second Language (ESL) program:<ul>
+<li><a href="tel:+1-805-592-9463" aria-label="Call 805-592-9463">805-592-9463</a> (SLO Campus) </li>
+<li><a href="tel:+1-805-591-6273" aria-label="Call 805-591-6273">805-591-6273</a> (North County Campus) </li>
+<li><a href="tel:+1-805-592-9463" aria-label="Call 805-592-9463">805-592-9463</a> (South County Center) </li>
+<li>Call M–Th 10am–7pm</li>
+</ul>
+</li>
+<li>Continuing Education program:<ul>
+<li><a href="tel:+1-805-592-9463" aria-label="Call 805-592-9463">805-592-9463</a> (SLO Campus) </li>
+<li><a href="tel:+1-805-591-6273" aria-label="Call 805-591-6273">805-591-6273</a> (North County Campus) </li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:basicneeds@cuest.edu" aria-label="Email basicneeds@cuest.edu">basicneeds@cuest.edu</a> (Basic Needs Center) </li>
+<li><a href="mailto:admit@cuesta.edu" aria-label="Email admit@cuesta.edu">admit@cuesta.edu</a> (Admission)</li>
+<li><a href="mailto:scchelp@cuesta.edu" aria-label="Email scchelp@cuesta.edu">scchelp@cuesta.edu</a> (South County Campus)</li>
+<li><a href="mailto:ContinuingEd@cuesta.edu" aria-label="Email ContinuingEd@cuesta.edu">ContinuingEd@cuesta.edu</a> (Continuing Education) </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Basic Needs Office is in room 5014B of the SLO campus, open M/Th/F 9am–4pm, Tu 9am–6pm </li>
+<li>The Paso Robles campus hosts a Cougar Food Pantry for students in room N1005, M–F 9am–5pm; <a href="tel:+1-805-591-4301" aria-label="Call 805-591-4301">805-591-4301</a> </li>
+<li>The SLO campus hosts a Cougar Food Pantry for students in room 5014A’s cafeteria, M–F 9am–4:30pm </li>
+<li><a href="https://www.cuesta.edu/community/index.html" data-external-link="true">Community Education</a> programs are open to otherwise unenrolled people</li>
+<li><a href="https://www.cuesta.edu/academics/continuinged/" data-external-link="true">Continuing Education</a> has vocational / lifetime-learning programs, and ESL</li>
+<li>Partners with <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for The Bridge Cafe"><strong>The Bridge Cafe</strong></a> for its Culinary Arts program</li>
+<li>Partners with <a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> for ESL classes</li>
+<li>The SLO &amp; North County campuses are <a href="#" data-directory-link="SLO-Food-Bank" aria-label="View directory entry for SLO Food Bank"><strong>SLO Food Bank</strong></a> food box distribution sites </li>
+</ul>
+</li>
+</ul>
+<h2><span>Deaf and Disabled Telecommunication Program (DDTP)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="California-Connect" aria-label="View directory entry for California Connect"><strong>California Connect</strong></a></em></p>
+</blockquote>
+<h2><span>Denti-Cal Dental Care Dentist Referral</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CCDS" aria-label="View directory entry for Central Coast Dental Society"><strong>Central Coast Dental Society</strong></a></em></p>
+</blockquote>
+<h2><span>Department of Motor Vehicles (DMV)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="California-DMV" aria-label="View directory entry for California DMV"><strong>California DMV</strong></a></em></p>
+</blockquote>
+<h2><span>Department of Rehabilitation</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="California-Department-of-Rehabilitation" aria-label="View directory entry for California Department of Rehabilitation"><strong>California Department of Rehabilitation</strong></a></em></p>
+</blockquote>
+<h2><span>Department of Social Services</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Dignity-Health">Dignity Health</a></span></h2>
+<ul>
+<li>Website: <a href="https://www.dignityhealth.org/" data-external-link="true">dignityhealth.org</a></li>
+<li>Operates <a href="#" data-directory-link="Arroyo-Grande-Community-Hospital" aria-label="View directory entry for Arroyo Grande Community Hospital"><strong>Arroyo Grande Community Hospital</strong></a>, <a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a>, and <a href="#" data-directory-link="Dignity-Health-Urgent-Care" aria-label="View directory entry for Dignity Health Urgent Care"><strong>Dignity Health Urgent Care</strong></a></li>
+<li>Operates the “Substance Use Navigator” program</li>
+</ul>
+<h2><span><a id="Dignity-Health-Urgent-Care">Dignity Health Urgent Care</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="Dignity-Health" aria-label="View directory entry for Dignity Health"><strong>Dignity Health</strong></a></em></p>
+</blockquote>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Atascadero: 5920 W Mall, Atascadero <a href="#" class="map-link" data-lat="35.489540" data-lon="-120.668170" data-zoom="17" data-label="Dignity Health Urgent Care">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-461-2131" aria-label="Call 805-461-2131">805-461-2131</a></td>
+</tr>
+<tr>
+<td data-label="Location">Pismo Beach: 877 Oak Park Blvd, Pismo Beach <a href="#" class="map-link" data-lat="35.132062" data-lon="-120.606526" data-zoom="17" data-label="Dignity Health Urgent Care">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-8450" aria-label="Call 805-474-8450">805-474-8450</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Hours:</strong> M–F 8am–6pm, Sa 8am–4pm, Su closed </li>
+<li>Notes: Accepts Medicare and Medi-Cal as well as several private insurers; walk-ins welcome, no appointment necessary; lab and X-ray services on site </li>
+</ul>
+<h2><span><a id="Disability-Rights-California">Disability Rights California</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.disabilityrightsca.org/get-help" data-external-link="true">www.disabilityrightsca.org/get-help</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-776-5746" aria-label="Call 800-776-5746">800-776-5746</a> (TTY: <a href="tel:+1-800-719-5798" aria-label="Call 800-719-5798">800-719-5798</a>) </li>
+<li><strong>Hours:</strong> M/Tu/Th/F 9am–3pm </li>
+</ul>
+<h2><span><a id="Discipleship-Home">Discipleship Home</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://thediscipleshiphome.com/" data-external-link="true">thediscipleshiphome.com</a></li>
+<li><strong>Location:</strong> 1359 21st Court, Oceano <a class="map-link" data-lat="35.104942" data-lon="-120.607980" data-zoom="17" data-label="Discipleship Home">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-668-9185" aria-label="Call 805-668-9185">805-668-9185</a> </li>
+<li><strong>Email:</strong> <a href="mailto:thediscipleshiphome15@gmail.com" aria-label="Email thediscipleshiphome15@gmail.com">thediscipleshiphome15@gmail.com</a> </li>
+</ul>
+<h2><span>DMV</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="California-DMV" aria-label="View directory entry for California DMV"><strong>California DMV</strong></a></em></p>
+</blockquote>
+<h2><span>Doggy Days</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Cal-Poly-Doggy-Days" aria-label="View directory entry for Cal Poly “Doggy Days” Veterinary Clinics"><strong>Cal Poly “Doggy Days” Veterinary Clinics</strong></a></em></p>
+</blockquote>
+
+
+<h2><span>Drug and Alcohol Services</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Drug-and-Alcohol-Services" aria-label="View directory entry for SLO County Drug and Alcohol Services"><strong>SLO County Drug and Alcohol Services</strong></a></em></p>
+</blockquote>
+<h2><span>ECHO</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Eckerd-Connects-Workforce-Development">Eckerd Connects Workforce Development</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.eckerd.org/jobs-training/slo/" data-external-link="true">eckerd.org/jobs-training/slo</a></li>
+<li><strong>Locations:</strong><ul>
+<li>3450 Broad Street #103A, SLO <a href="#" class="map-link" data-lat="35.257894" data-lon="-120.646738" data-zoom="17" data-label="Eckerd Connects">Map</a> </li>
+<li>534 Spring Street, Paso Robles <a href="#" class="map-link" data-lat="35.619702" data-lon="-120.690592" data-zoom="17" data-label="Eckerd Connects">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-439-2557" aria-label="Call 805-439-2557">805-439-2557</a> </li>
+<li><a href="tel:+1-941-585-9659" aria-label="Call 941-585-9659">941-585-9659</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:SLOCal@eckerd.org" aria-label="Email SLOCal@eckerd.org">SLOCal@eckerd.org</a></li>
+<li><strong>Hours:</strong> M–F 9am–4pm (SLO)</li>
+</ul>
+<h2><span><a id="ECHO">El Camino Homeless Organization (ECHO)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.echoshelter.org/" data-external-link="true">www.echoshelter.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>6370 Atascadero Ave., Atascadero <a href="#" class="map-link" data-lat="35.486312" data-lon="-120.670295" data-zoom="17" data-label="El Camino Homeless Organization">Map</a> </li>
+<li>1134 Black Oak Dr., Paso Robles <a href="#" class="map-link" data-lat="35.645387" data-lon="-120.687569" data-zoom="17" data-label="El Camino Homeless Organization">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-462-3663" aria-label="Call 805-462-FOOD">805-462-FOOD</a> </li>
+<li><strong>Email:</strong> <a href="mailto:wlewis@echoshelter.org" aria-label="Email wlewis@echoshelter.org">wlewis@echoshelter.org</a> </li>
+<li><strong>How to access:</strong><ul>
+<li>For transitional housing, contact ECHO to get on a waiting list; for dinner/showers/laundry, just attend on time</li>
+<li>Emergency shelter bed signup at the Paso Robles location only, 4:30–5:30pm </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Dinner (also available to non-residents) at 5pm at both locations </li>
+<li>Showers (available to non-residents) M–F from 4–5:30pm at both locations </li>
+<li>Laundry (available to non-residents) W from 10am–6pm at the Paso Robles location. </li>
+<li>The Paso Robles location operates as an emergency warming center during adverse weather </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="El-Chorro-Regional-Park-Campground">El Chorro Regional Park Campground</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocountyparks.com/camp/el-chorro/" data-external-link="true">slocountyparks.com/camp/el-chorro</a></li>
+<li><strong>Location:</strong> State Hwy 1 @ Dairy Creek (4 miles NW of SLO) <a href="#" class="map-link" data-lat="35.338721" data-lon="-120.720193" data-zoom="13" data-label="El Chorro Regional Park Campground">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5930;ext=4" aria-label="Call 805-781-5930 x4">805-781-5930 x4</a> (Monday–Friday 8:30am–4:30pm)</li>
+<li><strong>Email:</strong> <a href="mailto:sloparks@co.slo.ca.us" aria-label="Email sloparks@co.slo.ca.us">sloparks@co.slo.ca.us</a></li>
+</ul>
+
+
+<h2><span><a id="Employment-Development-Department">Employment Development Department</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://edd.ca.gov/" data-external-link="true">edd.ca.gov</a></li>
+<li><strong>Location:</strong> 3450 Broad St. #103A, SLO <a href="#" class="map-link" data-lat="35.257956" data-lon="-120.646557" data-zoom="17" data-label="EDD">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-800-300-5616" aria-label="Call 800-300-5616">800-300-5616</a></li>
+<li>Local office: <a href="tel:+1-805-878-2842" aria-label="Call 805-878-2842">805-878-2842</a></li>
+<li>Customer service: <a href="tel:+1-805-439-2557" aria-label="Call 805-439-2557">805-439-2557</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li>Notes:<ul>
+<li>Operates “Migrant Seasonal Farmworker” program</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Enhanced-Care-Management">Enhanced Care Management</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/enhanced-care-management" data-external-link="true">slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/enhanced-care-management</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-4687" aria-label="Call 805-781-4687">805-781-4687</a> </li>
+<li><strong>Email:</strong> <a href="mailto:ph.ecm@co.slo.ca.us" aria-label="Email ph.ecm@co.slo.ca.us">ph.ecm@co.slo.ca.us</a> </li>
+<li>Notes:<ul>
+<li><a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a> is the entry-point for this program (including its <a href="#" data-directory-link="Outreach-and-Engagement-Services" aria-label="View directory entry for Outreach and Engagement Services"><strong>Outreach and Engagement Services</strong></a> center)</li>
+<li>Offered to youth through <a href="#" data-directory-link="Seneca-Central-Coast" aria-label="View directory entry for Seneca Central Coast"><strong>Seneca Central Coast</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="EyeCare-America">EyeCare America</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://aao.org/eyecare-america" data-external-link="true">aao.org/eyecare-america</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-877-887-6327" aria-label="Call 877-887-6327">877-887-6327</a> (M–F 8am–2pm) </li>
+<li><strong>Email:</strong> <a href="mailto:eyecareamerica@aao.org" aria-label="Email eyecareamerica@aao.org">eyecareamerica@aao.org</a> </li>
+<li><strong>How to access:</strong> To begin, complete a questionnaire on their website</li>
+</ul>
+<h2><span><a id="Family-and-Industrial-Medical-Center">Family and Industrial Medical Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://fimcslo.com/" data-external-link="true">fimcslo.com</a></li>
+<li><strong>Location:</strong> 47 Santa Rosa St., SLO <a href="#" class="map-link" data-lat="35.292602" data-lon="-120.667778" data-zoom="17" data-label="Family and Industrial Medical Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-542-9596" aria-label="Call 805-542-9596">805-542-9596</a> </li>
+<li><strong>Hours:</strong> M–F 8am–7pm, Sa.–Su. 9am–4pm </li>
+</ul>
+<h2><span><a id="Family-Care-Network">Family Care Network</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://fcni.org" data-external-link="true">fcni.org</a></li>
+<li><strong>Location:</strong> 1255 Kendall Rd., SLO <a href="#" class="map-link" data-lat="35.236909" data-lon="-120.629489" data-zoom="17" data-label="Family Care">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-3535" aria-label="Call 805-781-3535">805-781-3535</a> </li>
+<li><strong>Email:</strong> <a href="mailto:Contact@fcni.org" aria-label="Email Contact@fcni.org">Contact@fcni.org</a> </li>
+<li>Notes: Operates <a href="#" data-directory-link="Housing-Support-Program" aria-label="View directory entry for Housing Support Program (HSP)"><strong>Housing Support Program (HSP)</strong></a> </li>
+</ul>
+<h2><span>FamilyPACT</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Planned-Parenthood" aria-label="View directory entry for Planned Parenthood"><strong>Planned Parenthood</strong></a></em></p>
+</blockquote>
+<h2><span>First Presbyterian Church</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Green-Pastures" aria-label="View directory entry for Green Pastures"><strong>Green Pastures</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Five-Cities-Christian-Women-Food-Pantry">Five Cities Christian Women Food Pantry</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://fivecitieschristianwomenfoodpantry.org/" data-external-link="true">fivecitieschristianwomenfoodpantry.org</a></li>
+<li><strong>Location:</strong> 946 Rockaway Ave., Grover Beach <a class="map-link" data-lat="35.120091" data-lon="-120.619796" data-zoom="17" data-label="Five Cities Christian Women Food Pantry">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-473-3368" aria-label="Call 805-473-3368">805-473-3368</a> </li>
+<li><strong>Hours:</strong> M–F 2–3:30pm except federal holidays </li>
+<li>Hosted by <a href="#" data-directory-link="Lifepoint-Church" aria-label="View directory entry for Lifepoint Church"><strong>Lifepoint Church</strong></a></li>
+</ul>
+<h2><span><a id="5Cities-Meals-on-Wheels">Five Cities Meals on Wheels</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.5citiesmow.com/" data-external-link="true">5citiesmow.com</a></li>
+<li><strong>Location:</strong> 780 Bello Street, Pismo Beach <a class="map-link" data-lat="35.143111" data-lon="-120.639100" data-zoom="17" data-label="Five Cities Meals on Wheels">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-773-2053" aria-label="Call 805-773-2053">805-773-2053</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@5citiesmow.com" aria-label="Email info@5citiesmow.com">info@5citiesmow.com</a> </li>
+</ul>
+<h2><span><a id="Flying-Flags-Avila-Beach">Flying Flags Avila Beach</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.flyingflagsavilabeach.com" data-external-link="true">flyingflagsavilabeach.com</a></li>
+<li><strong>Location:</strong> 6450 Babe Lane, Avila Beach <a href="#" class="map-link" data-lat="35.176751" data-lon="-120.754479" data-zoom="15" data-label="Flying Flags">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-888-0158" aria-label="Call 805-888-0158">805-888-0158</a></li>
+<li><strong>Hours:</strong> Every day 8am–6pm</li>
+</ul>
+<h2><span>Food Bank</span></h2>
+<blockquote>
+<p><em>See [**SLO Food Bank**](#SLO Food Bank)</em></p>
+</blockquote>
+<h2><span><a id="Food-Not-Bombs">Food Not Bombs</a></span></h2>
+<ul>
+<li><strong>Social media:</strong><ul>
+<li>Facebook: <a href="https://www.facebook.com/FoodNotBombsSLO/" data-external-link="true">facebook.com/FoodNotBombsSLO</a></li>
+<li>Instagram: <a href="https://instagram.com/foodnotbombs_slo" data-external-link="true">@foodnotbombs_slo</a></li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:slofoodnotbombs@gmail.com" aria-label="Email slofoodnotbombs@gmail.com">slofoodnotbombs@gmail.com</a> </li>
+<li><strong>Location:</strong> Mitchell Park, SLO <a href="#" class="map-link" data-lat="35.278724" data-lon="-120.657960" data-zoom="17" data-label="Food Not Bombs">Map</a> </li>
+<li><strong>Hours:</strong> Su 1–3pm </li>
+</ul>
+<h2><span><a id="Foxys-Thrift-Shop">Foxy’s Thrift Shop</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 655 Morro Bay Blvd., Morro Bay <a class="map-link" data-lat="35.366302" data-lon="-120.845882" data-zoom="17" data-label="Foxy’s Thrift Shop">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-772-8800" aria-label="Call 805-772-8800">805-772-8800</a> </li>
+<li><strong>Hours:</strong> Daily 10am–5pm</li>
+</ul>
+<h2><span><a id="Fred-and-Bettys">Fred &amp; Betty’s Thrift Store</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.fredandbettys.org" data-external-link="true">fredandbettys.org</a></li>
+<li><strong>Location:</strong> 532 Higuera St., SLO <a href="#" class="map-link" data-lat="35.277121" data-lon="-120.667745" data-zoom="17" data-label="Fred and Betty’s Thrift Store">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-593-0255" aria-label="Call 805-593-0255">805-593-0255</a> </li>
+<li><strong>Hours:</strong> M–Sa 10am–5pm </li>
+</ul>
+<h2><span><a id="French-Hospital-Medical-Center">French Hospital Medical Center</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="Dignity-Health" aria-label="View directory entry for Dignity Health"><strong>Dignity Health</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.dignityhealth.org/central-coast/locations/frenchhospital" data-external-link="true">dignityhealth.org/central-coast/locations/frenchhospital</a></li>
+<li><strong>Location:</strong> 1911 Johnson Ave., SLO <a href="#" class="map-link" data-lat="35.277962" data-lon="-120.650922" data-zoom="15" data-label="French Hospital Medical Center">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li>ER: <a href="tel:+1-805-542-6621" aria-label="Call 805-542-6621">805-542-6621</a></li>
+<li>Front desk: <a href="tel:+1-805-543-5353" aria-label="Call 805-543-5353">805-543-5353</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> 24/7</li>
+</ul>
+<h2><span><a id="Front-Porch">Front Porch</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.frontporchslo.org/" data-external-link="true">https://www.frontporchslo.org/</a></li>
+<li><strong>Location:</strong> 1468 E. Foothill, SLO <a href="#" class="map-link" data-lat="35.297443" data-lon="-120.660964" data-zoom="17" data-label="Front Porch">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-818-731-4984" aria-label="Call 818-731-4984">818-731-4984</a></li>
+<li><strong>Email:</strong> <a href="mailto:hello@frontporchslo.org" aria-label="Email hello@frontporchslo.org">hello@frontporchslo.org</a> </li>
+<li><strong>Hours:</strong> M–Th 7am–11pm, F 7am–4pm, Su 7am–6pm (depending on volunteer availability, likely closed during Cal Poly breaks) </li>
+<li><strong>How to access:</strong> oriented toward students from Cuesta College or Cal Poly, but “Whoever you are, you are welcome here” and “No matter what, you’re welcome here.” </li>
+</ul>
+<h2><span><a id="GALA">GALA Pride &amp; Diversity Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://galacc.org/" data-external-link="true">galacc.org</a></li>
+<li><strong>Location:</strong> 1060 Palm St., SLO <a href="#" class="map-link" data-lat="35.283421" data-lon="-120.661309" data-zoom="17" data-label="GALA">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-4252" aria-label="Call 805-541-4252">805-541-4252</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@galacc.org" aria-label="Email info@galacc.org">info@galacc.org</a></li>
+<li><strong>Hours:</strong> M–F 8am–5pm<ul>
+<li>Food pantry M–F 10am–3pm</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Genoa-Pharmacy">Genoa Pharmacy</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/genoa-pharmacy" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/genoa-pharmacy</a></li>
+<li><strong>Location:</strong> 2178 Johnson Avenue #P1, SLO <a href="#" class="map-link" data-lat="35.275431" data-lon="-120.646555" data-zoom="17" data-label="Genoa Pharmacy">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-242-4051" aria-label="Call 805-242-4051">805-242-4051</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–5pm (closed 12:30–1pm) </li>
+<li>Notes: The on-site pharmacy for <a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a> </li>
+</ul>
+<h2><span>GLAD</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Tri-County-GLAD" aria-label="View directory entry for Tri-County GLAD"><strong>Tri-County GLAD</strong></a></em></p>
+</blockquote>
+<h2><span>God’s Storehouse</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Grace-Central-Coast" aria-label="View directory entry for Grace Central Coast"><strong>Grace Central Coast</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Golden-1-Credit-Union">Golden 1 Credit Union</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.golden1.com" data-external-link="true">golden1.com</a></li>
+<li><strong>Locations:</strong> <ul>
+<li>8727 El Camino Real, Atascadero <a href="#" class="map-link" data-lat="35.472833" data-lon="-120.651861" data-zoom="17" data-label="Golden 1 Credit Union">Map</a></li>
+<li>128 Niblick Rd., Paso Robles <a href="#" class="map-link" data-lat="35.612529" data-lon="-120.683731" data-zoom="17" data-label="Golden 1 Credit Union">Map</a></li>
+<li>852 E. Foothill Blvd., SLO <a href="#" class="map-link" data-lat="35.294492" data-lon="-120.670846" data-zoom="17" data-label="Golden 1 Credit Union">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-877-465-3361" aria-label="Call 877-GOLDEN-1">877-GOLDEN-1</a> </li>
+<li><strong>Hours:</strong> M–F 10am–5pm, Sa 10am–2pm </li>
+</ul>
+<h2><span><a id="Good-Samaritan-Shelter">Good Samaritan Shelter</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://goodsamaritanshelter.org/" data-external-link="true">goodsamaritanshelter.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Santa Maria emergency shelter: 401 W. Morrison Ave., Santa Maria <a href="#" class="map-link" data-lat="34.943820" data-lon="-120.441034" data-zoom="17" data-label="Good Samaritan Shelter">Map</a> </li>
+<li>Administrative offices: 400 West Park, Santa Maria <a href="#" class="map-link" data-lat="34.944295" data-lon="-120.440996" data-zoom="17" data-label="Good Samaritan Shelter">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> Emergency shelter: <a href="tel:+1-805-347-3338;ext=101" aria-label="Call 805-347-3338 x101">805-347-3338 x101</a> </li>
+<li><strong>Email:</strong> Layne Harlow (<a href="mailto:lharlow@goodsamaritanshelter.org" aria-label="Email lharlow@goodsamaritanshelter.org">lharlow@goodsamaritanshelter.org</a>)</li>
+<li><strong>Hours:</strong><ul>
+<li>Emergency shelter: 24/7 </li>
+<li>Shelter intake appointments 8:30am–5pm M–F</li>
+<li>Shelter opens at 4:30pm daily</li>
+<li>Administrative offices open 9am–5pm M–F </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> (shelter) Call M–F 8:30am–4:00pm, or walk in 9am–3pm, to establish an intake appointment </li>
+<li>Notes:<ul>
+<li>operates <a href="#" data-directory-link="Welcome-Home-Village" aria-label="View directory entry for Welcome Home Village"><strong>Welcome Home Village</strong></a></li>
+<li>entry-point for the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+<li>operates <a href="#" data-directory-link="Supportive-Services-for-Veteran-Families" aria-label="View directory entry for Supportive Services for Veteran Families"><strong>Supportive Services for Veteran Families</strong></a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Goodwill">Goodwill Stores</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ccgoodwill.org/" data-external-link="true">ccgoodwill.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">8310 El Camino Real #A, Atascadero <a href="#" class="map-link" data-lat="35.474441" data-lon="-120.656410" data-zoom="17" data-label="Goodwill Store">Map</a></td>
+<td data-label="Hours">Daily 9am–7pm</td>
+</tr>
+<tr>
+<td data-label="Location">1628 W. Grand Ave., Grover Beach <a href="#" class="map-link" data-lat="35.120113" data-lon="-120.611025" data-zoom="17" data-label="Goodwill Store">Map</a></td>
+<td data-label="Hours">Daily 9am–7pm</td>
+</tr>
+<tr>
+<td data-label="Location">1020 Park St., Paso Robles <a href="#" class="map-link" data-lat="35.625127" data-lon="-120.689607" data-zoom="17" data-label="Goodwill Store">Map</a></td>
+<td data-label="Hours">Su–Th 9am–7pm, Fr–Sa 9am–8pm</td>
+</tr>
+<tr>
+<td data-label="Location">15 S. Higuera St., SLO <a href="#" class="map-link" data-lat="35.265971" data-lon="-120.670164" data-zoom="17" data-label="Goodwill Store">Map</a></td>
+<td data-label="Hours">Daily 9am–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">880 Industrial Way, SLO <a href="#" class="map-link" data-lat="35.252988" data-lon="-120.640955" data-zoom="17" data-label="Goodwill Outlet">Map</a> (Outlet)</td>
+<td data-label="Hours">Daily 7am–4pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-800-894-8440" aria-label="Call 800-894-8440">800-894-8440</a><ul>
+<li>Opportunity Platform: <a href="tel:+1-805-544-0542;ext=8520" aria-label="Call 805-544-0542&nbsp;x8520">805-544-0542&nbsp;x8520</a>, <a href="mailto:jjauregui@ccgoodwill.org" aria-label="Email jjauregui@ccgoodwill.org">jjauregui@ccgoodwill.org</a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Grace-Central-Coast">Grace Central Coast</a> “God’s Storehouse”</span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://gracecentralcoast.org/" data-external-link="true">gracecentralcoast.org</a></li>
+<li><strong>Location:</strong> 1350 Osos Street, SLO <a href="#" class="map-link" data-lat="35.279206" data-lon="-120.658411" data-zoom="17" data-label="God’s Storehouse">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-2358" aria-label="Call 805-543-2358">805-543-2358</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@gracecentralcoast.org" aria-label="Email info@gracecentralcoast.org">info@gracecentralcoast.org</a> </li>
+<li><strong>Hours</strong> (God’s Storehouse food distribution): Sa. 8–10am </li>
+</ul>
+<h2><span>Grassroots</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Grassroots" aria-label="View directory entry for SLO Grassroots"><strong>SLO Grassroots</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Green-Pastures">Green Pastures</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://fpcslo.org/greenpastures" data-external-link="true">fpcslo.org/greenpastures</a></li>
+<li><strong>Location:</strong> 981 Marsh St., SLO (First Presbyterian Church) <a href="#" class="map-link" data-lat="35.279915" data-lon="-120.660514" data-zoom="17" data-label="Green Pastures">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-5451" aria-label="Call 805-543-5451">805-543-5451</a> </li>
+<li><strong>Email:</strong> <a href="mailto:churchoffice@fpcslo.org" aria-label="Email churchoffice@fpcslo.org">churchoffice@fpcslo.org</a> </li>
+<li><strong>Hours:</strong> First and third Wednesdays at 1pm </li>
+<li><strong>How to access:</strong> Lottery system—first 8 names drawn receive assistance; must be present to enter </li>
+</ul>
+<h2><span><a id="Grover-Beach-Community-Services">Grover Beach Community Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.groverbeach.org/141/Community-Services" data-external-link="true">groverbeach.org/141/Community-Services</a></li>
+<li><strong>Location:</strong> 1230 Trouville Ave., Grover Beach <a class="map-link" data-lat="35.115854" data-lon="-120.616578" data-zoom="17" data-label="Grover Beach Community Services">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-473-4580" aria-label="Call 805-473-4580">805-473-4580</a> </li>
+<li><strong>Email:</strong> <a href="mailto:CS@groverbeach.org" aria-label="Email CS@groverbeach.org">CS@groverbeach.org</a> </li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+</ul>
+<h2><span><a id="Gryphon-Society">Gryphon Society</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://gryphonsociety.weebly.com/" data-external-link="true">gryphonsociety.weebly.com</a></li>
+<li><strong>Locations:</strong> Various; gender-segregated</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-550-8140" aria-label="Call 805-550-8140">805-550-8140</a> (men)</li>
+<li><a href="tel:+1-805-748-8491" aria-label="Call 805-748-8491">805-748-8491</a> (women)</li>
+<li><a href="tel:+1-805-748-6204" aria-label="Call 805-748-6204">805-748-6204</a></li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@gryphonsociety.weebly.com" aria-label="Email info@gryphonsociety.weebly.com">info@gryphonsociety.weebly.com</a></li>
+</ul>
+<h2><span><a id="Habitat-for-Humanity">Habitat for Humanity SLO County</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://habitatslo.org/" data-external-link="true">habitatslo.org</a></li>
+<li><strong>Location:</strong> 844 9th St., Paso Robles <a href="#" class="map-link" data-lat="35.623410" data-lon="-120.688886" data-zoom="17" data-label="Habitat for Humanity">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-782-0687" aria-label="Call 805-782-0687">805-782-0687</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@habitatslo.org" aria-label="Email info@habitatslo.org">info@habitatslo.org</a> </li>
+</ul>
+<p><strong>ReStore</strong> (recycled construction and home renovation materials):</p>
+<ul>
+<li><strong>Website:</strong> <a href="https://habitatslo.org/restores/" data-external-link="true">habitatslo.org/restores</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Paso Robles: 844 9th St., Paso Robles <a href="#" class="map-link" data-lat="35.623410" data-lon="-120.688886" data-zoom="17" data-label="Habitat for Humanity ReStore (Paso Robles)">Map</a> <ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-434-0486" aria-label="Call 805-434-0486">805-434-0486</a> </li>
+<li><strong>Email:</strong> <a href="mailto:restorepaso@habitatslo.org" aria-label="Email restorepaso@habitatslo.org">restorepaso@habitatslo.org</a> </li>
+<li><strong>Hours:</strong> Tu–Sa 10am–5pm </li>
+</ul>
+</li>
+<li>SLO: 2790 Broad St., SLO <a href="#" class="map-link" data-lat="35.264447" data-lon="-120.651866" data-zoom="17" data-label="Habitat for Humanity ReStore (SLO)">Map</a> <ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-546-8699" aria-label="Call 805-546-8699">805-546-8699</a> </li>
+<li><strong>Email:</strong> <a href="mailto:restoreslo@habitatslo.org" aria-label="Email restoreslo@habitatslo.org">restoreslo@habitatslo.org</a> </li>
+<li><strong>Hours:</strong> Tu–Sa 10am–5pm </li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h2><span>HASLO (Housing Authority of SLO)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="HASLO" aria-label="View directory entry for Housing Authority of SLO (HASLO)"><strong>Housing Authority of SLO (HASLO)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Healing-and-Restoration-Campus">Healing and Restoration Campus</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.sloharc.org/" data-external-link="true">sloharc.org</a></li>
+<li><strong>Location:</strong> Los Osos Valley Road near Laguna Lake (former DeVaul Ranch / Sunny Acres property) <a href="#" class="map-link" data-lat="35.273513" data-lon="-120.706208" data-zoom="16" data-label="Healing and Restoration Campus">Map</a></li>
+</ul>
+
+<ul>
+<li>Notes: A project of <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></li>
+</ul>
+<h2><span>Health Department</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Health-Department" aria-label="View directory entry for SLO County Health Department"><strong>SLO County Health Department</strong></a></em></p>
+</blockquote>
+<h2><span>Health Insurance Counseling &amp; Advocacy Program</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="HiCAP" aria-label="View directory entry for HiCAP (Health Insurance Counseling &amp; Advocacy Program)"><strong>HiCAP (Health Insurance Counseling &amp; Advocacy Program)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="HCHP">Healthcare for the Homeless Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.communityhealthcenters.org/locations/slo-prado/" data-external-link="true">communityhealthcenters.org/locations/slo-prado/</a></li>
+<li><strong>Location:</strong> 40 Prado Rd., SLO <a href="#" class="map-link" data-lat="35.256218" data-lon="-120.672031" data-zoom="17" data-label="40 Prado Homeless Services Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-473-4712" aria-label="Call 805-473-4712">805-473-4712</a> </li>
+<li><strong>Hours:</strong> M/Tu/Th 8am–5pm, W 9am–6pm </li>
+<li>Notes:<ul>
+<li>operated by <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a></li>
+<li>hosted by <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Help-Hope-Live">Help Hope Live</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://helphopelive.org/" data-external-link="true">helphopelive.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-642-8399" aria-label="Call 800-642-8399">800-642-8399</a> (M–F 9am–6pm Eastern Time) </li>
+</ul>
+<h2><span>Helping Friends Program</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Helping-Friends-Program" aria-label="View directory entry for Voice for the Animals Helping Friends Program"><strong>Voice for the Animals Helping Friends Program</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Help-Me-Grow">Help Me Grow SLO County</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slohelpmegrow.org/" data-external-link="true">slohelpmegrow.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1030 Southwood Dr., SLO <a href="#" class="map-link" data-lat="35.266202" data-lon="-120.642336" data-zoom="17" data-label="Help Me Grow">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-305-4481" aria-label="Call 805-305-4481">805-305-4481</a></td>
+</tr>
+<tr>
+<td data-label="Location">704 Spring St., Paso Robles <a href="#" class="map-link" data-lat="35.621655" data-lon="-120.690685" data-zoom="17" data-label="Help Me Grow">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-440-1878" aria-label="Call 805-440-1878">805-440-1878</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Hours:</strong> M–F 8am–4:30pm </li>
+</ul>
+<h2><span><a id="HiCAP">HiCAP (Health Insurance Counseling &amp; Advocacy Program)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://centralcoastseniors.org/hicap/" data-external-link="true">centralcoastseniors.org/hicap</a></li>
+<li><strong>Location:</strong><ul>
+<li>1445 Santa Rosa St., SLO <a href="#" class="map-link" data-lat="35.278951" data-lon="-120.657079" data-zoom="17" data-label="HiCAP">Map</a></li>
+<li>528 S. Broadway, Santa Maria <a href="#" class="map-link" data-lat="34.947390" data-lon="-120.435627" data-zoom="17" data-label="HiCAP">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-928-5663" aria-label="Call 805-928-5663">805-928-5663</a> / <a href="tel:+1-800-434-0222" aria-label="Call 800-434-0222">800-434-0222</a></li>
+<li><strong>Email:</strong> <a href="mailto:hicap@centralcoastseniors.org" aria-label="Email hicap@centralcoastseniors.org">hicap@centralcoastseniors.org</a></li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li><strong>How to access:</strong> Make an appointment by phone or by visiting the website.</li>
+</ul>
+<h2><span><a id="Homeless-Outreach-Full-Service-Partnership">Homeless Outreach Full Service Partnership</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-adult-services/homeless-outreach-full-service-partnership" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-adult-services/homeless-outreach-full-service-partnership</a></li>
+<li><strong>Phone:</strong><ul>
+<li>TMHA: <a href="tel:+1-805-540-6500" aria-label="Call 805-540-6500">805-540-6500</a> </li>
+<li>Behavioral Health Access Line: <a href="tel:+1-800-838-1361" aria-label="Call 800-838-1361">800-838-1361</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@t-mha.org" aria-label="Email info@t-mha.org">info@t-mha.org</a> </li>
+<li><strong>How to access:</strong> Contact <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association"><strong>Transitions Mental Health Association</strong></a> at the above phone number or email </li>
+</ul>
+<h2><span><a id="HomeShare-SLO">HomeShare SLO</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.smartsharehousingsolutions.org/homeshare-slo" data-external-link="true">smartsharehousingsolutions.org/homeshare-slo</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-215-5474" aria-label="Call 805-215-5474">805-215-5474</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@smartsharehousingsolutions.org" aria-label="Email info@smartsharehousingsolutions.org">info@smartsharehousingsolutions.org</a> </li>
+<li>Notes: A project of <a href="#" data-directory-link="SmartShare-Housing-Solutions" aria-label="View directory entry for SmartShare Housing Solutions"><strong>SmartShare Housing Solutions</strong></a> </li>
+</ul>
+<h2><span>Hope House</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Hopes-Village">Hope’s Village</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://hopesvillageofslo.com/" data-external-link="true">hopesvillageofslo.com</a></li>
+<li><strong>Mailing address:</strong> PO Box 1991, Templeton, CA 93465 </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-234-5478" aria-label="Call 805-234-5478">805-234-5478</a> </li>
+<li><strong>Email:</strong> <a href="mailto:beckyrjorgeson@yahoo.com" aria-label="Email beckyrjorgeson@yahoo.com">beckyrjorgeson@yahoo.com</a> </li>
+</ul>
+<h2><span><a id="Hospice-SLO">Hospice SLO</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://hospiceslo.org/" data-external-link="true">hospiceslo.org</a></li>
+<li><strong>Location:</strong> Dorothy D. Rupe Center, 1304 Pacific St., SLO <a href="#" class="map-link" data-lat="35.282539" data-lon="-120.655148" data-zoom="17" data-label="Hospice SLO">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-2266" aria-label="Call 805-544-2266">805-544-2266</a> </li>
+<li><strong>Email:</strong> <a href="mailto:hospiceslo@hospiceslo.org" aria-label="Email hospiceslo@hospiceslo.org">hospiceslo@hospiceslo.org</a> </li>
+<li><strong>Hours:</strong> M–F 10am–4pm </li>
+<li>Notes: All services provided at no charge; does not bill insurance </li>
+</ul>
+<h2><span><a id="HouseKeys">HouseKeys</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.housekeys19.com" data-external-link="true">housekeys19.com</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-877-460-5397" aria-label="Call 877-460-5397">877-460-5397</a> </li>
+<li><strong>Email:</strong> <a href="mailto:customerservice@housekeys.org" aria-label="Email customerservice@housekeys.org">customerservice@housekeys.org</a> </li>
+<li><strong>How to access:</strong> Create account at MyHouseKeys to enter drawings and receive notifications about available units</li>
+</ul>
+<h2><span><a id="HASLO">Housing Authority of SLO (HASLO)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.haslo.org/" data-external-link="true">haslo.org</a></li>
+<li><strong>Location:</strong> 487 Leff St., SLO <a href="#" class="map-link" data-lat="35.272418" data-lon="-120.662971" data-zoom="17" data-label="HASLO">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-4478" aria-label="Call 805-543-4478">805-543-4478</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@haslo.org" aria-label="Email info@haslo.org">info@haslo.org</a> </li>
+<li><strong>Hours:</strong> M–Th 8am–5pm (also open every other Friday) </li>
+<li><strong>How to access:</strong> submit a paper application to get on the waiting list for affordable apartments</li>
+<li>Notes:<ul>
+<li>Operates “Halcyon Collective” (Arroyo Grande)</li>
+<li>Operates “Macadero Gardens” (Atascadero)</li>
+<li>Operates “Cleaver &amp; Clark Commons” (Grover Beach)</li>
+<li>Operates “Rockview at Sunset” (Morro Bay)</li>
+<li>Operates “Willow Walk Senior Apartments” (Nipomo)</li>
+<li>Operates “Oak Park 1 &amp; 2” (Paso Robles)</li>
+<li>Operates “Paso Homekey” (Paso Robles)</li>
+<li>Operates “Sunset Terrace” (Shell Beach)</li>
+<li>Operates “860 on the Wye” (SLO)</li>
+<li>Operates “The Anderson Apartments” (SLO)</li>
+<li>Operates “Apartments at Toscano” (SLO)</li>
+<li>Operates “Balay-Ko on Monterey” (SLO)</li>
+<li>Operates “Bishop Street Studios” (SLO)</li>
+<li>Operates “Courtyard at the Meadows” (SLO)</li>
+<li>Operates “Iron Works Apartments” (SLO)</li>
+<li>Operates “Madonna Road Apartments” (SLO)</li>
+<li>Operates “Marvin Gardens” (SLO)</li>
+<li>Operates “Moylan Terrace Homeownership” (SLO)</li>
+<li>Operates “SLO Villages” (SLO)</li>
+<li>Operates “South Hills Crossing” (SLO)</li>
+<li>Operates “Parkwood Apartments”</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Housing-Now">Housing Now</a></span></h2>
+<ul>
+<li><strong>How to access:</strong> via the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+<li>Notes:<ul>
+<li>Formerly known as “50 Now” and “70 Now”</li>
+<li>Operated by <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Housing-Support-Program">Housing Support Program</a> (HSP)</span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://fcni.org/how-we-help/ensuring-stability/" data-external-link="true">fcni.org/how-we-help/ensuring-stability</a></li>
+<li><strong>Location:</strong> 1255 Kendall Rd., SLO <a href="#" class="map-link" data-lat="35.237660" data-lon="-120.630188" data-zoom="17" data-label="Housing Support Program">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-3535" aria-label="Call 805-781-3535">805-781-3535</a>  </li>
+<li><strong>Email:</strong> <a href="mailto:Contact@fcni.org" aria-label="Email Contact@fcni.org">Contact@fcni.org</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–5pm</li>
+<li><strong>How to access:</strong> Get a referral from a <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> Employment Resource Specialist</li>
+<li>Notes:<ul>
+<li>Run by <a href="#" data-directory-link="Family-Care-Network" aria-label="View directory entry for Family Care Network"><strong>Family Care Network</strong></a></li>
+<li>Can make referrals to <a href="#" data-directory-link="Medically-Fragile-Homeless-Program" aria-label="View directory entry for Medically Fragile Homeless Program"><strong>Medically Fragile Homeless Program</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Immigrant-Hope-Arroyo-Grande">Immigrant Hope Arroyo Grande</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://immigranthopeag.org/" data-external-link="true">immigranthopeag.org</a></li>
+<li><strong>Location:</strong> 995 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.118232" data-lon="-120.592895" data-zoom="17" data-label="Immigrant Hope">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-221-4319" aria-label="Call 805-221-4319">805-221-4319</a> </li>
+<li><strong>How to access:</strong> Call, visit the office, or use their <a href="https://immigranthopeag.org/contact-us/" data-external-link="true">web contact form</a></li>
+</ul>
+<h2><span><a id="Immigrant-Legal-Defense">Immigrant Legal Defense (ILD)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ild.org/" data-external-link="true">ild.org</a></li>
+<li><strong>Location:</strong> Cal Poly Dream Center, Science Building (Building 52), Room E-11, Cal Poly SLO campus <a href="#" class="map-link" data-lat="35.300215" data-lon="-120.664443" data-zoom="17" data-label="Cal Poly Dream Center">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-756-6362" aria-label="Call 805-756-6362">805-756-6362</a></li>
+<li><strong>Email:</strong> <a href="mailto:info@ild.org" aria-label="Email info@ild.org">info@ild.org</a> </li>
+<li><strong>How to access:</strong> Schedule appointments via Calendly at <a href="https://calendly.com/csulegalservices/ild" data-external-link="true">calendly.com/csulegalservices/ild</a> or through Dream Center website at <a href="https://dreamcenter.calpoly.edu/LegalServices" data-external-link="true">dreamcenter.calpoly.edu/LegalServices</a></li>
+</ul>
+<h2><span>Independent Living Resource Center (ILRC)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Access-Central-Coast" aria-label="View directory entry for Access Central Coast"><strong>Access Central Coast</strong></a></em></p>
+</blockquote>
+<h2><span><a id="In-Home-Supportive-Services">In-Home Supportive Services (IHSS)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/social-services/adult-services/services/in-home-supportive-services-%28ihss%29-program" data-external-link="true">slocounty.ca.gov/departments/social-services/adult-services/services/in-home-supportive-services-(ihss)-program</a></li>
+<li><strong>Location:</strong><ul>
+<li>9630 El Camino Real, Atascadero <a href="#" class="map-link" data-lat="35.4657747" data-lon="-120.6485702" data-zoom="17" data-label="In-Home Supportive Services">Map</a> </li>
+<li>1086 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.119759" data-lon="-120.595638" data-zoom="17" data-label="In-Home Supportive Services">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li>Atascadero: <a href="tel:+1-805-461-6110" aria-label="Call 805-461-6110">805-461-6110</a> </li>
+<li>Arroyo Grande: <a href="tel:+1-805-474-2103" aria-label="Call 805-474-2103">805-474-2103</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–5pm </li>
+<li><strong>How to access:</strong> By phone, or by completing an <a href="https://www.slocounty.ca.gov/Departments/Social-Services/Forms-Documents/Adult-Services/IHSS-Forms/Online-IHSS-Application-Form.aspx" data-external-link="true">online application form</a>, or by visiting any <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> office (no appointment necessary) </li>
+</ul>
+<h2><span><a id="Jewish-Family-Services">Jewish Family Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.jccslo.com/jewish-family-services.html" data-external-link="true">jccslo.com/jewish-family-services.html</a></li>
+<li><strong>Location:</strong> 578 Marsh St., SLO <a class="map-link" data-lat="35.277234" data-lon="-120.665549" data-zoom="17" data-label="Jewish Family Services">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-426-5465" aria-label="Call 805-426-5465">805-426-5465</a></li>
+<li><strong>How to access:</strong> Use the online form; they cannot process assistance requests by phone or email</li>
+</ul>
+<h2><span><a id="Judson-Terrace">Judson Terrace</a></span></h2>
+
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Location</th>
+<th>Phone</th>
+<th>Ages</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Name"><a href="https://www.humangood.org/judson-terrace-homes" data-external-link="true">Judson Terrace Homes</a></td>
+<td data-label="Location">3000 Augusta St., SLO <a href="#" class="map-link" data-lat="35.267515" data-lon="-120.640529" data-zoom="17" data-label="Judson Terrace Homes">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-544-1600" aria-label="Call 805-544-1600">805-544-1600</a></td>
+<td data-label="Ages">55+</td>
+</tr>
+<tr>
+<td data-label="Name"><a href="https://www.humangood.org/judson-terrace-lodge" data-external-link="true">Judson Terrace Lodge</a></td>
+<td data-label="Location">3042 Augusta St., SLO <a href="#" class="map-link" data-lat="35.268078" data-lon="-120.639555" data-zoom="17" data-label="Judson Terrace Lodge">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-541-4567" aria-label="Call 805-541-4567">805-541-4567</a></td>
+<td data-label="Ages">62+</td>
+</tr>
+</tbody></table>
+<ul>
+<li>Notes:<ul>
+<li>Low-income seniors; HUD residents typically pay 30% of gross income for rent</li>
+<li>Applications available only when waiting list is open; contact directly for current status</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Kings-Cupboard">King’s Cupboard at El Morro Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://sites.vivery.org/kings-cupboard-at-el-morro-church-pantry/los-osos-ca/2156" data-external-link="true">sites.vivery.org/kings-cupboard-at-el-morro-church-pantry/los-osos-ca/2156</a></li>
+<li><strong>Location:</strong> El Morro Church of the Nazarene, 1480 Santa Ysabel, Bldg. A, Los Osos <a href="#" class="map-link" data-lat="35.330593" data-lon="-120.822637" data-zoom="17" data-label="King’s Cupboard at El Morro Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-528-0391" aria-label="Call 805-528-0391">805-528-0391</a> </li>
+<li><strong>Hours:</strong> Tuesdays, 8–10am </li>
+</ul>
+<h2><span>Kinship Center</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Seneca-Central-Coast" aria-label="View directory entry for Seneca Central Coast"><strong>Seneca Central Coast</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Kritter-Care">Kritter Care</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://krittercare.org/" data-external-link="true">krittercare.org</a></li>
+<li><strong>Location:</strong> Morro Bay </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-889-9808" aria-label="Call 805-889-9808">805-889-9808</a> </li>
+</ul>
+<h2><span><a id="Laundry-Love">Laundry Love</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://laundrylove.org/" data-external-link="true">laundrylove.org</a></li>
+<li><strong>Location:</strong> 2179 10th St., Los Osos <a class="map-link" data-lat="35.311757" data-lon="-120.832637" data-zoom="17" data-label="Laundry Love">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-441-7262" aria-label="Call 805-441-7262">805-441-7262</a> </li>
+<li><strong>Email:</strong> <a href="mailto:naseema6@sbcglobal.net" aria-label="Email naseema6@sbcglobal.net">naseema6@sbcglobal.net</a> </li>
+<li><strong>Hours:</strong> last Weds. of the month, 11am–1pm (seniors only) &amp; 4–6pm (anyone) </li>
+</ul>
+<h2><span>Law Library</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Law-Library" aria-label="View directory entry for SLO County Law Library"><strong>SLO County Law Library</strong></a></em></p>
+</blockquote>
+<h2><span>Lawyer Referral and Information Service</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Bar-Association" aria-label="View directory entry for SLO County Bar Association Lawyer Referral and Information Service"><strong>SLO County Bar Association Lawyer Referral and Information Service</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Le-Sage-Riviera-RV-Park">Le Sage Riviera RV Park</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://lesageriviera.com" data-external-link="true">lesageriviera.com</a></li>
+<li><strong>Location:</strong> 319 N Highway 1, Grover Beach <a class="map-link" data-lat="35.126730" data-lon="-120.631745" data-zoom="17" data-label="Le Sage Riviera RV Park">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-489-5506" aria-label="Call 805-489-5506">805-489-5506</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@lesageriviera.com" aria-label="Email info@lesageriviera.com">info@lesageriviera.com</a> </li>
+<li><strong>Hours:</strong> M–Sa 9am–4:30pm, Su 9am–3pm </li>
+</ul>
+<h2><span><a id="Legacy-Church-Pantry">Legacy Church Pantry</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ourlegacy.church/" data-external-link="true">ourlegacy.church</a></li>
+<li><strong>Location:</strong><ul>
+<li>Food pantry: 6030 Del Rio Rd., Atascadero <a href="#" class="map-link" data-lat="35.512659" data-lon="-120.702113" data-zoom="17" data-label="Legacy Church Food Pantry">Map</a></li>
+<li>Church: 5545 Ardilla Ave., Atascadero <a href="#" class="map-link" data-lat="35.489669" data-lon="-120.674958" data-zoom="17" data-label="Legacy Church">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-2626" aria-label="Call 805-466-2626">805-466-2626</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@ourlegacy.church" aria-label="Email info@ourlegacy.church">info@ourlegacy.church</a> </li>
+<li><strong>Hours</strong> (food pantry): Th 1–2pm </li>
+</ul>
+<h2><span>Legal Assistance Foundation</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Legal-Assistance-Foundation" aria-label="View directory entry for SLO Legal Assistance Foundation (SLOLAF)"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Liberty-Tattoo-Removal-Program">Liberty Tattoo Removal Program</a></span></h2>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-540-8353" aria-label="Call 805-540-8353">805-540-8353</a> </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:libertytattooremoval@capslo.org" aria-label="Email libertytattooremoval@capslo.org">libertytattooremoval@capslo.org</a> </li>
+<li><a href="mailto:floydbland@capslo.org" aria-label="Email floydbland@capslo.org">floydbland@capslo.org</a> </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Operated by <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo"><strong>Community Action Partnership San Luis Obispo</strong></a></li>
+<li>Hosted by <a href="#" data-directory-link="Adventist-Health-Sierra-Vista" aria-label="View directory entry for Adventist Health Sierra Vista"><strong>Adventist Health Sierra Vista</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Lifepoint-Church">Lifepoint Church</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://lifepointcentralcoast.com/" data-external-link="true">lifepointcentralcoast.com</a> </li>
+<li><strong>Locations:</strong><ul>
+<li>Main: 207 Pilgrim Way, Arroyo Grande <a href="#" class="map-link" data-lat="35.115749" data-lon="-120.575423" data-zoom="17" data-label="Lifepoint Church">Map</a></li>
+<li>Outreach location: 946 Rockaway Ave., Grover Beach <a href="#" class="map-link" data-lat="35.120091" data-lon="-120.619796" data-zoom="17" data-label="Lifepoint Church outreach location">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-489-3328" aria-label="Call 805-489-3328">805-489-3328</a></li>
+<li><strong>Email:</strong> <a href="mailto:church@lifepointcentralcoast.com" aria-label="Email church@lifepointcentralcoast.com">church@lifepointcentralcoast.com</a></li>
+<li>Notes:<ul>
+<li>Hosts <a href="#" data-directory-link="CCPAW" aria-label="View directory entry for Central Coast Partnership for Animal Welfare"><strong>Central Coast Partnership for Animal Welfare</strong></a></li>
+<li>Hosts <a href="#" data-directory-link="Five-Cities-Christian-Women-Food-Pantry" aria-label="View directory entry for Five Cities Christian Women Food Pantry"><strong>Five Cities Christian Women Food Pantry</strong></a></li>
+<li>Hosts <a href="#" data-directory-link="Peoples-Kitchen-GB" aria-label="View directory entry for People’s Kitchen (Grover Beach)"><strong>People’s Kitchen (Grover Beach)</strong></a></li>
+<li>Hosts <a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Lifesigns">Lifesigns</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://lifesignsinc.org/" data-external-link="true">lifesignsinc.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-888-930-7776;ext=1" aria-label="Call 888-930-7776 x1">888-930-7776 x1</a> <ul>
+<li>For after-hours emergency interpreting: <a href="tel:+1-800-633-8883" aria-label="Call 800-633-8883">800-633-8883</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:Lifesigns@lifesignsinc.org" aria-label="Email Lifesigns@lifesignsinc.org">Lifesigns@lifesignsinc.org</a> </li>
+</ul>
+<h2><span><a id="Life-Steps-Foundation">Life Steps Foundation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.lifestepsfoundation.org/" data-external-link="true">lifestepsfoundation.org</a></li>
+<li><strong>Location:</strong> 218 W. Carmen Lane #108, Santa Maria <a href="#" class="map-link" data-lat="34.924628" data-lon="-120.438631" data-zoom="17" data-label="Life Steps Foundation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-549-0150" aria-label="Call 805-549-0150">805-549-0150</a> </li>
+<li><strong>Email:</strong> <a href="mailto:ccasoffice@lifestepsfoundation.org" aria-label="Email ccasoffice@lifestepsfoundation.org">ccasoffice@lifestepsfoundation.org</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5:30pm</li>
+</ul>
+<h2><span><a id="Link-Family-Resource-Center">The Link Family Resource Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://linkslo.org/" data-external-link="true">linkslo.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Atascadero: 4507 Del Rio Ave Bldg. #1, Atascadero <a href="#" class="map-link" data-lat="35.513562" data-lon="-120.686928" data-zoom="17" data-label="The Link Family Resource Center (Atascadero)">Map</a> </li>
+<li>Paso Robles: 1802 Chestnut St., Paso Robles <a href="#" class="map-link" data-lat="35.628326" data-lon="-120.691147" data-zoom="17" data-label="The Link Family Resource Center (Paso Robles)">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-5404" aria-label="Call 805-466-5404">805-466-5404</a> <ul>
+<li>Family Advocate Services: <a href="tel:+1-805-794-0217" aria-label="Call 805-794-0217">805-794-0217</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 9am–5pm </li>
+<li><strong>How to access:</strong> accepts self-referrals, school referrals, and community agency referrals</li>
+<li>Notes:<ul>
+<li>Operated by <a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening (CFS)"><strong>Center for Family Strengthening (CFS)</strong></a></li>
+<li>See also <a href="#" data-directory-link="North-County-Family-Resource-Center" aria-label="View directory entry for North County Family Resource Center"><strong>North County Family Resource Center</strong></a></li>
+<li>See also <a href="#" data-directory-link="SAFE-Family-Resource-Centers" aria-label="View directory entry for SAFE Family Resource Centers"><strong>SAFE Family Resource Centers</strong></a></li>
+</ul>
+</li>
+</ul>
+
+
+<h2><span><a id="Literacy-Connection">The Literacy Connection</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://catalog.slolibrary.org/tlc" data-external-link="true">catalog.slolibrary.org/tlc</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5077" aria-label="Call 805-781-5077">805-781-5077</a> </li>
+<li><strong>Email:</strong> <a href="mailto:TLCinfo@slolibrary.org" aria-label="Email TLCinfo@slolibrary.org">TLCinfo@slolibrary.org</a> </li>
+<li><strong>How to access:</strong> Submit a form on <a href="https://catalog.slolibrary.org/tlc" data-external-link="true">the library website</a> </li>
+<li>Notes: Program of <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a></li>
+</ul>
+<h2><span><a id="Little-Free-Libraries">Little Free Libraries</a></span></h2>
+<p>🗺️ <strong><a href="little-free-libraries-map.html" rel="noopener">View all locations on an interactive map</a></strong></p>
+<ul>
+<li><strong>Website:</strong> <a href="https://littlefreelibrary.org/" data-external-link="true">littlefreelibrary.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Arroyo Grande:<ul>
+<li>330 Alder St. <a href="#" class="map-link" data-lat="35.114090" data-lon="-120.593823" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>121 Allen St. <a href="#" class="map-link" data-lat="35.119917" data-lon="-120.575391" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Amarillo Dr. <a href="#" class="map-link" data-lat="35.073182" data-lon="-120.586066" data-zoom="16" data-label="Little Free Library">Map</a></li>
+<li>2510 Appaloosa Way <a href="#" class="map-link" data-lat="35.073411" data-lon="-120.580329" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Corner of Cedar &amp; Boysenberry <a href="#" class="map-link" data-lat="35.117185" data-lon="-120.604837" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>529 E. Cherry Ave. <a href="#" class="map-link" data-lat="35.121326" data-lon="-120.570416" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>615 E. Cherry Ave. <a href="#" class="map-link" data-lat="35.122401" data-lon="-120.568374" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2385 Clarkie Way <a href="#" class="map-link" data-lat="35.087336" data-lon="-120.563930" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Cypress Ridge Pkwy. near Cypress Ridge golf course entrance <a href="#" class="map-link" data-lat="35.065912" data-lon="-120.572875" data-zoom="16" data-label="Little Free Library">Map</a></li>
+<li>485 Dorothy Ln. <a href="#" class="map-link" data-lat="35.055285" data-lon="-120.581134" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>303 N. Elm St. <a href="#" class="map-link" data-lat="35.123058" data-lon="-120.600336" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>512 S. Elm St. <a href="#" class="map-link" data-lat="35.110289" data-lon="-120.600857" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>282 Gait Way <a href="#" class="map-link" data-lat="35.089684" data-lon="-120.578772" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1146 Maple St. <a href="#" class="map-link" data-lat="35.117013" data-lon="-120.598429" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Maple St. @ Walnut St. <a href="#" class="map-link" data-lat="35.116732" data-lon="-120.597214" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>127 S. Mason St. <a href="#" class="map-link" data-lat="35.123681" data-lon="-120.575667" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>328 Orchard St. <a href="#" class="map-link" data-lat="35.118206" data-lon="-120.578403" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1270 Poplar St. <a href="#" class="map-link" data-lat="35.119016" data-lon="-120.603324" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1260 Sage St. <a href="#" class="map-link" data-lat="35.118284" data-lon="-120.603290" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1414 Sierra Dr. <a href="#" class="map-link" data-lat="35.126825" data-lon="-120.603753" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>494 Stagecoach Rd. <a href="#" class="map-link" data-lat="35.131236" data-lon="-120.564362" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>958 Sycamore Dr. <a href="#" class="map-link" data-lat="35.108422" data-lon="-120.593270" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>250 Wesley St. <a href="#" class="map-link" data-lat="35.126572" data-lon="-120.581547" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Atascadero:<ul>
+<li>9481 Carmel Rd. <a href="#" class="map-link" data-lat="35.439074" data-lon="-120.615227" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>8505 Carmelita Ave. <a href="#" class="map-link" data-lat="35.472397" data-lon="-120.673113" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3155 El Camino Real <a href="#" class="map-link" data-lat="35.506468" data-lon="-120.690123" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2720 Ferrocarril Rd. <a href="#" class="map-link" data-lat="35.518062" data-lon="-120.682527" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>8934 Junipero Ave. <a href="#" class="map-link" data-lat="35.480842" data-lon="-120.652139" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Mariquita Ave. <a href="#" class="map-link" data-lat="35.494020" data-lon="-120.672484" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>9125 Mountain View Dr. <a href="#" class="map-link" data-lat="35.466434" data-lon="-120.665097" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>5265 Palma Ave. <a href="#" class="map-link" data-lat="35.493723" data-lon="-120.675068" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>14985 Powerline Rd. <a href="#" class="map-link" data-lat="35.420287" data-lon="-120.628037" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>8155 San Gregorio Rd. <a href="#" class="map-link" data-lat="35.513614" data-lon="-120.722312" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>10675 San Marcos Rd. <a href="#" class="map-link" data-lat="35.463859" data-lon="-120.699431" data-zoom="16" data-label="Little Free Library">Map</a></li>
+<li>13400 Santa Ana Rd. <a href="#" class="map-link" data-lat="35.503843" data-lon="-120.725162" data-zoom="16" data-label="Little Free Library">Map</a></li>
+<li>6605 Santa Ynez Ave. <a href="#" class="map-link" data-lat="35.483352" data-lon="-120.669031" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>7310 Sonora Ave. <a href="#" class="map-link" data-lat="35.487968" data-lon="-120.655054" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>8437 Vaquero Ln. <a href="#" class="map-link" data-lat="35.476039" data-lon="-120.647912" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>4555 Viscano Ave. <a href="#" class="map-link" data-lat="35.507060" data-lon="-120.669193" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Avila Beach:<ul>
+<li>1401 San Luis Bay Dr. <a href="#" class="map-link" data-lat="35.193967" data-lon="-120.715208" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>191 San Miguel St. <a href="#" class="map-link" data-lat="35.180624" data-lon="-120.733256" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>259 Squire Canyon Rd. <a href="#" class="map-link" data-lat="35.194958" data-lon="-120.681242" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Cambria:<ul>
+<li>6404 Buckley Dr. <a href="#" class="map-link" data-lat="35.574393" data-lon="-121.098921" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>701 Drake St. <a href="#" class="map-link" data-lat="35.548281" data-lon="-121.091709" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>521 Hastings St. <a href="#" class="map-link" data-lat="35.564578" data-lon="-121.102896" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2750 Holden Pl. <a href="#" class="map-link" data-lat="35.547895" data-lon="-121.074863" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>383 Orlando Dr. <a href="#" class="map-link" data-lat="35.547507" data-lon="-121.094860" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1176 Pineridge Dr. <a href="#" class="map-link" data-lat="35.541138" data-lon="-121.073378" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>365 Weymouth St. <a href="#" class="map-link" data-lat="35.571884" data-lon="-121.107462" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Cayucos:<ul>
+<li>84 13th St. <a href="#" class="map-link" data-lat="35.441637" data-lon="-120.891423" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1175 Cass Ave. <a href="#" class="map-link" data-lat="35.441671" data-lon="-120.893139" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>151 F St. <a href="#" class="map-link" data-lat="35.448532" data-lon="-120.901740" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>517 Lucerne Rd. <a href="#" class="map-link" data-lat="35.448889" data-lon="-120.910614" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>625 S. Ocean Ave. <a href="#" class="map-link" data-lat="35.445027" data-lon="-120.896035" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Grover Beach:<ul>
+<li>338 N. 3rd St. <a href="#" class="map-link" data-lat="35.124773" data-lon="-120.627183" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>251 S. 4th St. <a href="#" class="map-link" data-lat="35.120202" data-lon="-120.626670" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>266 N. 5th St. <a href="#" class="map-link" data-lat="35.123621" data-lon="-120.624910" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>240 Anita Ave. <a href="#" class="map-link" data-lat="35.108002" data-lon="-120.609531" data-zoom="17" data-label="Little Free Libraries">Map</a></li>
+<li>1230 Trouville Ave. <a href="#" class="map-link" data-lat="35.115854" data-lon="-120.616578" data-zoom="17" data-label="Little Free Libraries">Map</a></li>
+<li>1624 Trouville Ave. <a href="#" class="map-link" data-lat="35.115683" data-lon="-120.611738" data-zoom="17" data-label="Little Free Libraries">Map</a></li>
+</ul>
+</li>
+<li>Los Osos / Baywood Park:<ul>
+<li>1643 4th St. <a href="#" class="map-link" data-lat="35.321573" data-lon="-120.839052" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1182 7th St. <a href="#" class="map-link" data-lat="35.330479" data-lon="-120.835297" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1855 7th St. <a href="#" class="map-link" data-lat="35.317787" data-lon="-120.835598" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1180 9th St. <a href="#" class="map-link" data-lat="35.330435" data-lon="-120.833012" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1257 11th St. <a href="#" class="map-link" data-lat="35.328834" data-lon="-120.830823" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1426 16th St. <a href="#" class="map-link" data-lat="35.325639" data-lon="-120.825394" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1539 18th St. <a href="#" class="map-link" data-lat="35.323582" data-lon="-120.823474" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1639 18th St. <a href="#" class="map-link" data-lat="35.321708" data-lon="-120.823474" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2130 Andre Ave. <a href="#" class="map-link" data-lat="35.310294" data-lon="-120.820349" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2315 Bayview Heights Dr. <a href="#" class="map-link" data-lat="35.309403" data-lon="-120.833878" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2148 Bush Dr. <a href="#" class="map-link" data-lat="35.311895" data-lon="-120.834482" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2149 Lariat Dr. <a href="#" class="map-link" data-lat="35.307316" data-lon="-120.811683" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>561 Loma St. <a href="#" class="map-link" data-lat="35.317673" data-lon="-120.843891" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1351 Los Olivos Ave. <a href="#" class="map-link" data-lat="35.312628" data-lon="-120.825568" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1078 Los Osos Valley Rd. <a href="#" class="map-link" data-lat="35.311720" data-lon="-120.831102" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2003 Lost Oak Dr. <a href="#" class="map-link" data-lat="35.314850" data-lon="-120.826659" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>732 Manzanita Dr. <a href="#" class="map-link" data-lat="35.310765" data-lon="-120.838720" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2345 Oak Ridge Dr. <a href="#" class="map-link" data-lat="35.307342" data-lon="-120.825877" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2100 Pecho Rd. <a href="#" class="map-link" data-lat="35.314075" data-lon="-120.851884" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>948 Santa Maria Ave. <a href="#" class="map-link" data-lat="35.328212" data-lon="-120.834610" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1188 Scenic Way <a href="#" class="map-link" data-lat="35.330164" data-lon="-120.821371" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2340 Tierra Dr. <a href="#" class="map-link" data-lat="35.307885" data-lon="-120.826553" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Morro Bay:<ul>
+<li>720 Cabrillo Pl. <a href="#" class="map-link" data-lat="35.355395" data-lon="-120.843558" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Cloisters Community Park <a href="#" class="map-link" data-lat="35.390449" data-lon="-120.861604" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>482 Estero Ave. <a href="#" class="map-link" data-lat="35.361721" data-lon="-120.844277" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2401 Ironwood Ave. <a href="#" class="map-link" data-lat="35.387703" data-lon="-120.853193" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>495 Main St. <a href="#" class="map-link" data-lat="35.361784" data-lon="-120.850224" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>450 San Jacinto St. <a href="#" class="map-link" data-lat="35.394094" data-lon="-120.857676" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Nipomo:<ul>
+<li>421 N. Las Flores Dr. <a href="#" class="map-link" data-lat="35.016626" data-lon="-120.511421" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>789 Live Oak Ridge Rd. <a href="#" class="map-link" data-lat="35.044438" data-lon="-120.516232" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>525 Sandydale Dr. <a href="#" class="map-link" data-lat="35.044833" data-lon="-120.493745" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Oceano:<ul>
+<li>1341 18th St. <a href="#" class="map-link" data-lat="35.105805" data-lon="-120.611494" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1501 24th St. <a href="#" class="map-link" data-lat="35.102689" data-lon="-120.603769" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Paso Robles:<ul>
+<li>14140 Chimney Rock Rd. <a href="#" class="map-link" data-lat="35.685885" data-lon="-120.949099" data-zoom="15" data-label="Little Free Library">Map</a></li>
+<li>5090 Deer Creek Way <a href="#" class="map-link" data-lat="35.675182" data-lon="-120.599488" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1130 Merry Hill Rd. <a href="#" class="map-link" data-lat="35.626407" data-lon="-120.701740" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2247 Oak St. <a href="#" class="map-link" data-lat="35.637880" data-lon="-120.693794" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2004 Pine St. <a href="#" class="map-link" data-lat="35.635204" data-lon="-120.689301" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3773 Ruth Way #A <a href="#" class="map-link" data-lat="35.635204" data-lon="-120.689301" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1103 Spring St. <a href="#" class="map-link" data-lat="35.625533" data-lon="-120.692883" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>539 Veronica Dr. <a href="#" class="map-link" data-lat="35.620405" data-lon="-120.668131" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2105 Vine St. <a href="#" class="map-link" data-lat="35.636053" data-lon="-120.695039" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>904 Vista Cerro Dr. <a href="#" class="map-link" data-lat="35.626666" data-lon="-120.657874" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Pismo Beach:<ul>
+<li>28 El Viento <a href="#" class="map-link" data-lat="35.141748" data-lon="-120.619004" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>224 Irish Way <a href="#" class="map-link" data-lat="35.134519" data-lon="-120.616391" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>990 Price St. <a href="#" class="map-link" data-lat="35.143482" data-lon="-120.641506" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2411 Price St. <a href="#" class="map-link" data-lat="35.148810" data-lon="-120.651196" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2555 Price St. <a href="#" class="map-link" data-lat="35.149153" data-lon="-120.653452" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>995 Skyline Dr. <a href="#" class="map-link" data-lat="35.136528" data-lon="-120.606985" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>San Miguel:<ul>
+<li>1197 L St. <a href="#" class="map-link" data-lat="35.750082" data-lon="-120.698097" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Santa Margarita:<ul>
+<li>22070 H St. <a href="#" class="map-link" data-lat="35.394411" data-lon="-120.600808" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3120 Ranchita Canyon Rd. <a href="#" class="map-link" data-lat="35.735801" data-lon="-120.607985" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Shell Beach:<ul>
+<li>302 Cuyama Ave. <a href="#" class="map-link" data-lat="35.156784" data-lon="-120.677138" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>262 Esparto Ave. <a href="#" class="map-link" data-lat="35.155398" data-lon="-120.673018" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>SLO:<ul>
+<li>1330 Alder St. <a href="#" class="map-link" data-lat="35.247297" data-lon="-120.629542" data-zoom="16" data-label="Little Free Library">Map</a></li>
+<li>1378 Avalon St. (@ Oceanaire Dr.) <a href="#" class="map-link" data-lat="35.263063" data-lon="-120.687116" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>79 Benton Way <a href="#" class="map-link" data-lat="35.291125" data-lon="-120.670781" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Bluerock Drive near Stoneridge Park <a href="#" class="map-link" data-lat="35.261906" data-lon="-120.655375" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1410 Broad St. @ Pacific <a href="#" class="map-link" data-lat="35.276596" data-lon="-120.662295" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Center St. by Nazarene church</li>
+<li>Center St. between Chorro and Lincoln <a href="#" class="map-link" data-lat="35.287044" data-lon="-120.667729" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>171 Cerro Romauldo Ave. <a href="#" class="map-link" data-lat="35.295083" data-lon="-120.677927" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3450 Dairy Creek Rd. (SLO Botanical Garden) <a href="#" class="map-link" data-lat="35.331880" data-lon="-120.728717" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>2378 Boulevard Del Campo <a href="#" class="map-link" data-lat="35.270140" data-lon="-120.649130" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1295 Descanso St. <a href="#" class="map-link" data-lat="35.265559" data-lon="-120.698268" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>107 Earthwood Ln. <a href="#" class="map-link" data-lat="35.236681" data-lon="-120.675588" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1595 Eto Circle <a href="#" class="map-link" data-lat="35.255055" data-lon="-120.695018" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1383 Fairway Dr. <a href="#" class="map-link" data-lat="35.257552" data-lon="-120.699459" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>157 Fel Mar Dr. <a href="#" class="map-link" data-lat="35.298910" data-lon="-120.684954" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1348 Fernwood Dr. <a href="#" class="map-link" data-lat="35.264175" data-lon="-120.638396" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1011 George St. <a href="#" class="map-link" data-lat="35.274520" data-lon="-120.654666" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1 Grand Ave. <a href="#" class="map-link" data-lat="35.122113" data-lon="-120.634064" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3440 Gregory Ct. <a href="#" class="map-link" data-lat="35.264324" data-lon="-120.635237" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1415 Higuera St. <a href="#" class="map-link" data-lat="35.284846" data-lon="-120.654559" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>On a utility pole at Morro St. and Islay St. <a href="#" class="map-link" data-lat="35.276876" data-lon="-120.658486" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1121 Islay St. <a href="#" class="map-link" data-lat="35.278313" data-lon="-120.655482" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1215 Joyce Ct. <a href="#" class="map-link" data-lat="35.269615" data-lon="-120.647253" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3962 Kilbern Way <a href="#" class="map-link" data-lat="35.253618" data-lon="-120.636411" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>10 La Entrada Ave. <a href="#" class="map-link" data-lat="35.293831" data-lon="-120.682958" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>286 Lawrence Dr. <a href="#" class="map-link" data-lat="35.264210" data-lon="-120.659173" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>655 Lawrence Dr. <a href="#" class="map-link" data-lat="35.263965" data-lon="-120.653293" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1148 Leff St. <a href="#" class="map-link" data-lat="35.277910" data-lon="-120.654495" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>United Church of Christ (11245 Los Osos Valley Road) <a href="#" class="map-link" data-lat="35.260531" data-lon="-120.695661" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1708 Lynn <a href="#" class="map-link" data-lat="35.259926" data-lon="-120.699974" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Corner of Mill &amp; Toro <a href="#" class="map-link" data-lat="35.285083" data-lon="-120.660090" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Monday Club, 1815 Monterey at Grand <a href="#" class="map-link" data-lat="35.288367" data-lon="-120.651308" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1430 Noveno Ave. <a href="#" class="map-link" data-lat="35.260767" data-lon="-120.636610" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1552 Oceanaire Dr. (near Atascadero St.) <a href="#" class="map-link" data-lat="35.260794" data-lon="-120.684820" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1906 Oceanaire Dr. (near Pinecove Dr.) <a href="#" class="map-link" data-lat="35.255958" data-lon="-120.684262" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>Pacific between Johnson &amp; Pepper <a href="#" class="map-link" data-lat="35.282736" data-lon="-120.654597" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1768 Pereira Dr. <a href="#" class="map-link" data-lat="35.255695" data-lon="-120.688071" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1358 Purple Sage Ln. <a href="#" class="map-link" data-lat="35.246714" data-lon="-120.629867" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>333 Sage St. <a href="#" class="map-link" data-lat="35.255406" data-lon="-120.663539" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>373 Sage St. <a href="#" class="map-link" data-lat="35.255423" data-lon="-120.661865" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1401 San Luis Bay Dr. <a href="#" class="map-link" data-lat="35.192977" data-lon="-120.715295" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1739 San Luis Dr. <a href="#" class="map-link" data-lat="35.286554" data-lon="-120.650418" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1391 San Marcos Ct. <a href="#" class="map-link" data-lat="35.269203" data-lon="-120.642908" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>In front of The Establishment, 1703 Santa Barbara Ave. <a href="#" class="map-link" data-lat="35.276342" data-lon="-120.656708" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>By the Montessori school at South Higuera &amp; Los Osos Valley Road <a href="#" class="map-link" data-lat="35.241860" data-lon="-120.676929" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>3960 S. Higuera St. #34 <a href="#" class="map-link" data-lat="35.248051" data-lon="-120.674354" data-zoom="16" data-label="Little Free Library">Map</a></li>
+<li>Nazarene church on 3396 Southwood Dr. <a href="#" class="map-link" data-lat="35.264981" data-lon="-120.635355" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1767 Southwood Dr. <a href="#" class="map-link" data-lat="35.264823" data-lon="-120.629282" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>4475 Wavertree St. <a href="#" class="map-link" data-lat="35.247748" data-lon="-120.627995" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>637 Woodbridge <a href="#" class="map-link" data-lat="35.267197" data-lon="-120.656072" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+<li>Templeton:<ul>
+<li>785 Ashley Ln. <a href="#" class="map-link" data-lat="35.540835" data-lon="-120.717790" data-zoom="18" data-label="Little Free Library">Map</a></li>
+<li>620 Old Country Rd. <a href="#" class="map-link" data-lat="35.549455" data-lon="-120.709426" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>308 Puffin Way <a href="#" class="map-link" data-lat="35.553923" data-lon="-120.730080" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>215 S. Main St. <a href="#" class="map-link" data-lat="35.550900" data-lon="-120.703762" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>1027 Santa Rita Rd. <a href="#" class="map-link" data-lat="35.542668" data-lon="-120.722494" data-zoom="17" data-label="Little Free Library">Map</a></li>
+<li>158 Wessels Way <a href="#" class="map-link" data-lat="35.555604" data-lon="-120.706229" data-zoom="17" data-label="Little Free Library">Map</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>Hours:</strong> Daily, 24/7</li>
+</ul>
+<h2><span><a id="Little-Free-Pantries">Little Free Pantries</a></span></h2>
+<p>🗺️ <strong><a href="little-free-pantries-map.html" rel="noopener">View all locations on an interactive map</a></strong></p>
+<p>Note: Little Free Pantries come and go.
+Sometimes they are neglected, damaged, or removed.
+If you see one listed here that is no longer in service, please use the feedback button to tell VivaSLO about it.</p>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.littlefreepantry.org/" data-external-link="true">littlefreepantry.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Arroyo Grande:<ul>
+<li>132 South Halcyon Rd. <a href="#" class="map-link" data-lat="35.117680" data-lon="-120.591688" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>268 Summit Station Rd. <a href="#" class="map-link" data-lat="35.064428" data-lon="-120.517080" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Atascadero:<ul>
+<li>9557 Curbaril Ave. <a href="#" class="map-link" data-lat="35.491538" data-lon="-120.647313" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>9333 Santa Barbara Rd. <a href="#" class="map-link" data-lat="35.449172" data-lon="-120.633742" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Grover Beach:<ul>
+<li>202 S. 8th St. / 770 Rockaway Ave. <a href="#" class="map-link" data-lat="35.120336" data-lon="-120.621656" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>393 N. 16th St. <a href="#" class="map-link" data-lat="35.124713" data-lon="-120.611462" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>925 Newport Ave. <a href="#" class="map-link" data-lat="35.125591" data-lon="-120.619581" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Los Osos:<ul>
+<li>1500 block of 5th St. <a href="#" class="map-link" data-lat="35.323564" data-lon="-120.837615" data-zoom="16" data-label="Little Free Pantry">Map</a></li>
+<li>1559 10th St. <a href="#" class="map-link" data-lat="35.323314" data-lon="-120.832444" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>490 Los Osos Valley Rd. <a href="#" class="map-link" data-lat="35.313346" data-lon="-120.845536" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Morro Bay:<ul>
+<li>3000 Hemlock Ave. <a href="#" class="map-link" data-lat="35.396754" data-lon="-120.857001" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>397 San Joaquin St. <a href="#" class="map-link" data-lat="35.392420" data-lon="-120.857967" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Nipomo:<ul>
+<li>181 W Tefft St. <a href="#" class="map-link" data-lat="35.041418" data-lon="-120.477533" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>267 W Tefft St. <a href="#" class="map-link" data-lat="35.039950" data-lon="-120.479340" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Oceano:<ul>
+<li>1322 24th St. <a href="#" class="map-link" data-lat="35.105814" data-lon="-120.604037" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>1501 24th St. <a href="#" class="map-link" data-lat="35.102703" data-lon="-120.603613" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>1930 Ocean St. <a href="#" class="map-link" data-lat="35.099906" data-lon="-120.610517" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>615 Pier Ave. <a href="#" class="map-link" data-lat="35.107217" data-lon="-120.624337" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Paso Robles:<ul>
+<li>8th St. and Olive St. <a href="#" class="map-link" data-lat="35.622280" data-lon="-120.694835" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>3301 Oak St. <a href="#" class="map-link" data-lat="35.648648" data-lon="-120.694685" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>1003 Pioneer Trail Rd. <a href="#" class="map-link" data-lat="35.606196" data-lon="-120.643111" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Pismo Beach: 206 Margo Way <a href="#" class="map-link" data-lat="35.135993" data-lon="-120.610013" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>Santa Margarita:<ul>
+<li>22210 El Camino Real <a href="#" class="map-link" data-lat="35.392602" data-lon="-120.606745" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>22495 K St. <a href="#" class="map-link" data-lat="35.386645" data-lon="-120.606553" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>SLO:<ul>
+<li>3320 Bullock Ln. <a href="#" class="map-link" data-lat="35.260531" data-lon="-120.643519" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>2021 Broad St. <a href="#" class="map-link" data-lat="35.271279" data-lon="-120.657976" data-zoom="18" data-label="Little Free Pantry">Map</a></li>
+<li>226 Ferrini Rd. <a href="#" class="map-link" data-lat="35.295416" data-lon="-120.673839" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>335 High St. <a href="#" class="map-link" data-lat="35.272050" data-lon="-120.665095" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>2075 Johnson Ave. <a href="#" class="map-link" data-lat="35.276312" data-lon="-120.648300" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>11245 Los Osos Valley Rd. <a href="#" class="map-link" data-lat="35.260575" data-lon="-120.695157" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>474 Marsh St. <a href="#" class="map-link" data-lat="35.276460" data-lon="-120.667080" data-zoom="18" data-label="Little Free Pantry">Map</a></li>
+<li>1306 Nipomo St. <a href="#" class="map-link" data-lat="35.276676" data-lon="-120.664180" data-zoom="17" data-label="Little Free Pantry">Map</a> </li>
+<li>695 Pismo St. <a href="#" class="map-link" data-lat="35.276376" data-lon="-120.662522" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>corner of San Carlos and Bushnell <a href="#" class="map-link" data-lat="35.269527" data-lon="-120.652344" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+<li>193 San Jose Ct. <a href="#" class="map-link" data-lat="35.291537" data-lon="-120.683366" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li>Templeton: 806 Old Country Rd. <a href="#" class="map-link" data-lat="35.547338" data-lon="-120.710440" data-zoom="17" data-label="Little Free Pantry">Map</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong> Daily, 24/7</li>
+</ul>
+<h2><span><a id="Loaves-and-Fishes-Atascadero">Loaves &amp; Fishes (Atascadero)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://alffoodpantry.org/" data-external-link="true">alffoodpantry.org</a></li>
+<li><strong>Location:</strong> 5411 El Camino Real, Atascadero <a class="map-link" data-lat="35.492964" data-lon="-120.676511" data-zoom="17" data-label="Loaves &amp; Fishes (Atascadero)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-461-1504" aria-label="Call 805-461-1504">805-461-1504</a> </li>
+<li><strong>Email:</strong> <a href="mailto:contact@alffoodpantry.org" aria-label="Email contact@alffoodpantry.org">contact@alffoodpantry.org</a> </li>
+<li><strong>Hours</strong> (food pantry): M–F 1–3pm </li>
+<li>Notes: Not affiliated with <a href="#" data-directory-link="Loaves-and-Fishes-Paso-Robles" aria-label="View directory entry for Loaves &amp; Fishes (Paso Robles)"><strong>Loaves &amp; Fishes (Paso Robles)</strong></a></li>
+</ul>
+<h2><span><a id="Loaves-and-Fishes-Paso-Robles">Loaves &amp; Fishes (Paso Robles)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://loavesandfishespaso.org" data-external-link="true">loavesandfishespaso.org</a></li>
+<li><strong>Location:</strong> 2650 Spring St., Paso Robles <a href="#" class="map-link" data-lat="35.642136" data-lon="-120.692363" data-zoom="17" data-label="Loaves and Fishes (Paso Robles)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-238-4742" aria-label="Call 805-238-4742">805-238-4742</a> </li>
+<li><strong>Hours:</strong> M–Th 2pm–4pm, or by appointment </li>
+<li>Notes: Not affiliated with <a href="#" data-directory-link="Loaves-and-Fishes-Atascadero" aria-label="View directory entry for Loaves &amp; Fishes (Atascadero)"><strong>Loaves &amp; Fishes (Atascadero)</strong></a></li>
+</ul>
+<h2><span><a id="Long-Term-Care-Ombudsman">Long Term Care Ombudsman</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://ombudsmanslo.org/" data-external-link="true">ombudsmanslo.org</a></li>
+<li><strong>Location:</strong> 3232 S. Higuera St. #101B, SLO <a class="map-link" data-lat="35.256866" data-lon="-120.668734" data-zoom="17" data-label="Long Term Care Ombudsman">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-785-0132" aria-label="Call 805-785-0132">805-785-0132</a> (office) </li>
+<li><a href="tel:+1-800-231-4024" aria-label="Call 800-231-4024">800-231-4024</a> (24-hour emergency) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@ombudsmanslo.org" aria-label="Email info@ombudsmanslo.org">info@ombudsmanslo.org</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–4:30pm </li>
+</ul>
+<h2><span><a id="Lopez-Lake-Recreation-Area">Lopez Lake Recreation Area</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocountyparks.com/camp/lopez-lake/" data-external-link="true">slocountyparks.com/camp/lopez-lake/</a></li>
+<li><strong>Location:</strong> 6800 Lopez Dr., Arroyo Grande <a href="#" class="map-link" data-lat="35.190855" data-lon="-120.457415" data-zoom="15" data-label="Lopez Lake Recreation Area">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-788-2381" aria-label="Call 805-788-2381">805-788-2381</a>  M–Th 8am–5pm; <a href="tel:+1-805-781-5930" aria-label="Call 805-781-5930">805-781-5930</a> (reservations)</li>
+<li><strong>Email:</strong> <a href="mailto:sloparks@co.slo.ca.us" aria-label="Email sloparks@co.slo.ca.us">sloparks@co.slo.ca.us</a></li>
+<li><strong>Hours:</strong> 6am–sunset daily</li>
+</ul>
+<h2><span><a id="Los-Osos-Cares">Los Osos Cares Resource Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.losososcares.com/" data-external-link="true">losososcares.com</a></li>
+<li><strong>Location:</strong> Sunnyside School, 800 Manzanita Dr., Room 18, Los Osos <a class="map-link" data-lat="35.309785" data-lon="-120.835047" data-zoom="17" data-label="Los Osos Cares Resource Center">Map</a> <ul>
+<li>Community Dinners: 2180 Palisades Ave., Los Osos </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-592-2701" aria-label="Call 805-592-2701">805-592-2701</a> </li>
+<li><strong>Email:</strong> <a href="mailto:wecareinlososos@gmail.com" aria-label="Email wecareinlososos@gmail.com">wecareinlososos@gmail.com</a> </li>
+<li><strong>Hours:</strong> Tu/W/Th 1–3pm <ul>
+<li>Community Dinners: Wednesdays 5–6pm </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Hosts Community Dinner at <a href="#" data-directory-link="South-Bay-Community-Center" aria-label="View directory entry for South Bay Community Center"><strong>South Bay Community Center</strong></a></li>
+<li>Hosts “Coastal Family Resource Center”</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Lucia-Mar-Adult-Education">Lucia Mar Adult Education</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://adulted.luciamarschools.org/" data-external-link="true">adulted.luciamarschools.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Name">Main office</td>
+<td data-label="Location">602 Orchard St., Arroyo Grande <a href="#" class="map-link" data-lat="35.115292" data-lon="-120.576271" data-zoom="17" data-label="Lucia Mar Adult Education">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-3222" aria-label="Call 805-474-3222">805-474-3222</a></td>
+</tr>
+<tr>
+<td data-label="Name">Nipomo Learning Center</td>
+<td data-label="Location">190 E. Price St. (E &amp; F), Nipomo <a href="#" class="map-link" data-lat="35.042848" data-lon="-120.471869" data-zoom="17" data-label="Lucia Mar Adult Education">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-3000;ext=7602" aria-label="Call 805-474-3000 x7602">805-474-3000 x7602</a></td>
+</tr>
+<tr>
+<td data-label="Name">Oceano Community Center</td>
+<td data-label="Location">1575 17th St. (30, 33, &amp; 34), Oceano <a href="#" class="map-link" data-lat="35.101995" data-lon="-120.612296" data-zoom="17" data-label="Lucia Mar Adult Education">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-3000;ext=7601" aria-label="Call 805-474-3000 x7601">805-474-3000 x7601</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:brienne.phillips@lmusd.org" aria-label="Email brienne.phillips@lmusd.org">brienne.phillips@lmusd.org</a> </li>
+<li>Notes: Partners with <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> for ESL classes</li>
+</ul>
+<h2><span><a id="Lumina-Alliance">Lumina Alliance</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://luminaalliance.org/" data-external-link="true">luminaalliance.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>555 S. 13th St. #B, Grover Beach <a href="#" class="map-link" data-lat="35.116240" data-lon="-120.615517" data-zoom="17" data-label="Lumina Alliance">Map</a></li>
+<li>102 S. Vine St. #C, Paso Robles <a href="#" class="map-link" data-lat="35.614368" data-lon="-120.692636" data-zoom="17" data-label="Lumina Alliance">Map</a> </li>
+<li>51 Zaca Ln. #150, SLO <a href="#" class="map-link" data-lat="35.251244" data-lon="-120.673442" data-zoom="17" data-label="Lumina Alliance">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-545-8888" aria-label="Call 805-545-8888">805-545-8888</a> (24-hour free &amp; confidential crisis line) </li>
+<li><a href="tel:+1-805-781-6400" aria-label="Call 805-781-6400">805-781-6400</a> (Business line) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:Contact@LuminaAlliance.org" aria-label="Email Contact@LuminaAlliance.org">Contact@LuminaAlliance.org</a> </li>
+<li>Note: RISE merged with Stand Strong in 2021 to form Lumina Alliance</li>
+</ul>
+<h2><span><a id="Lumina-Thrift">Lumina Thrift</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://luminaalliance.org/thriftstore/" data-external-link="true">luminaalliance.org/thriftstore</a></li>
+<li><strong>Location:</strong> 545 Higuera St., SLO <a class="map-link" data-lat="35.277002" data-lon="-120.667160" data-zoom="17" data-label="Lumina Thrift">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-592-3596" aria-label="Call 805-592-3596">805-592-3596</a> </li>
+<li><strong>Hours:</strong> M–Sa 10am–5pm </li>
+</ul>
+<h2><span>LyonHeart Place</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Marijuana-Anonymous">Marijuana Anonymous</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://marijuana-anonymous.org/" data-external-link="true">marijuana-anonymous.org</a></li>
+<li><strong>Location:</strong> 2939 Augusta St., SLO <a href="#" class="map-link" data-lat="35.267094" data-lon="-120.641232" data-zoom="17" data-label="Marijuana Anonymous">Map</a>  (<a href="#" data-directory-link="Middlehouse" aria-label="View directory entry for Middlehouse"><strong>Middlehouse</strong></a>)</li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-766-6779" aria-label="Call 800-766-6779">800-766-6779</a> </li>
+<li><strong>Email:</strong> <a href="mailto:slo.marijuana.anonymous@gmail.com" aria-label="Email slo.marijuana.anonymous@gmail.com">slo.marijuana.anonymous@gmail.com</a> </li>
+<li><strong>Hours:</strong> 6:30–7:30pm on Mondays </li>
+</ul>
+<h2><span><a id="Marthas-Place-Childrens-Center">Martha’s Place Children’s Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/martha%E2%80%99s-place-children-s-center" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/marthas-place-childrens-center</a></li>
+<li><strong>Location:</strong> 2925 McMillan Ave. #108, SLO <a class="map-link" data-lat="35.263382" data-lon="-120.648288" data-zoom="17" data-label="Martha’s Place Children’s Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-4948" aria-label="Call 805-781-4948">805-781-4948</a> </li>
+<li><strong>Hours:</strong> M–F 8am–5pm </li>
+<li>Notes: For children ages 0–5 with behavioral or mental health issues</li>
+</ul>
+<h2><span>Meals on Wheels</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="5Cities-Meals-on-Wheels" aria-label="View directory entry for Five Cities Meals on Wheels"><strong>Five Cities Meals on Wheels</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Meals-that-Connect">Meals that Connect</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://mealsthatconnect.org/en/" data-external-link="true">mealsthatconnect.org</a></li>
+<li><strong>Location:</strong> 265 South St. #B, SLO <a href="#" class="map-link" data-lat="35.269139" data-lon="-120.666800" data-zoom="17" data-label="Meals that Connect">Map</a> (office) <ul>
+<li>Serves meals in Atascadero, Templeton, Cambria, San Simeon, Los Osos, Morro Bay, Cayucos, Nipomo, Oceano, Paso Robles, Santa Margarita, and SLO</li>
+<li>Also does some home delivery </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-3312" aria-label="Call 805-541-3312">805-541-3312</a> </li>
+<li><strong>Email:</strong> <a href="mailto:officeadmin@mealsthatconnect.org" aria-label="Email officeadmin@mealsthatconnect.org">officeadmin@mealsthatconnect.org</a> </li>
+<li><strong>Hours:</strong> (varies by site)</li>
+<li><strong>How to access:</strong> open to people aged 60 and above; complete an application </li>
+</ul>
+<h2><span><a id="Medi-Cal">Medi-Cal</a></span></h2>
+<blockquote>
+<p><em>See also: <a href="#" data-directory-link="CenCal" aria-label="View directory entry for CenCal"><strong>CenCal</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Locations:</strong> <em>See <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></em></li>
+<li>Medi-Cal Dental:<ul>
+<li><strong>Website:</strong> <a href="http://www.denti-cal.ca.gov/" data-external-link="true">www.denti-cal.ca.gov</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-322-6384" aria-label="Call 800-322-6384">800-322-6384</a> (TTY: <a href="tel:+1-800-735-2922" aria-label="Call 800-735-2922">800-735-2922</a>)</li>
+</ul>
+</li>
+<li>Medi-Cal Rx:<ul>
+<li><strong>Website:</strong> <a href="https://medi-calrx.dhcs.ca.gov/" data-external-link="true">medi-calrx.dhcs.ca.gov</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-977-2273" aria-label="Call 800-977-2273">800-977-2273</a></li>
+</ul>
+</li>
+<li>Medi-Cal Shuttle: <em>See <a href="#" data-directory-link="Ride-On-Transportation" aria-label="View directory entry for Ride-On Transportation"><strong>Ride-On Transportation</strong></a></em></li>
+<li>Notes:<ul>
+<li><a href="#" data-directory-link="CenCal" aria-label="View directory entry for CenCal Health"><strong>CenCal Health</strong></a> is the local Medi-Cal administrator </li>
+<li>Apply at <a href="https://www.coveredca.com/" data-external-link="true">www.coveredca.com</a> or <a href="https://benefitscal.com/" data-external-link="true">BenefitsCal.com</a> or in person at local DSS offices </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Medically-Fragile-Homeless-Program">Medically Fragile Homeless Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://cfsslo.org/#mfh" data-external-link="true">cfsslo.org/#mfh</a></li>
+<li><strong>Email:</strong> <a href="mailto:carrie@linkslo.org" aria-label="Email carrie@linkslo.org">carrie@linkslo.org</a> </li>
+<li>Notes:<ul>
+<li>Access through <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> or <a href="#" data-directory-link="Housing-Support-Program" aria-label="View directory entry for Housing Support Program (HSP)"><strong>Housing Support Program (HSP)</strong></a> or <a href="#" data-directory-link="Adult-Protective-Services" aria-label="View directory entry for Adult Protective Services"><strong>Adult Protective Services</strong></a> or <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs"><strong>CalWORKs</strong></a></li>
+<li>Operated by <a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening (CFS)"><strong>Center for Family Strengthening (CFS)</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="MISP">Medically Indigent Services Program (MISP)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/medically-indigent-services-program-%28misp%29" data-external-link="true">slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/medically-indigent-services-program-(misp)</a></li>
+<li><strong>Location:</strong> 2180 Johnson Ave., SLO <a class="map-link" data-lat="35.274671" data-lon="-120.646514" data-zoom="17" data-label="Medically Indigent Services Program">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5500" aria-label="Call 805-781-5500">805-781-5500</a> </li>
+<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm) </li>
+</ul>
+<h2><span><a id="MedStop">MedStop</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://medstopurgentcare.com/" data-external-link="true">medstopurgentcare.com</a></li>
+<li><strong>Location:</strong> 283 Madonna Rd. Suite B (Madonna Plaza), SLO </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-549-8880" aria-label="Call 805-549-8880">805-549-8880</a> </li>
+<li><strong>Hours:</strong> M–F 8am–7pm, Sa.–Su. 8am–4pm </li>
+</ul>
+<h2><span><a id="MHET">Mental Health Evaluation Team</a> / <a id="Mobile-Crisis-Team">Mobile Crisis Team</a></span></h2>
+<ul>
+<li><strong>Website:</strong><ul>
+<li>MHET: <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-%28mhet%29" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-(mhet)</a></li>
+<li>Mobile Crisis Team: <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-%28mct%29" data-external-link="true">https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-(mct)</a></li>
+</ul>
+</li>
+<li><strong>Location:</strong> county-wide</li>
+<li><strong>Phone:</strong><ul>
+<li>MHET: <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> </li>
+<li>Mobile Crisis Team: <a href="tel:+1-800-783-0607" aria-label="Call 800-783-0607">800-783-0607</a> </li>
+</ul>
+</li>
+</ul>
+<h2><span>Mental Health Services</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Mental-Health-Services" aria-label="View directory entry for SLO County Mental Health Services"><strong>SLO County Mental Health Services</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Middlehouse">Middlehouse</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://middlehouse.org/" data-external-link="true">middlehouse.org</a></li>
+<li><strong>Location:</strong> 2939 Augusta St., SLO <a class="map-link" data-lat="35.267094" data-lon="-120.641232" data-zoom="17" data-label="Middlehouse">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-8328" aria-label="Call 805-544-8328">805-544-8328</a> </li>
+<li><strong>Email:</strong> <a href="mailto:middlehouse93401@gmail.com" aria-label="Email middlehouse93401@gmail.com">middlehouse93401@gmail.com</a> </li>
+</ul>
+<h2><span>Minister’s Discretionary Fund</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Mission-Thrift">Mission Thrift</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.omsslo.org/apps/pages/index.jsp?uREC_ID=3643070&amp;type=d&amp;pREC_ID=2413322" data-external-link="true">omsslo.org/apps/pages/index.jsp?uREC_ID=3643070&amp;type=d&amp;pREC_ID=2413322</a></li>
+<li><strong>Location:</strong> 2958 S. Higuera St., SLO <a class="map-link" data-lat="35.259753" data-lon="-120.668913" data-zoom="17" data-label="Mission Thrift">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-548-2660" aria-label="Call 805-548-2660">805-548-2660</a> </li>
+<li><strong>Email:</strong> <a href="mailto:Morradre@omsslo.com" aria-label="Email Morradre@omsslo.com">Morradre@omsslo.com</a> </li>
+<li><strong>Hours:</strong> M–Sa 12pm–5pm </li>
+</ul>
+<h2><span>Mobile Crisis Team</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Mobile-Crisis-Team" aria-label="View directory entry for Mental Health Evaluation Team / Mobile Crisis Team"><strong>Mental Health Evaluation Team</strong> / <strong>Mobile Crisis Team</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Mobile-Crisis-Unit">Mobile Crisis Unit</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocity.org/government/department-directory/fire-department/mobile-crisis-unit-mcu" data-external-link="true">slocity.org/government/department-directory/fire-department/mobile-crisis-unit-mcu</a></li>
+<li><strong>Location:</strong> SLO city only</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-550-7270" aria-label="Call 805-550-7270">805-550-7270</a> </li>
+<li><a href="tel:+1-805-781-7312" aria-label="Call 805-781-7312">805-781-7312</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–Th 8am–5:30pm; every other Friday 8am–5:30pm</li>
+</ul>
+<h2><span><a id="Morro-Bay-Lions-Foundation">Morro Bay Lions Foundation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://morrobaylions.org/2025/07/24/community-dinners-at-vets-hall/" data-external-link="true">morrobaylions.org/2025/07/24/community-dinners-at-vets-hall</a></li>
+<li><strong>Location:</strong> Morro Bay Vets Memorial Building, 209 Surf St., Morro Bay <a href="#" class="map-link" data-lat="35.370461" data-lon="-120.853497" data-zoom="17" data-label="Morro Bay Lions Foundation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-772-4421" aria-label="Call 805-772-4421">805-772-4421</a></li>
+<li><strong>Hours:</strong><ul>
+<li>Mondays: 4:30pm (doors open for pantry shopping, free clothes, towels, toiletries) </li>
+<li>Dinner service: 5:30–6:30pm </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Morro-Bay-Senior-Center">Morro Bay Senior Citizens</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://morrobayseniors.org/" data-external-link="true">morrobayseniors.org</a></li>
+<li><strong>Location:</strong> 1001 Kennedy Way, Morro Bay <a class="map-link" data-lat="35.368668" data-lon="-120.845781" data-zoom="17" data-label="Morro Bay Senior Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-772-4421" aria-label="Call 805-772-4421">805-772-4421</a> </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:info@morrobayseniors.org" aria-label="Email info@morrobayseniors.org">info@morrobayseniors.org</a> </li>
+<li><a href="mailto:mbactivesrs@gmail.com" aria-label="Email mbactivesrs@gmail.com">mbactivesrs@gmail.com</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 9am–4pm </li>
+<li>Membership: $25/year individual, $40/year household (90+ free); open to people 55+ </li>
+<li>Notes:<ul>
+<li>Hosts <a href="#" data-directory-link="HiCAP" aria-label="View directory entry for HiCAP"><strong>HiCAP</strong></a></li>
+<li>Hosts <a href="#" data-directory-link="Senior-Legal-Services-Project" aria-label="View directory entry for Senior Legal Services Project"><strong>Senior Legal Services Project</strong></a> on the first Friday of the month</li>
+</ul>
+</li>
+</ul>
+
+
+<h2><span>My Home for Hope</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Balay-Ko-on-Barka" aria-label="View directory entry for Balay Ko on Barka"><strong>Balay Ko on Barka</strong></a></em></p>
+</blockquote>
+
+
+<h2><span><a id="Narcotics-Anonymous">Narcotics Anonymous</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://centralcoastna.org/" data-external-link="true">centralcoastna.org</a></li>
+<li><strong>Locations:</strong> <a href="https://www.centralcoastna.org/directory/" data-external-link="true">various locations</a> in Arroyo Grande, Atascadero, Cambria, Guadalupe, Lompoc, Orcutt, Paso Robles, San Luis Obispo, and Santa Maria <ul>
+<li>Also has some virtual (Zoom) meetings</li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-549-7730" aria-label="Call 805-549-7730">805-549-7730</a> </li>
+</ul>
+<h2><span><a id="NCI-Affiliates-Thrift">NCI Affiliates Thrift</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://nciaffiliates.org/thrift-stores/" data-external-link="true">nciaffiliates.org/thrift-stores</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">2070 El Camino Real, Atascadero <a href="#" class="map-link" data-lat="35.512708" data-lon="-120.698150" data-zoom="17" data-label="NCI Affiliates Thrift">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-462-0500" aria-label="Call 805-462-0500">805-462-0500</a></td>
+</tr>
+<tr>
+<td data-label="Location">183 Niblick Rd., Paso Robles <a href="#" class="map-link" data-lat="35.616768" data-lon="-120.682216" data-zoom="17" data-label="NCI Affiliates Thrift">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-296-3153" aria-label="Call 805-296-3153">805-296-3153</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Hours:</strong> Daily 10am–6pm </li>
+<li>Notes: Operated by NCI Affiliates; training location for vocational services</li>
+</ul>
+<h2><span><a id="NeedyMeds">NeedyMeds</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://needymeds.org/" data-external-link="true">needymeds.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-800-503-6897" aria-label="Call 800-503-6897">800-503-6897</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@needymeds.org" aria-label="Email info@needymeds.org">info@needymeds.org</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5pm Eastern Time </li>
+</ul>
+<h2><span>NeighborAid</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="North-County-NeighborAid" aria-label="View directory entry for North County NeighborAid"><strong>North County NeighborAid</strong></a></em></p>
+</blockquote>
+<h2><span><a id="New-Life-U-Pick-Pantry">New Life U-Pick Pantry</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.newlifepismo.com/pantry/" data-external-link="true">newlifepismo.com/pantry</a></li>
+<li><strong>Location:</strong> 941 N. Oak Park Blvd., Pismo Beach <a href="#" class="map-link" data-lat="35.136159" data-lon="-120.606430" data-zoom="17" data-label="New Life U-Pick Pantry">Map</a> (New Life Community Center) </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-489-3891" aria-label="Call 805-489-3891">805-489-3891</a> </li>
+<li><strong>Email:</strong> <a href="mailto:pantry@newlifepismo.com" aria-label="Email pantry@newlifepismo.com">pantry@newlifepismo.com</a> </li>
+<li><strong>Hours:</strong> Tu 6–7:30pm, W 10am–noon, Th 1:30–3:30pm </li>
+</ul>
+<h2><span><a id="Nipomo-Community-Presbyterian">Nipomo Community Presbyterian</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.nipomopresbyterian.org" data-external-link="true">nipomopresbyterian.org</a></li>
+<li><strong>Location:</strong> 1235 N. Thompson Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.070495" data-lon="-120.512163" data-zoom="17" data-label="Nipomo Community Presbyterian">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-473-8059" aria-label="Call 805-473-8059">805-473-8059</a></li>
+<li>Hours (food pantry): F 12:45–1:30pm </li>
+</ul>
+<h2><span><a id="Nipomo-Food-Basket">Nipomo Food Basket</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.nipomofoodbasket.com/" data-external-link="true">nipomofoodbasket.com</a></li>
+<li><strong>Location:</strong> 197 W. Tefft St., Nipomo <a class="map-link" data-lat="35.042387" data-lon="-120.476916" data-zoom="17" data-label="Nipomo Food Basket">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-619-7681" aria-label="Call 805-619-7681">805-619-7681</a> </li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:helpu@nipomofoodbasket.org" aria-label="Email helpu@nipomofoodbasket.org">helpu@nipomofoodbasket.org</a> </li>
+<li><a href="mailto:info@nipomofoodbasket.com" aria-label="Email info@nipomofoodbasket.com">info@nipomofoodbasket.com</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M/Tu/Th/F 10am–1pm </li>
+</ul>
+<h2><span><a id="Nipomo-Senior-Center">Nipomo Senior Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://nipomoseniorcenter.org/" data-external-link="true">nipomoseniorcenter.org</a></li>
+<li><strong>Location:</strong> 200 E. Dana St., Nipomo <a class="map-link" data-lat="35.044026" data-lon="-120.471889" data-zoom="17" data-label="Nipomo Senior Center">Map</a> (entrance on Beechnut St.)</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-929-1615" aria-label="Call 805-929-1615">805-929-1615</a> </li>
+<li><strong>Email:</strong> <a href="mailto:contact@nipomoseniorcenter" aria-label="Email contact@nipomoseniorcenter">contact@nipomoseniorcenter</a> </li>
+<li><strong>Hours:</strong> M–F 9am–1pm </li>
+<li>Note: Hosts <a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a> lunches </li>
+</ul>
+<h2><span>Noor Foundation</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a></em></p>
+</blockquote>
+<h2><span><a id="North-County-Family-Resource-Center">North County Family Resource Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/north-county-family-resource-center/" data-external-link="true">capslo.org/north-county-family-resource-center</a></li>
+<li><strong>Location:</strong> 704 Spring St., Paso Robles <a href="#" class="map-link" data-lat="35.621655" data-lon="-120.690685" data-zoom="17" data-label="Family Resource Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-440-1878" aria-label="Call 805-440-1878">805-440-1878</a> </li>
+<li>Notes:<ul>
+<li>See also <a href="#" data-directory-link="Link-Family-Resource-Center" aria-label="View directory entry for Link Family Resource Center"><strong>Link Family Resource Center</strong></a></li>
+<li>See also <a href="#" data-directory-link="SAFE-Family-Resource-Centers" aria-label="View directory entry for SAFE Family Resource Centers"><strong>SAFE Family Resource Centers</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="North-County-NeighborAid">North County NeighborAid</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://cfsslo.org/north-county-neighboraid/" data-external-link="true">cfsslo.org/north-county-neighboraid</a></li>
+<li><strong>Location:</strong> 1428 Phillips Lane #203, SLO <a href="#" class="map-link" data-lat="35.288103" data-lon="-120.657544" data-zoom="17" data-label="North County NeighborAid">Map</a> </li>
+<li><strong>Mailing address:</strong> 7343 El Camino Real #346, Atascadero </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-5404" aria-label="Call 805-466-5404">805-466-5404</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@NoCoNeighborAid.org" aria-label="Email info@NoCoNeighborAid.org">info@NoCoNeighborAid.org</a> </li>
+<li><strong>Hours:</strong> By appointment</li>
+<li><strong>How to access:</strong> Make a request by using their <a href="https://cfsslo.org/north-county-neighboraid/" data-external-link="true">web form</a></li>
+<li>Notes: Grassroots initiative managed by <a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening"><strong>Center for Family Strengthening</strong></a></li>
+</ul>
+<h2><span><a id="North-County-Paws-Cause">North County Paws Cause</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.northcounty-pawscause.org/" data-external-link="true">northcounty-pawscause.org</a></li>
+<li><strong>Location:</strong> Paso Robles </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-674-8664" aria-label="Call 805-674-8664">805-674-8664</a> / <a href="sms:+1-805-674-8664">805-674-8664</a> </li>
+<li><strong>Email:</strong> <a href="mailto:northcountypawscause@gmail.com" aria-label="Email northcountypawscause@gmail.com">northcountypawscause@gmail.com</a> </li>
+</ul>
+<h2><span><a id="North-County-Care">North County Care Minor Emergency Services</a></span></h2>
+
+<ul>
+<li><strong>Location:</strong> 636 Spring St., Paso Robles <a href="#" class="map-link" data-lat="35.621268" data-lon="-120.690517" data-zoom="17" data-label="North County Care Minor Emergency Services">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-238-2422" aria-label="Call 805-238-2422">805-238-2422</a> </li>
+<li><strong>Hours:</strong> M–F 10am–5pm </li>
+</ul>
+
+
+
+<h2><span><a id="Oceano-Campground">Oceano Campground</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocountyparks.com/camp/oceano/" data-external-link="true">https://slocountyparks.com/camp/oceano/</a></li>
+<li><strong>Location:</strong> 494 Air Park Dr., Oceano <a class="map-link" data-lat="35.104656" data-lon="-120.625624" data-zoom="17" data-label="Oceano Campground">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-4900" aria-label="Call 805-781-4900">805-781-4900</a>  M–Th 8am–4:30pm; F–Su 8am–6pm, <a href="tel:+1-805-781-5930" aria-label="Call 805-781-5930">805-781-5930</a> (reservations)</li>
+</ul>
+<h2><span>Office of Emergency Services</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Office-of-Emergency-Services" aria-label="View directory entry for SLO County Office of Emergency Services"><strong>SLO County Office of Emergency Services</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Open-Arms-Pantry">Open Arms Pantry at Rock Harbor</a></span></h2>
+<ul>
+<li><strong>Location:</strong> Rock Harbor Christian Fellowship, 1475 Quintana Rd., Morro Bay <a href="#" class="map-link" data-lat="35.363751" data-lon="-120.824600" data-zoom="17" data-label="Open Arms Pantry at Rock Harbor">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-799-7031" aria-label="Call 805-799-7031">805-799-7031</a> </li>
+<li><strong>Hours:</strong> Sa 9:30–10:30am; also available throughout the week on a walk-in basis </li>
+</ul>
+<h2><span>Outreach Apparel</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Childrens-Resource-Network-of-the-Central-Coast" aria-label="View directory entry for Children’s Resource Network of the Central Coast"><strong>Children’s Resource Network of the Central Coast</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Outreach-and-Engagement-Services">Outreach and Engagement Services</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Location:</strong> 1320 Nipomo St., SLO <a class="map-link" data-lat="35.276474" data-lon="-120.663915" data-zoom="17" data-label="Outreach and Engagement Services">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-4004" aria-label="Call 805-544-4004">805-544-4004</a></li>
+<li><strong>Hours:</strong> M–F 10am–3pm</li>
+<li><strong>How to access:</strong> Walk-ins OK</li>
+</ul>
+
+
+<h2><span><a id="Parent-Connection-of-SLO-County">Parent Connection of SLO County</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://sloparents.org/" data-external-link="true">sloparents.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-3700" aria-label="Call 805-543-3700">805-543-3700</a>  (Español: <a href="tel:+1-805-540-1223" aria-label="Call 805-540-1223">805-540-1223</a>)</li>
+<li><strong>Email:</strong> <a href="mailto:info@sloparents.org" aria-label="Email info@sloparents.org">info@sloparents.org</a> </li>
+<li>Note: operated by <a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening (CFS)"><strong>Center for Family Strengthening (CFS)</strong></a></li>
+</ul>
+<h2><span><a id="Parents-Helping-Parents">Parents Helping Parents of SLO County</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.phpslo.org/" data-external-link="true">phpslo.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">7305 Morro Rd. #104a, Atascadero <a href="#" class="map-link" data-lat="35.478644" data-lon="-120.666592" data-zoom="17" data-label="Parents Helping Parents">Map</a></td>
+<td data-label="Hours">W 10am–1pm (by appointment)</td>
+</tr>
+<tr>
+<td data-label="Location">1146 Farmhouse Lane, SLO <a href="#" class="map-link" data-lat="35.239987" data-lon="-120.634147" data-zoom="17" data-label="Parents Helping Parents">Map</a></td>
+<td data-label="Hours">M–F 8am–4:30pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-3277" aria-label="Call 805-543-3277">805-543-3277</a> </li>
+<li><strong>Email:</strong> <a href="mailto:php@ucp-slo.org" aria-label="Email php@ucp-slo.org">php@ucp-slo.org</a> </li>
+</ul>
+<h2><span>Partnership for Animal Welfare</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CCPAW" aria-label="View directory entry for Central Coast Partnership for Animal Welfare"><strong>Central Coast Partnership for Animal Welfare</strong></a></em></p>
+</blockquote>
+
+
+<h2><span><a id="Paso-Robles-Housing-Authority">Paso Robles Housing Authority</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://pasoroblesha.org/" data-external-link="true">pasoroblesha.org</a></li>
+<li><strong>Location:</strong> 901 30th Street, Paso Robles <a href="#" class="map-link" data-lat="35.645727" data-lon="-120.690330" data-zoom="17" data-label="Paso Robles Housing Authority">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-238-4015" aria-label="Call 805-238-4015">805-238-4015</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@pasoroblesha.org" aria-label="Email info@pasoroblesha.org">info@pasoroblesha.org</a> </li>
+<li><strong>Hours:</strong> M–F 9am–4:30pm (closed Noon–1pm) </li>
+<li><strong>How to access:</strong> Call or email</li>
+<li>Notes:<ul>
+<li>Operates affordable housing properties including Oak Park 1–4 and Sunrise Villas </li>
+<li>Offers community services including “Youth Works” program </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Paso-Robles-Senior-Center">Paso Robles Senior Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.prcity.com/293/Senior-Services" data-external-link="true">prcity.com/293/Senior-Services</a></li>
+<li><strong>Location:</strong> 270 Scott St., Paso Robles <a href="#" class="map-link" data-lat="35.608089" data-lon="-120.655487" data-zoom="17" data-label="Paso Robles Senior Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-237-3880" aria-label="Call 805-237-3880">805-237-3880</a></li>
+<li><strong>Hours:</strong> M–F 8am–5pm <ul>
+<li>Food pantry: Second and fourth Tuesdays of the month at 10am </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>A lunch service site for <a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a> </li>
+<li>A <a href="#" data-directory-link="SLO-Food-Bank" aria-label="View directory entry for SLO Food Bank"><strong>SLO Food Bank</strong></a> pantry &amp; food box distribution site </li>
+<li>Hosts <a href="#" data-directory-link="HiCAP" aria-label="View directory entry for HiCAP"><strong>HiCAP</strong></a> </li>
+<li>Hosts <a href="#" data-directory-link="Senior-Legal-Services-Project" aria-label="View directory entry for Senior Legal Services Project"><strong>Senior Legal Services Project</strong></a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Paso-Robles-Parks-and-Recreation">Paso Robles Recreation Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.prcity.com/268/Recreation-Services" data-external-link="true">prcity.com/268/Recreation-Services</a></li>
+<li><strong>Location:</strong> Centennial Park, 600 Nickerson Dr., Paso Robles <a href="#" class="map-link" data-lat="35.622846" data-lon="-120.670075" data-zoom="17" data-label="Paso Robles Parks and Recreation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-237-3988" aria-label="Call 805-237-3988">805-237-3988</a> </li>
+<li><strong>Email:</strong> <a href="mailto:recservices@prcity.com" aria-label="Email recservices@prcity.com">recservices@prcity.com</a></li>
+<li><strong>Hours:</strong> M–Th 12pm–5pm (registration desk) </li>
+<li>Note: offers scholarships to cover fees for its recreation activities; apply in person at the registration desk </li>
+</ul>
+<h2><span><a id="PathPoint">PathPoint</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://pathpoint.org/locations/san-luis-obispo" data-external-link="true">pathpoint.org/locations/san-luis-obispo</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">775 W. Grand Ave. #C (Grover Beach) <a href="#" class="map-link" data-lat="35.121994" data-lon="-120.621843" data-zoom="17" data-label="PathPoint">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-473-9582" aria-label="Call 805-473-9582">805-473-9582</a></td>
+</tr>
+<tr>
+<td data-label="Location">11491 Los Osos Valley Rd. (SLO) <a href="#" class="map-link" data-lat="35.258145" data-lon="-120.692577" data-zoom="17" data-label="PathPoint">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-782-8890" aria-label="Call 805-782-8890">805-782-8890</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:info@pathpoint.org" aria-label="Email info@pathpoint.org">info@pathpoint.org</a> </li>
+</ul>
+<h2><span>Paws Cause</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="North-County-Paws-Cause" aria-label="View directory entry for North County Paws Cause"><strong>North County Paws Cause</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Peoples-Justice-Project">People’s Justice Project</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://peoplesjusticeproject.org/" data-external-link="true">peoplesjusticeproject.org</a></li>
+<li><strong>Location:</strong> 5708 Hollister Ave., Ste. A #1033, Goleta <a href="#" class="map-link" data-lat="34.435859" data-lon="-119.823284" data-zoom="17" data-label="People’s Justice Project">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-242-6691" aria-label="Call 805-242-6691">805-242-6691</a> </li>
+<li><strong>Email:</strong> <a href="mailto:legal@peoplesjusticeproject.org" aria-label="Email legal@peoplesjusticeproject.org">legal@peoplesjusticeproject.org</a> </li>
+</ul>
+<h2><span><a id="Peoples-Kitchen-GB">People’s Kitchen (Grover Beach)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.scpk.org/" data-external-link="true">scpk.org</a></li>
+<li><strong>Location:</strong> 946 Rockaway Ave., Grover Beach <a class="map-link" data-lat="35.120091" data-lon="-120.619796" data-zoom="17" data-label="People’s Kitchen (Grover Beach)">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-266-1838" aria-label="Call 805-266-1838">805-266-1838</a> </li>
+<li><a href="tel:+1-805-458-1992" aria-label="Call 805-458-1992">805-458-1992</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:scpk5cities@gmail.com" aria-label="Email scpk5cities@gmail.com">scpk5cities@gmail.com</a> </li>
+<li><a href="mailto:dnimwold@gmail.com" aria-label="Email dnimwold@gmail.com">dnimwold@gmail.com</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> Daily 11:30am–1pm </li>
+<li>Notes: Hosted by House of God Church </li>
+</ul>
+<h2><span><a id="Peoples-Kitchen-SLO">People’s Kitchen (SLO)</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slopeopleskitchen.org/" data-external-link="true">slopeopleskitchen.org</a></li>
+<li><strong>Location:</strong> 43 Prado Road, SLO <a class="map-link" data-lat="35.256164" data-lon="-120.672655" data-zoom="17" data-label="People’s Kitchen">Map</a> </li>
+<li><strong>Email:</strong> <a href="mailto:mnparker539@gmail.com" aria-label="Email mnparker539@gmail.com">mnparker539@gmail.com</a> </li>
+<li><strong>Hours:</strong> Daily at noon </li>
+<li><strong>How to access:</strong> Come during serving time. </li>
+</ul>
+<h2><span><a id="Peoples-Self-Help-Housing">Peoples’ Self-Help Housing</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.pshhc.org/" data-external-link="true">pshhc.org</a></li>
+<li><strong>Location:</strong> 1060 Kendall Road, SLO <a class="map-link" data-lat="35.236784" data-lon="-120.633302" data-zoom="17" data-label="People’s Self-Help Housing">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-3088" aria-label="Call 805-781-3088">805-781-3088</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@pshhc.org" aria-label="Email info@pshhc.org">info@pshhc.org</a> </li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li><strong>How to access:</strong> Submit a rental application at their website, or download it, complete it, and submit it by email, mail, or in person </li>
+<li>Notes:<ul>
+<li>Operates “Broad Street Place”</li>
+<li>Operates “Sea Breeze Apartments”</li>
+<li>Operates “Tiburon Place”</li>
+<li>Operates “Villas at Higuera”</li>
+</ul>
+</li>
+</ul>
+<h2><span>Pet Pantry</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Woods-Humane-Society" aria-label="View directory entry for Woods Humane Society"><strong>Woods Humane Society</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Pets-of-the-Homeless">Pets of the Homeless</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://petsofthehomeless.org/" data-external-link="true">petsofthehomeless.org</a></li>
+<li><strong>Mailing addresses:</strong> 710 W. Washington St., Carson City, NV 89703 </li>
+<li><strong>Phone:</strong> <a href="tel:+1-775-841-7463" aria-label="Call 775-841-7463">775-841-7463</a> <ul>
+<li>Emergency Veterinary Care Program: case managers available M–F 9am–3pm for new cases </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@petsofthehomeless.org" aria-label="Email info@petsofthehomeless.org">info@petsofthehomeless.org</a> </li>
+<li>Notes: Has partner locations in SLO including Animal Care Clinic, Mission Animal Hospital, and Woods Humane Society </li>
+</ul>
+<h2><span><a id="Pismo-Beach-Athletic-Club">Pismo Beach Athletic Club</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://pbac.com/" data-external-link="true">pbac.com</a></li>
+<li><strong>Location:</strong> 1751 Price St., Pismo Beach <a class="map-link" data-lat="35.146449" data-lon="-120.646490" data-zoom="17" data-label="Pismo Beach Athletic Club">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-773-3011" aria-label="Call 805-773-3011">805-773-3011</a> </li>
+<li><strong>Hours:</strong> M–F 5:30am–9pm, Sa–Su 7am–4pm </li>
+</ul>
+<h2><span><a id="Pismo-Beach-Recreation-Division">Pismo Beach Recreation Division</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.pismobeach.org/73/Recreation" data-external-link="true">pismobeach.org/73/Recreation</a></li>
+<li><strong>Location:</strong> 760 Mattie Rd., Pismo Beach <a class="map-link" data-lat="35.165712" data-lon="-120.688289" data-zoom="17" data-label="Pismo Beach Recreation Division">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-773-7063" aria-label="Call 805-773-7063">805-773-7063</a> </li>
+<li><strong>Email:</strong> <a href="mailto:recreation@pismobeach.org" aria-label="Email recreation@pismobeach.org">recreation@pismobeach.org</a> </li>
+</ul>
+<h2><span><a id="Planned-Parenthood">Planned Parenthood</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://plannedparenthood.org/planned-parenthood-california-central-coast" data-external-link="true">plannedparenthood.org/planned-parenthood-california-central-coast</a></li>
+<li><strong>Location:</strong> 743 Pismo St., SLO <a class="map-link" data-lat="35.276498" data-lon="-120.661688" data-zoom="17" data-label="Planned Parenthood">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-888-898-3806" aria-label="Call 888-898-3806">888-898-3806</a> </li>
+<li><strong>Email:</strong> <a href="mailto:health.center@ppcentralcoast.org" aria-label="Email health.center@ppcentralcoast.org">health.center@ppcentralcoast.org</a> </li>
+<li><strong>Hours:</strong> M 9am–6pm, Tu–Sa 8am–5pm (closed some holidays) </li>
+<li>Notes: entry-point for “FamilyPACT”</li>
+</ul>
+<h2><span><a id="Port-San-Luis-Harbor-District">Port San Luis Harbor District</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.portsanluis.com/" data-external-link="true">portsanluis.com</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-595-5400" aria-label="Call 805-595-5400">805-595-5400</a> </li>
+<li><strong>Hours</strong> (administrative): M–F 8am–4:30pm (closed Noon–1pm) </li>
+<li>Coastal Gateway Multi-Purpose Room<ul>
+<li><strong>Website:</strong> <a href="https://www.portsanluis.com/2164/Coastal-Gateway-Multi-Purpose-Room" data-external-link="true">portsanluis.com/2164/Coastal-Gateway-Multi-Purpose-Room</a></li>
+<li><strong>Location:</strong> 3900 Avila Beach Dr., Avila Beach <a class="map-link" data-lat="35.172545" data-lon="-120.756491" data-zoom="17" data-label="Port San Luis Harbor District">Map</a> </li>
+</ul>
+</li>
+<li>RV Camping<ul>
+<li><strong>Website:</strong> <a href="https://www.portsanluis.com/2163/RV-Camping" data-external-link="true">portsanluis.com/2163/RV-Camping</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-305-4796" aria-label="Call 805-305-4796">805-305-4796</a></li>
+<li><strong>Email:</strong> <a href="mailto:reservations@portsanluis.com" aria-label="Email reservations@portsanluis.com">reservations@portsanluis.com</a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Pregnancy-Parenting-Support">Pregnancy &amp; Parenting Support</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ppsslo.org/" data-external-link="true">www.ppsslo.org</a></li>
+<li><strong>Location:</strong> 3480 S. Higuera #110, SLO <a class="map-link" data-lat="35.245008" data-lon="-120.673657" data-zoom="17" data-label="Pregnancy &amp; Parenting Support">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-3367" aria-label="Call 805-541-3367">805-541-3367</a>, <a href="sms:+1-805-541-3367">805-541-3367</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@ppsslo.org" aria-label="Email info@ppsslo.org">info@ppsslo.org</a> </li>
+<li><strong>Hours:</strong> M–F 10am–3pm </li>
+<li><strong>How to access:</strong> By appointment only; call or text to make an appointment </li>
+</ul>
+<h2><span>Public Health Department</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Public-Health-Department" aria-label="View directory entry for SLO County Public Health Department"><strong>SLO County Public Health Department</strong></a></em></p>
+</blockquote>
+<h2><span>Rapha House</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Recovery-Dharma">Recovery Dharma</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://recoverydharma.org/" data-external-link="true">recoverydharma.org</a></li>
+<li><strong>Location:</strong> 865 Aerovista Pl. #106, SLO (<a href="#" data-directory-link="Aspire-Counseling-Service" aria-label="View directory entry for Aspire Counseling Service"><strong>Aspire Counseling Service</strong></a>) <a href="#" class="map-link" data-lat="35.242312" data-lon="-120.640925" data-zoom="17" data-label="Aspire Counseling Service">Map</a> </li>
+<li><strong>Email:</strong> <a href="mailto:tedrossini@gmail.com" aria-label="Email tedrossini@gmail.com">tedrossini@gmail.com</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-510-417-6162" aria-label="Call 510-417-6162">510-417-6162</a> </li>
+<li><strong>Hours:</strong> Sa. 10:20–11:20am </li>
+</ul>
+<h2><span><a id="Recuperative-Care-Program">Recuperative Care Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/rcp/" data-external-link="true">capslo.org/rcp</a></li>
+<li><strong>Location:</strong> <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado"><strong>40 Prado</strong></a>, SLO <a class="map-link" data-lat="35.256164" data-lon="-120.672655" data-zoom="17" data-label="40 Prado Homeless Services Center">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-458-2895" aria-label="Call 805-458-2895">805-458-2895</a> (Ariana Long) </li>
+<li><a href="tel:+1-805-503-2984" aria-label="Call 805-503-2984">805-503-2984</a> (Amy Nielson, inquiries) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:rcp40prado@capslo.org" aria-label="Email rcp40prado@capslo.org">rcp40prado@capslo.org</a> </li>
+<li><strong>Hours:</strong> 24/7 </li>
+<li><strong>How to access:</strong> Must be referred by a medical professional </li>
+</ul>
+<h2><span><a id="Recycle-101">Recycle 101</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 1909 Front St., Oceano <a class="map-link" data-lat="35.098794" data-lon="-120.612028" data-zoom="17" data-label="Recycle 101 — Oceano">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-363-1034" aria-label="Call 805-363-1034">805-363-1034</a> </li>
+<li><strong>Hours:</strong> W 9am–4pm, M/Tu/Th/F/Sa 9am–Noon, M/Tu/Th/F 12:30–4pm </li>
+<li>Notes: CRV recycling for cash (5¢ for containers &lt;24oz, 10¢ for ≥24oz)</li>
+</ul>
+<h2><span><a id="Red-Cross">Red Cross</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.redcross.org/local/california/central-california.html" data-external-link="true">redcross.org/local/california/central-california.html</a></li>
+<li><strong>Location:</strong> 225 Prado Rd. #A <a class="map-link" data-lat="35.253953" data-lon="-120.666367" data-zoom="17" data-label="Red Cross">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li>Local office: <a href="tel:+1-805-543-0696" aria-label="Call 805-543-0696">805-543-0696</a> </li>
+<li>24/7 national line: <a href="tel:+1-800-733-2767" aria-label="Call 800-733-2767">800-733-2767</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 9am–4pm </li>
+</ul>
+<h2><span><a id="Red-Rover-Relief">Red Rover Relief</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://redrover.org/relief/" data-external-link="true">redrover.org/relief</a></li>
+<li><strong>Mailing address:</strong> P.O. Box 188890, Sacramento, CA 95818 </li>
+<li><strong>Phone:</strong> <a href="tel:+1-916-429-2457" aria-label="Call 916-429-2457">916-429-2457</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@redrover.org" aria-label="Email info@redrover.org">info@redrover.org</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–4:30pm </li>
+</ul>
+<h2><span><a id="Refuge-Church-Atascadero">Refuge Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://refugechurch.info/connect/open-arms-ministry" data-external-link="true">refugechurch.info/connect/open-arms-ministry</a></li>
+<li><strong>Location:</strong> 6955 Portola Rd., Atascadero <a class="map-link" data-lat="35.476475" data-lon="-120.679480" data-zoom="17" data-label="Refuge Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-3554" aria-label="Call 805-466-3554">805-466-3554</a> </li>
+<li><strong>Email:</strong> <a href="mailto:office@refugechurch.info" aria-label="Email office@refugechurch.info">office@refugechurch.info</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Food and clothing pantry: Tu 5–6pm, W 6–6:30pm, or by appointment</li>
+<li>Refuge recovery (for anyone struggling with addiction): Tu 6pm </li>
+<li>Free meals: Tu 5pm/W 6pm dinner</li>
+<li>Office: M–F 8am–5pm</li>
+</ul>
+</li>
+</ul>
+<h2><span>Refugee and Immigrant Services Education</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a></em></p>
+</blockquote>
+<h2><span>Regional Transit Authority (RTA)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-RTA" aria-label="View directory entry for SLO Regional Transit Authority"><strong>SLO Regional Transit Authority</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Renovate-Church">Renovate Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://renovateslo.com/" data-external-link="true">renovateslo.com</a></li>
+<li><strong>Location:</strong> 2075 Johnson Ave., SLO <a class="map-link" data-lat="35.276312" data-lon="-120.648300" data-zoom="17" data-label="Renovate Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-0945" aria-label="Call 805-543-0945">805-543-0945</a></li>
+<li><strong>Email:</strong> <a href="mailto:office@renovateslo.com" aria-label="Email office@renovateslo.com">office@renovateslo.com</a></li>
+<li>Hours (food pantry): M 4–6pm</li>
+</ul>
+<h2><span><a id="Restoration-Church">Restoration Church</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 9333 Santa Barbara Rd., Atascadero <a class="map-link" data-lat="35.449172" data-lon="-120.633742" data-zoom="17" data-label="Restoration Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-538-0449" aria-label="Call 805-538-0449">805-538-0449</a> </li>
+<li><strong>Hours</strong> (food pantry): first Saturday of the month, 1–3pm </li>
+</ul>
+<h2><span><a id="Restorative-Partners">Restorative Partners</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://restorativepartners.org/" data-external-link="true">restorativepartners.org</a></li>
+<li><strong>Location:</strong> 3380 South Higuera St., SLO <a href="#" class="map-link" data-lat="35.255072" data-lon="-120.669130" data-zoom="17" data-label="Restorative Partners">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-242-1272" aria-label="Call 805-242-1272">805-242-1272</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@restorativepartners.org" aria-label="Email info@restorativepartners.org">info@restorativepartners.org</a></li>
+<li><strong>Hours:</strong> M–F 9am–5pm </li>
+<li>Notes:<ul>
+<li>Operates <a href="#" data-directory-link="Healing-and-Restoration-Campus" aria-label="View directory entry for Healing and Restoration Campus"><strong>Healing and Restoration Campus</strong></a> </li>
+<li>Operates “The Bridge Cafe” <ul>
+<li><strong>Location:</strong> 1074 Higuera St., SLO </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-1689" aria-label="Call 805-439-1689">805-439-1689</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@thebridgecafe.org" aria-label="Email info@thebridgecafe.org">info@thebridgecafe.org</a> </li>
+<li><strong>Hours:</strong> M–F 7am–3pm </li>
+</ul>
+</li>
+<li>Operates a housing program (<a href="https://restorativepartners.org/housing/" data-external-link="true">restorativepartners.org/housing</a>):<ul>
+<li>Anna’s Home (Paso Robles): Supports 5 women and their children with employment support, job management, financial literacy, life skills, and permanent housing goals </li>
+<li>Hope House (Los Osos): For returning women, offers 24/7 supervision, transportation, 12-step meetings, life skills training, mentorship, outpatient treatment </li>
+<li>Rapha House (Los Osos): 8-bed home for men focusing on recovery from addiction, restorative justice practices, clean and sober lifestyle </li>
+<li>LyonHeart Place (San Luis Obispo): Men’s State Parolee Reentry Housing Program with Joseph House and Francis House providing clinically structured and supportive environment </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-234-9074" aria-label="Call 805-234-9074">805-234-9074</a></li>
+<li><strong>Email:</strong> <a href="mailto:housing@restorativepartners.org" aria-label="Email housing@restorativepartners.org">housing@restorativepartners.org</a> </li>
+<li><strong>How to access:</strong> contact Restorative Partners to get on the waiting list</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Ride-On-Transportation">Ride-On Transportation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ride-on.org/" data-external-link="true">ride-on.org</a></li>
+<li><strong>Location:</strong> 3620 Sacramento Dr. #201, SLO <a href="#" class="map-link" data-lat="35.255366" data-lon="-120.641446" data-zoom="17" data-label="Ride-On Transportation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-8747" aria-label="Call 805-541-8747">805-541-8747</a> </li>
+<li><strong>Email:</strong> <a href="mailto:contact@ride-on.org" aria-label="Email contact@ride-on.org">contact@ride-on.org</a> </li>
+<li><a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal"><strong>Medi-Cal</strong></a> Shuttle a.k.a. <a href="https://www.cencalhealth.org/members/transportation/" data-external-link="true">CenCal Health Transportation</a><ul>
+<li><strong>Phone:</strong> <a href="tel:+1-855-659-4600" aria-label="Call 855-659-4600">855-659-4600</a> (Ventura Transit System) </li>
+</ul>
+</li>
+<li>Veterans Express Shuttle<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-8747" aria-label="Call 805-541-8747">805-541-8747</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 6:30am–5:00pm (phone hours) </li>
+<li><strong>How to access:</strong> Call, or <a href="https://www.ride-on.org/ride-on-ride-request.php" data-external-link="true">submit a ride request online</a></li>
+</ul>
+<h2><span>RISE</span></h2>
+<blockquote>
+<p><em>Former name of <a href="#" data-directory-link="Lumina-Alliance" aria-label="View directory entry for Lumina Alliance"><strong>Lumina Alliance</strong></a></em></p>
+</blockquote>
+<blockquote>
+<p><em>For “Refugee and Immigrant Services Education” see <a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Rotating-Overnight-Safe-Parking-Program">Rotating Overnight Safe Parking Program</a></span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/safe-parking/" data-external-link="true">capslo.org/safe-parking</a></li>
+<li><strong>Location:</strong> (various; apply at 40 Prado Rd., SLO <a class="map-link" data-lat="35.256164" data-lon="-120.672655" data-zoom="17" data-label="40 Prado Homeless Services Center">Map</a>)</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-544-4004" aria-label="Call 805-544-4004">805-544-4004</a> (main 40 Prado)</li>
+<li><a href="tel:+1-805-440-6168" aria-label="Call 805-440-6168">805-440-6168</a> (Cecil Hale, Safe Parking inquiries)</li>
+</ul>
+</li>
+<li><strong>How to access:</strong> Must first complete intake at <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a>, then you are referred to the rotating program on a case-by-case basis</li>
+<li><strong>Hours:</strong> 7pm–7am overnight only</li>
+</ul>
+<h2><span>RTA (Regional Transit Authority)</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-RTA" aria-label="View directory entry for SLO Regional Transit Authority"><strong>SLO Regional Transit Authority</strong></a></em></p>
+</blockquote>
+<h2><span>Runabout Paratransit</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-RTA" aria-label="View directory entry for SLO Regional Transit Authority"><strong>SLO Regional Transit Authority</strong></a></em></p>
+</blockquote>
+<h2><span><a id="RVs-for-Veterans">RVs for Veterans</a></span></h2>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-234-5478" aria-label="Call 805-234-5478">805-234-5478</a> </li>
+<li>Note: a project of <a href="#" data-directory-link="Hopes-Village" aria-label="View directory entry for Hope’s Village">Hope’s Village</a></li>
+</ul>
+<h2><span><a id="Second-Chances-Thrift-Store">Second Chances Thrift Store</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.captivehearts.org/second-chances-store.html" data-external-link="true">captivehearts.org/second-chances-store.html</a></li>
+<li><strong>Location:</strong> 892 W. Grand Ave., Grover Beach <a class="map-link" data-lat="35.121353" data-lon="-120.620453" data-zoom="17" data-label="Second Chances Thrift Store">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-202-8800" aria-label="Call 805-202-8800">805-202-8800</a> </li>
+<li><strong>Hours:</strong> M–Sa 10am–4:30pm </li>
+<li>Notes: Operated by <a href="#" data-directory-link="Captive-Hearts" aria-label="View directory entry for Captive Hearts">Captive Hearts</a> </li>
+</ul>
+<h2><span><a id="SAFE-Family-Resource-Centers">SAFE Family Resource Centers</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/s-a-f-e-family-resource-centers/" data-external-link="true">capslo.org/s-a-f-e-family-resource-centers</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1511 19th St., Oceano <a href="#" class="map-link" data-lat="35.102919" data-lon="-120.610154" data-zoom="17" data-label="SAFE Family Resource Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-3690" aria-label="Call 805-474-3690">805-474-3690</a></td>
+</tr>
+<tr>
+<td data-label="Location">1086 Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.119759" data-lon="-120.595638" data-zoom="17" data-label="SAFE Family Resource Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-2105" aria-label="Call 805-474-2105">805-474-2105</a></td>
+</tr>
+<tr>
+<td data-label="Location">920 W. Tefft St., Nipomo <a href="#" class="map-link" data-lat="35.027607" data-lon="-120.497553" data-zoom="16" data-label="SAFE Family Resource Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-3000;ext=5147" aria-label="Call 805-474-3000&nbsp;x5147">805-474-3000&nbsp;x5147</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:southcountysafe@capslo.org" aria-label="Email southcountysafe@capslo.org">southcountysafe@capslo.org</a> </li>
+<li><strong>How to access:</strong> Walk-ins OK; appointments preferred.</li>
+<li>Note:<ul>
+<li>Operated by <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></li>
+<li>See also <a href="#" data-directory-link="Link-Family-Resource-Center" aria-label="View directory entry for Link Family Resource Center"><strong>Link Family Resource Center</strong></a></li>
+<li>See also <a href="#" data-directory-link="North-County-Family-Resource-Center" aria-label="View directory entry for North County Family Resource Center"><strong>North County Family Resource Center</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="St-Barnabas-Thrift-Shop">St. Barnabas Thrift Shop</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://saintbarnabas-ag.org/get-involved/thrift-shop/" data-external-link="true">saintbarnabas-ag.org/get-involved/thrift-shop</a></li>
+<li><strong>Location:</strong> 1328 Grand Ave. #F, Grover Beach <a href="#" class="map-link" data-lat="35.121001" data-lon="-120.614790" data-zoom="17" data-label="St. Barnabas Thrit Shop">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-270-4023" aria-label="Call 805-270-4023">805-270-4023</a> </li>
+<li><strong>Email:</strong> <a href="mailto:stbarnabasthriftstore@gmail.com" aria-label="Email stbarnabasthriftstore@gmail.com">stbarnabasthriftstore@gmail.com</a> </li>
+<li><strong>Hours:</strong> Tu–F 10am–4pm, Sa Noon–4pm <ul>
+<li>“Bag Day” sale on the last Friday of the month</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="St-Josephs-Church">Saint Joseph’s Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://stjosephcayucos.org/" data-external-link="true">stjosephcayucos.org</a></li>
+<li><strong>Location:</strong> 360 Park Ave., Cayucos <a class="map-link" data-lat="35.447245" data-lon="-120.897665" data-zoom="17" data-label="Saint Joseph’s Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-995-3243" aria-label="Call 805-995-3243">805-995-3243</a> </li>
+<li><strong>Email:</strong> <a href="mailto:stjosephcayucos@charter.net" aria-label="Email stjosephcayucos@charter.net">stjosephcayucos@charter.net</a> </li>
+<li><strong>Hours</strong> (food pantry): Fridays 10am–Noon, or Thursdays by appointment</li>
+</ul>
+<h2><span><a id="St-Patricks-Church">Saint Patrick’s Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.stpatsag.org/" data-external-link="true">stpatsag.org</a></li>
+<li><strong>Location:</strong> 501 Fair Oaks Ave., Arroyo Grande <a class="map-link" data-lat="35.114145" data-lon="-120.583486" data-zoom="17" data-label="Saint Patrick’s Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-489-2680" aria-label="Call 805-489-2680">805-489-2680</a> </li>
+</ul>
+
+<ul>
+<li><strong>Email:</strong> <a href="mailto:info@stpatsag.org" aria-label="Email info@stpatsag.org">info@stpatsag.org</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Office: M/Tu/Th 9am–5pm (closed Noon–1:30pm), W 9:30am–5pm (closed Noon–1:30pm) </li>
+<li>Food pantry: Tu/W/Th 4–5pm</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="St-Patricks-Shamrock-Thrift">St. Patrick’s Shamrock Thrift</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 924 W. Grand Ave., Grover Beach <a class="map-link" data-lat="35.121190" data-lon="-120.619932" data-zoom="17" data-label="St. Patrick’s Shamrock Thrift">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-481-0612" aria-label="Call 805-481-0612">805-481-0612</a> </li>
+<li><strong>Hours:</strong> Tu–Sa 10am–4pm </li>
+</ul>
+<h2><span><a id="Salvation-Army">Salvation Army</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.salvationarmyusa.org/usa-western-territory/" data-external-link="true">salvationarmyusa.org/usa-western-territory</a><ul>
+<li><a href="https://sanluisobispo.salvationarmy.org/" data-external-link="true">sanluisobispo.salvationarmy.org</a></li>
+</ul>
+</li>
+</ul>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Food Pantry</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">815 Islay St., SLO <a class="map-link" data-lat="35.276084" data-lon="-120.659073" data-zoom="17" data-label="Salvation Army">Map</a> </td>
+<td data-label="Phone"><a href="tel:+1-805-544-2401" aria-label="Call 805-544-2401">805-544-2401</a> </td>
+<td data-label="Food Pantry">W/F 10am–Noon, Th. 2–4pm </td>
+<td data-label="Notes">Operates a “Rapid Rehousing Program”</td>
+</tr>
+<tr>
+<td data-label="Location">1550 W. Branch St., Arroyo Grande <a href="#" class="map-link" data-lat="35.130889" data-lon="-120.603205" data-zoom="17" data-label="Salvation Army">Map</a> </td>
+<td data-label="Phone"><a href="tel:+1-805-481-0278" aria-label="Call 805-481-0278">805-481-0278</a> </td>
+<td data-label="Food Pantry">M/W/F 10am–2pm</td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">8420 El Camino Real <a href="#" class="map-link" data-lat="35.473181" data-lon="-120.654509" data-zoom="17" data-label="Salvation Army">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-466-7201" aria-label="Call 805-466-7201">805-466-7201</a> </td>
+<td data-label="Food Pantry"></td>
+<td data-label="Notes"></td>
+</tr>
+<tr>
+<td data-label="Location">540 Quintana Rd., Morro Bay <a href="#" class="map-link" data-lat="35.369278" data-lon="-120.845871" data-zoom="17" data-label="Salvation Army">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-772-7062" aria-label="Call 805-772-7062">805-772-7062</a> </td>
+<td data-label="Food Pantry"></td>
+<td data-label="Notes">(was temporarily closed as of September 2025) </td>
+</tr>
+<tr>
+<td data-label="Location">711 Paso Robles St., Paso Robles <a href="#" class="map-link" data-lat="35.621917" data-lon="-120.685548" data-zoom="17" data-label="Salvation Army">Map</a> </td>
+<td data-label="Phone"><a href="tel:+1-805-238-9591" aria-label="Call 805-238-9591">805-238-9591</a> </td>
+<td data-label="Food Pantry"></td>
+<td data-label="Notes">(was temporarily closed as of September 2025) </td>
+</tr>
+</tbody></table>
+<h2><span><a id="San-Luis-Coastal-Adult-School">San Luis Coastal Adult School</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://ae.slcusd.org/" data-external-link="true">ae.slcusd.org</a></li>
+<li><strong>Location:</strong> 1500 Lizzie St., SLO <a class="map-link" data-lat="35.281251" data-lon="-120.649489" data-zoom="17" data-label="San Luis Coastal Adult School">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-549-1222" aria-label="Call 805-549-1222">805-549-1222</a> </li>
+<li><strong>Email:</strong> <a href="mailto:adultschool@slcusd.org" aria-label="Email adultschool@slcusd.org">adultschool@slcusd.org</a></li>
+<li><strong>How to access:</strong><ul>
+<li>Register for classes on-line at <a href="https://slcusd.asapconnected.com/" data-external-link="true">slcusd.asapconnected.com</a></li>
+<li>Or, come to the office during business hours</li>
+<li>Or, call during business hours</li>
+</ul>
+</li>
+<li>Note:<ul>
+<li>Hosts “San Luis Obispo Family Resource Center”</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-College-of-Law-Legal-Clinic">San Luis Obispo College of Law Legal Clinic</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://montereylaw.edu/clinics/indexslocl.html" data-external-link="true">montereylaw.edu/clinics/indexslocl.html</a></li>
+<li><strong>Location:</strong> 4119 Broad St. #200, SLO <a class="map-link" data-lat="35.245787" data-lon="-120.642691" data-zoom="17" data-label="SLO College of Law Legal Clinic">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-902-2752" aria-label="Call 805-902-CRLA">805-902-CRLA</a> </li>
+<li><strong>Email:</strong> <a href="mailto:mclworkshops@montereylaw.edu" aria-label="Email mclworkshops@montereylaw.edu">mclworkshops@montereylaw.edu</a></li>
+<li><strong>Hours:</strong> M–Th 9am–3pm (scheduling); consultations Tu 4:30–6:30pm</li>
+<li><strong>How to access:</strong> Telephone or Zoom appointments only </li>
+</ul>
+<h2><span><a id="Cal-Poly-Community-Counseling-Service">San Luis Obispo Counseling Service at Cal Poly</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="Community-Counseling-Center" aria-label="View directory entry for Community Counseling Center"><strong>Community Counseling Center</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocounselingservice.calpoly.edu/about" data-external-link="true">slocounselingservice.calpoly.edu/about</a></li>
+<li><strong>Location:</strong> Cotchett Education Bldg. 2, Room 125, Cal Poly SLO <a href="#" class="map-link" data-lat="35.300215" data-lon="-120.664443" data-zoom="17" data-label="Cal Poly Community Counseling Service">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-756-1532" aria-label="Call 805-756-1532">805-756-1532</a> </li>
+<li><strong>How to access:</strong> No walk-ins; Call to make an appointment. </li>
+</ul>
+
+
+<h2><span><a id="Santa-Margarita-KOA-Holiday">Santa Margarita KOA Holiday</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://koa.com/campgrounds/santa-margarita/" data-external-link="true">koa.com/campgrounds/santa-margarita</a></li>
+<li><strong>Location:</strong> 4765 Santa Margarita Lake Rd., Santa Margarita <a class="map-link" data-lat="35.319614" data-lon="-120.499214" data-zoom="17" data-label="Santa Margarita KOA Holiday">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-438-5618" aria-label="Call 805-438-5618">805-438-5618</a> </li>
+<li><strong>Email:</strong> <a href="mailto:santamargarita@koa.com" aria-label="Email santamargarita@koa.com">santamargarita@koa.com</a> </li>
+</ul>
+<h2><span><a id="Santa-Margarita-Lake-Recreation-Area">Santa Margarita Lake Recreation Area</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocountyparks.com/camp/santa-margarita-lake/" data-external-link="true">slocountyparks.com/camp/santa-margarita-lake/</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-788-2397" aria-label="Call 805-788-2397">805-788-2397</a> </li>
+<li><strong>Email:</strong> <a href="mailto:sloparks@co.slo.ca.us" aria-label="Email sloparks@co.slo.ca.us">sloparks@co.slo.ca.us</a></li>
+</ul>
+<h2><span><a id="Santa-Margarita-Senior-Center">Santa Margarita Area Senior Citizens Club</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 22202 “H” St., Santa Margarita <a href="#" class="map-link" data-lat="35.392015" data-lon="-120.605121" data-zoom="17" data-label="Senior Center">Map</a><ul>
+<li>Note: some maps show the address as 2201 “H” St.</li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-438-5854" aria-label="Call 805-438-5854">805-438-5854</a></li>
+<li><a href="tel:+1-805-438-3482" aria-label="Call 805-438-3482">805-438-3482</a> </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>A lunch service site for <a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a></li>
+<li>A <a href="#" data-directory-link="SLO-Food-Bank" aria-label="View directory entry for SLO Food Bank"><strong>SLO Food Bank</strong></a> neighborhood food distribution site</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Santa-Maria-Valley-Hispanic-Church">Santa Maria Valley Hispanic SDA Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://santamariavalleyhispanicca.adventistchurch.org/" data-external-link="true">santamariavalleyhispanicca.adventistchurch.org</a></li>
+<li><strong>Location:</strong> 1575 Orchard Rd., Nipomo <a href="#" class="map-link" data-lat="35.005086" data-lon="-120.459890" data-zoom="17" data-label="Santa Maria Valley Hispanic Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-929-5694" aria-label="Call 805-929-5694">805-929-5694</a> </li>
+<li><strong>Hours</strong> (food pantry): Sa 11am–12:30pm</li>
+</ul>
+<h2><span><a id="Seneca-Central-Coast">Seneca Central Coast</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://senecafoa.org/regions/central-coast/" data-external-link="true">senecafoa.org/regions/central-coast</a></li>
+<li><strong>Location:</strong> 6850 Morro Rd., Atascadero <a href="#" class="map-link" data-lat="35.482077" data-lon="-120.666571" data-zoom="17" data-label="Seneca Central Coast">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-434-2449" aria-label="Call 805-434-2449">805-434-2449</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@senecacenter.org" aria-label="Email info@senecacenter.org">info@senecacenter.org</a> </li>
+<li>Notes:<ul>
+<li>formerly called “Kinship Center”</li>
+<li>offers <a href="#" data-directory-link="Enhanced-Care-Management" aria-label="View directory entry for Enhanced Care Management"><strong>Enhanced Care Management</strong></a> </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Senior-Connection">Senior Connection</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://centralcoastseniors.org/senior-connection/" data-external-link="true">centralcoastseniors.org/senior-connection</a></li>
+<li><strong>Location:</strong> 528 S. Broadway, Santa Maria <a href="#" class="map-link" data-lat="34.947346" data-lon="-120.435439" data-zoom="17" data-label="Senior Connection">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-800-510-2020" aria-label="Call 800-510-2020">800-510-2020</a> </li>
+<li><a href="tel:+1-805-928-2552" aria-label="Call 805-928-2552">805-928-2552</a> </li>
+<li><a href="tel:+1-805-928-9554" aria-label="Call 805-928-9554">805-928-9554</a> </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@centralcoastseniors.org" aria-label="Email info@centralcoastseniors.org">info@centralcoastseniors.org</a></li>
+<li><strong>Hours:</strong> M–F 8am–5pm </li>
+<li><strong>How to access:</strong> Walk-ins OK.</li>
+</ul>
+<h2><span><a id="Senior-Go">Senior Go!</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.sloseniorgo.org/" data-external-link="true">sloseniorgo.org</a></li>
+<li><strong>Locations:</strong> Throughout SLO County </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-473-3333" aria-label="Call 805-473-3333">805-473-3333</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5pm, Sa 10am–3pm (closed major holidays) </li>
+</ul>
+<h2><span><a id="Senior-Legal-Services-Project">Senior Legal Services Project</a></span></h2>
+<ul>
+<li><strong>Location:</strong><ul>
+<li>3232 S. Higuera St. #101D, SLO <a class="map-link" data-lat="35.256866" data-lon="-120.668734" data-zoom="17" data-label="Senior Legal Services Project">Map</a> </li>
+<li>102 S. Vine St. #C, Paso Robles <a href="#" class="map-link" data-lat="35.614368" data-lon="-120.692636" data-zoom="17" data-label="Lumina Alliance">Map</a> </li>
+<li>Also operates clinics at various Senior Centers and similar sites</li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-5140" aria-label="Call 805-543-5140">805-543-5140</a> </li>
+<li><strong>Email:</strong> <a href="mailto:intake@slolaf.org" aria-label="Email intake@slolaf.org">intake@slolaf.org</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–5pm</li>
+<li>Note: a project of <a href="#" data-directory-link="SLO-Legal-Assistance-Foundation" aria-label="View directory entry for SLO Legal Assistance Foundation (SLOLAF)"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a></li>
+</ul>
+<h2><span><a id="SESLOC-Credit-Union">SESLOC Credit Union</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.sesloc.org/" data-external-link="true">sesloc.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>1399 Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.120489" data-lon="-120.605442" data-zoom="17" data-label="SESLOC Credit Union">Map</a> </li>
+<li>8380 El Camino Real, Atascadero <a href="#" class="map-link" data-lat="35.473958" data-lon="-120.654657" data-zoom="17" data-label="SESLOC Credit Union">Map</a> </li>
+<li>1 Grand Ave. Bldg. 65, Cal Poly <a href="#" class="map-link" data-lat="35.300241" data-lon="-120.658679" data-zoom="16" data-label="SESLOC Credit Union">Map</a> (closed during academic break periods) </li>
+<li>705 Golden Hill Rd., Paso Robles <a href="#" class="map-link" data-lat="35.622969" data-lon="-120.659648" data-zoom="17" data-label="SESLOC Credit Union">Map</a> </li>
+<li>3807 Broad St., SLO <a href="#" class="map-link" data-lat="35.250534" data-lon="-120.644817" data-zoom="17" data-label="SESLOC Credit Union">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-1816" aria-label="Call 805-543-1816">805-543-1816</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5pm </li>
+</ul>
+<h2><span><a id="Shower-the-People">Shower the People</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://showerthepeopleslo.org/" data-external-link="true">showerthepeopleslo.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">946 Rockaway Ave., Grover Beach <a href="#" class="map-link" data-lat="35.120119" data-lon="-120.619991" data-zoom="17" data-label="Shower the People">Map</a></td>
+<td data-label="Hours">W 10am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">2201 Lawton Ave., SLO           <a href="#" class="map-link" data-lat="35.269229" data-lon="-120.657617" data-zoom="17" data-label="Shower the People">Map</a></td>
+<td data-label="Hours">Tu &amp; Th 10am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">11245 Los Osos Valley Rd., SLO  <a href="#" class="map-link" data-lat="35.260128" data-lon="-120.696026" data-zoom="17" data-label="Shower the People">Map</a></td>
+<td data-label="Hours">Sa 10am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">995 Palm St., SLO               <a href="#" class="map-link" data-lat="35.282298" data-lon="-120.662520" data-zoom="17" data-label="Shower the People">Map</a></td>
+<td data-label="Hours">Su 12:30–3:30pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:showerthepeopleslo@gmail.com" aria-label="Email showerthepeopleslo@gmail.com">showerthepeopleslo@gmail.com</a></li>
+<li>Note: Hosted by <a href="#" data-directory-link="Lifepoint-Church" aria-label="View directory entry for Lifepoint Church"><strong>Lifepoint Church</strong></a> and <a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a> among others</li>
+</ul>
+<h2><span>Sierra Vista Hospital</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Adventist-Health-Sierra-Vista" aria-label="View directory entry for Adventist Health Sierra Vista"><strong>Adventist Health Sierra Vista</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Silver-City-Resort">Silver City Resort</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.silvercitymorrobay.com/" data-external-link="true">silvercitymorrobay.com</a></li>
+<li><strong>Location:</strong> 500 Atascadero Rd., Morro Bay <a class="map-link" data-lat="35.381677" data-lon="-120.859918" data-zoom="17" data-label="Silver City Resort">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-772-7478" aria-label="Call 805-772-7478">805-772-7478</a> </li>
+<li><strong>Email:</strong> <a href="mailto:silvercity@dmhllc.com" aria-label="Email silvercity@dmhllc.com">silvercity@dmhllc.com</a> </li>
+</ul>
+<h2><span><a id="SLO4Home">SLO for HOME</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.sloforhome.org/" data-external-link="true">sloforhome.org</a></li>
+<li><strong>Mailing address:</strong> P.O. Box 3901, SLO, CA 93403 </li>
+<li><strong>Email:</strong> <a href="mailto:info@sloforhome.org" aria-label="Email info@sloforhome.org">info@sloforhome.org</a> </li>
+</ul>
+<h2><span><a id="SLO-Bangers">SLO Bangers</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slobangers.com/" data-external-link="true">slobangers.com</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">6370 Atascadero Ave., Atascadero <a href="#" class="map-link" data-lat="35.486312" data-lon="-120.670295" data-zoom="17" data-label="SLO Bangers">Map</a></td>
+<td data-label="Hours">Su 4–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">760 Morro Bay Blvd., Morro Bay <a href="#" class="map-link" data-lat="35.365706" data-lon="-120.844141" data-zoom="17" data-label="SLO Bangers">Map</a></td>
+<td data-label="Hours">M 2–4pm</td>
+</tr>
+<tr>
+<td data-label="Location">1134 Black Oak Dr., Paso Robles <a href="#" class="map-link" data-lat="35.645387" data-lon="-120.687569" data-zoom="17" data-label="SLO Bangers">Map</a></td>
+<td data-label="Hours">Tu 4:30–5:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">2191 Johnson Ave., SLO <a href="#" class="map-link" data-lat="35.274319" data-lon="-120.646781" data-zoom="17" data-label="SLO Bangers">Map</a></td>
+<td data-label="Hours">W 5:30–8:15pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-458-0123" aria-label="Call 805-458-0123">805-458-0123</a> </li>
+<li><strong>Email:</strong> <a href="mailto:slobangers07@gmail.com" aria-label="Email slobangers07@gmail.com">slobangers07@gmail.com</a> </li>
+</ul>
+<h2><span><a id="SLO-Cal-Careers-Center">SLO Cal Careers Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://SLOCalCareers.org" data-external-link="true">SLOCalCareers.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>3563 Empleo Street, SLO <a href="#" class="map-link" data-lat="35.251551" data-lon="-120.668077" data-zoom="18" data-label="SLO Cal Careers Center">Map</a></li>
+<li>Youth Services: 3450 Broad St. #103a, SLO <a href="#" class="map-link" data-lat="35.257929" data-lon="-120.646915" data-zoom="17" data-label="SLO Cal Careers Youth Services Center">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-2557" aria-label="Call 805-439-2557">805-439-2557</a></li>
+<li><strong>Email:</strong><ul>
+<li><a href="mailto:SLOCal@eckerd.org" aria-label="Email SLOCal@eckerd.org">SLOCal@eckerd.org</a></li>
+<li><a href="mailto:info@slocalcareers.org" aria-label="Email info@slocalcareers.org">info@slocalcareers.org</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 9am–4pm</li>
+<li>Notes:<ul>
+<li>a.k.a. “America’s Job Center of California”</li>
+<li>formerly “Business and Career One Stop”</li>
+</ul>
+</li>
+</ul>
+
+
+<h2><span>SLO Counseling Service</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Cal-Poly-Community-Counseling-Service" aria-label="View directory entry for Cal Poly Community Counseling Service"><strong>Cal Poly Community Counseling Service</strong></a></em></p>
+</blockquote>
+<h2><span><a id="SLO-County-Animal-Services">SLO County Animal Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/animal-services" data-external-link="true">slocounty.ca.gov/departments/health-agency/animal-services</a></li>
+<li><strong>Location:</strong> 885 Oklahoma Ave., SLO <a class="map-link" data-lat="35.318844" data-lon="-120.715762" data-zoom="17" data-label="SLO County Animal Services">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-781-4400" aria-label="Call 805-781-4400">805-781-4400</a> (main office) </li>
+<li><a href="tel:+1-805-781-4407" aria-label="Call 805-781-4407">805-781-4407</a> (found animal recording) </li>
+</ul>
+</li>
+<li><strong>Hours:</strong><ul>
+<li>Office: M/Tu/Th/F 8am–5pm, W 8am–7pm; Sa 9am–5pm </li>
+<li>Kennel: M/Tu/Th/F/Sa 1pm–5pm; W 1pm–7pm </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> call to make an appointment</li>
+</ul>
+<h2><span><a id="SLO-County-Bar-Association">SLO County Bar Association Lawyer Referral and Information Service</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://slobarlris.org/" data-external-link="true">slobarlris.org</a></li>
+<li><strong>Mailing address:</strong> P.O. Box 585, SLO, CA 93406 </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-5502" aria-label="Call 805-541-5502">805-541-5502</a> </li>
+<li><strong>Email:</strong> <a href="mailto:lris@slobar.org" aria-label="Email lris@slobar.org">lris@slobar.org</a> </li>
+</ul>
+
+
+<h2><span><a id="SLO-County-Behavioral-Health">SLO County Behavioral Health</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Main Office: 2180 Johnson Ave., SLO <a href="#" class="map-link" data-lat="35.274722" data-lon="-120.646040" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> </li>
+<li>Arroyo Grande: 1350 Grand Ave. <a href="#" class="map-link" data-lat="35.120967" data-lon="-120.604497" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-474-2154" aria-label="Call 805-474-2154">805-474-2154</a> <ul>
+<li>Services Affirming Family Empowerment: 1086 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.119759" data-lon="-120.595638" data-zoom="17" data-label="SLO County Department of Social Services">Map</a> — <a href="tel:+1-805-474-2105" aria-label="Call 805-474-2105">805-474-2105</a> </li>
+</ul>
+</li>
+<li>Atascadero Health Campus: 5575 Hospital Dr. <a href="#" class="map-link" data-lat="35.492613" data-lon="-120.662895" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-461-6060" aria-label="Call 805-461-6060">805-461-6060</a> (adult mental health), <a href="tel:+1-805-461-6113" aria-label="Call 805-461-6113">805-461-6113</a> (youth mental health), <a href="tel:+1-805-461-6080" aria-label="Call 805-461-6080">805-461-6080</a> (adult drug and alcohol services) </li>
+<li>Grover Beach:<ul>
+<li>Youth &amp; Adult Drug and Alcohol Services: 1523 Longbranch Ave. <a href="#" class="map-link" data-lat="35.119403" data-lon="-120.612598" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-473-7080" aria-label="Call 805-473-7080">805-473-7080</a> </li>
+<li>Youth Mental Health Services: 1666 Ramona Ave. <a href="#" class="map-link" data-lat="35.119877" data-lon="-120.612731" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-473-7060" aria-label="Call 805-473-7060">805-473-7060</a> </li>
+</ul>
+</li>
+<li>Paso Robles Health Campus: 805 4th St. <a href="#" class="map-link" data-lat="35.618660" data-lon="-120.689219" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-237-3090" aria-label="Call 805-237-3090">805-237-3090</a> (adult mental health), <a href="tel:+1-805-237-3070" aria-label="Call 805-237-3070">805-237-3070</a> (youth mental health), <a href="tel:+1-805-226-3200" aria-label="Call 805-226-3200">805-226-3200</a> (adult drug and alcohol services) </li>
+<li>SLO:<ul>
+<li>Adult Drug and Alcohol Services: 2180 Johnson Ave. <a href="#" class="map-link" data-lat="35.274910" data-lon="-120.646191" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-781-4275" aria-label="Call 805-781-4275">805-781-4275</a> </li>
+<li>Adult Mental Health Services: 2178 Johnson Ave. <a href="#" class="map-link" data-lat="35.275337" data-lon="-120.646539" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-781-4700" aria-label="Call 805-781-4700">805-781-4700</a> </li>
+<li>Youth Drug and Alcohol Services: 277 South St. #T, SLO <a href="#" class="map-link" data-lat="35.268064" data-lon="-120.666476" data-zoom="17" data-label="SLO County Drug and Alcohol Services">Map</a> — <a href="tel:+1-805-781-4754" aria-label="Call 805-781-4754">805-781-4754</a> </li>
+<li>Youth Mental Health Services: 2975 McMillan Suite 160 <a href="#" class="map-link" data-lat="35.263533" data-lon="-120.648100" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-781-4179" aria-label="Call 805-781-4179">805-781-4179</a> </li>
+<li>Psychiatric Health Facility: 2178 Johnson Ave. <a href="#" class="map-link" data-lat="35.275431" data-lon="-120.646555" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> </li>
+<li>Martha’s Place Children’s Center (Ages 0–5): 2925 McMillan Ave. Suite 108 <a href="#" class="map-link" data-lat="35.263382" data-lon="-120.648288" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-805-781-4948" aria-label="Call 805-781-4948">805-781-4948</a> </li>
+<li>Prevention and Outreach Services: 277 South St. #T, SLO <a href="#" class="map-link" data-lat="35.268064" data-lon="-120.666476" data-zoom="17" data-label="SLO County Drug and Alcohol Services">Map</a> — <a href="tel:+1-805-781-4754" aria-label="Call 805-781-4754">805-781-4754</a> </li>
+<li>SLO Sobering Center: 2180 Johnson Ave. <a href="#" class="map-link" data-lat="35.274910" data-lon="-120.646191" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> — <a href="tel:+1-820-280-0415" aria-label="Call 820-280-0415">820-280-0415</a> </li>
+</ul>
+</li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li>Behavioral Health Access Line: <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> </li>
+<li>Local mental health crisis hotline: <a href="tel:+1-800-783-0607" aria-label="Call 800-783-0607">800-783-0607</a> </li>
+<li>Patient’s rights advocate: <a href="tel:+1-805-781-4738" aria-label="Call 805-781-4738">805-781-4738</a></li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm for lunch) </li>
+<li>Cost: “No clients are denied access to services due to inability to pay. Discounted fees and sliding fee schedules are available based on family size and income.” </li>
+<li>Notes:<ul>
+<li>Operates <a href="#" data-directory-link="SLO-County-Drug-and-Alcohol-Services" aria-label="View directory entry for SLO County Drug and Alcohol Services"><strong>SLO County Drug and Alcohol Services</strong></a></li>
+<li><a href="#" data-directory-link="Genoa-Pharmacy" aria-label="View directory entry for Genoa Pharmacy"><strong>Genoa Pharmacy</strong></a> is the on-site pharmacy for SLO County Behavioral Health</li>
+<li>Can refer you to the “Supported Employment” program</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-County-Clerk-Recorder">SLO County Clerk-Recorder</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/clerk-recorder" data-external-link="true">slocounty.ca.gov/departments/clerk-recorder</a></li>
+<li><strong>Locations:</strong><ul>
+<li>6565 Capistrano Ave., Second Floor, Atascadero <a href="#" class="map-link" data-lat="35.489136" data-lon="-120.663893" data-zoom="17" data-label="SLO County Clerk-Recorder">Map</a> </li>
+<li>1055 Monterey St. #D120, SLO <a class="map-link" data-lat="35.282079" data-lon="-120.660193" data-zoom="17" data-label="SLO County Clerk-Recorder">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-781-5080" aria-label="Call 805-781-5080">805-781-5080</a> </li>
+<li><a href="tel:+1-805-461-6041" aria-label="Call 805-461-6041">805-461-6041</a> (North County office) </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> SLO office only: M/Tu/Th/F 8am–5pm, W 8am–4pm (transactions end 30 minutes before closing) </li>
+</ul>
+<h2><span><a id="SLO-County-Department-of-Social-Services">SLO County Department of Social Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/social-services" data-external-link="true">slocounty.ca.gov/departments/social-services</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1086 E. Grand Ave., Arroyo Grande <a href="#" class="map-link" data-lat="35.119759" data-lon="-120.595638" data-zoom="17" data-label="SLO County Department of Social Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-2000" aria-label="Call 805-474-2000">805-474-2000</a></td>
+</tr>
+<tr>
+<td data-label="Location">9630 El Camino Real, Atascadero <a href="#" class="map-link" data-lat="35.465765" data-lon="-120.648798" data-zoom="17" data-label="Department of Social Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-461-6000" aria-label="Call 805-461-6000">805-461-6000</a></td>
+</tr>
+<tr>
+<td data-label="Location">600 Quintana Rd., Morro Bay <a href="#" class="map-link" data-lat="35.369273" data-lon="-120.844726" data-zoom="17" data-label="Department of Social Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-772-6405" aria-label="Call 805-772-6405">805-772-6405</a></td>
+</tr>
+<tr>
+<td data-label="Location">681 W. Tefft St. #1, Nipomo <a href="#" class="map-link" data-lat="35.033619" data-lon="-120.487984" data-zoom="17" data-label="Department of Social Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-931-1800" aria-label="Call 805-931-1800">805-931-1800</a></td>
+</tr>
+<tr>
+<td data-label="Location">406 Spring St., Paso Robles <a href="#" class="map-link" data-lat="35.618565" data-lon="-120.690345" data-zoom="17" data-label="Department of Social Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-3110" aria-label="Call 805-237-3110">805-237-3110</a></td>
+</tr>
+<tr>
+<td data-label="Location">3433 S. Higuera, SLO <a href="#" class="map-link" data-lat="35.253655" data-lon="-120.668725" data-zoom="17" data-label="SLO County Department of Social Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-1600" aria-label="Call 805-781-1600">805-781-1600</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Hours:</strong> M–F 8am–5pm (4pm–5pm by appointment only) </li>
+<li>Notes:<ul>
+<li>operates <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs Homeless Assistance Program"><strong>CalWORKs Homeless Assistance Program</strong></a></li>
+<li>operates <a href="https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/general-assistance-cash-aid" data-external-link="true">“General Assistance Disabled Program”</a></li>
+<li>operates <a href="https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/general-assistance-cash-aid" data-external-link="true">“General Relief / General Assistance”</a></li>
+<li>operates “Temporary Assistance for Needy Families (TANF)”</li>
+<li>entry-point for “CalFresh / EBT (Food Stamps)”</li>
+<li>entry-point for the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+<li>entry-point for the <a href="#" data-directory-link="Housing-Support-Program" aria-label="View directory entry for Housing Support Program (HSP)"><strong>Housing Support Program (HSP)</strong></a></li>
+<li>entry-point for the <a href="#" data-directory-link="Medically-Fragile-Homeless-Program" aria-label="View directory entry for Medically Fragile Homeless Program"><strong>Medically Fragile Homeless Program</strong></a></li>
+<li>can refer you to the <a href="#" data-directory-link="Child-Care-Resource-Connection" aria-label="View directory entry for Child Care Resource Connection"><strong>Child Care Resource Connection</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-County-Drug-and-Alcohol-Services">SLO County Drug and Alcohol Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/drug-and-alcohol-services" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health/drug-and-alcohol-services</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Walk-in Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">1523 Longbranch Ave., Grover Beach <a href="#" class="map-link" data-lat="35.119403" data-lon="-120.612598" data-zoom="17" data-label="SLO County Drug and Alcohol Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-473-7080" aria-label="Call 805-473-7080">805-473-7080</a> or <a href="tel:+1-805-473-7081" aria-label="Call 805-473-7081">805-473-7081</a></td>
+<td data-label="Walk-in Hours">Mo,Fr 8am–11am; Tu 2:30–5:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">805 E. 4th Street, Paso Robles <a href="#" class="map-link" data-lat="35.618678" data-lon="-120.689326" data-zoom="17" data-label="SLO County Drug and Alcohol Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-226-3200" aria-label="Call 805-226-3200">805-226-3200</a></td>
+<td data-label="Walk-in Hours">Mo,Th 8am–11am; Tu 2:30–5:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">2180 Johnson Ave., SLO <a href="#" class="map-link" data-lat="35.274910" data-lon="-120.646191" data-zoom="17" data-label="SLO County Drug and Alcohol Services">Map</a> — for adults</td>
+<td data-label="Phone"><a href="tel:+1-805-781-4275" aria-label="Call 805-781-4275">805-781-4275</a></td>
+<td data-label="Walk-in Hours">Tu,We 8am–11am; Th 2:30–5:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">277 South St. #T, SLO <a href="#" class="map-link" data-lat="35.268064" data-lon="-120.666476" data-zoom="17" data-label="SLO County Drug and Alcohol Services">Map</a> — for youth &amp; veterans</td>
+<td data-label="Phone"><a href="tel:+1-805-781-4754" aria-label="Call 805-781-4754">805-781-4754</a></td>
+<td data-label="Walk-in Hours">M–F 8am–5pm</td>
+</tr>
+</tbody></table>
+
+
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> (main access line)</li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li><strong>How to access:</strong> walk-ins OK (see Hours above), or call the main access line to make an appointment</li>
+<li>Notes:<ul>
+<li>Operated by <a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a></li>
+<li>Atascadero clinic closed as of July 1, 2025 (use Paso Robles clinic instead)</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-County-Health-Department">SLO County Health Department</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="SLO-County-Public-Health-Department" aria-label="View directory entry for SLO County Public Health Department"><strong>SLO County Public Health Department</strong></a></em></p>
+</blockquote>
+<ul>
+<li>Note: entry-point for the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+</ul>
+<h2><span><a id="SLO-County-Law-Library">SLO County Law Library</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocll.org/" data-external-link="true">slocll.org</a></li>
+<li><strong>Location:</strong> 1050 Monterey St., Room 125, SLO <a class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="SLO County Law Library">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5855" aria-label="Call 805-781-5855">805-781-5855</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slocll.org" aria-label="Email info@slocll.org">info@slocll.org</a> </li>
+<li><strong>Hours:</strong> M–W 9am–4pm, Th.–F 8:30am–1:30pm </li>
+</ul>
+<h2><span><a id="SLO-County-Mental-Health-Services">SLO County Mental Health Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health" data-external-link="true">slocounty.ca.gov/departments/health-agency/behavioral-health</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Serves</th>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Serves">Adults</td>
+<td data-label="Location">1350 E. Grand Ave. , Arroyo Grande<a href="#" class="map-link" data-lat="35.120967" data-lon="-120.604497" data-zoom="17" data-label="SLO County Mental Health Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-2154" aria-label="Call 805-474-2154">805-474-2154</a></td>
+</tr>
+<tr>
+<td data-label="Serves">Youths</td>
+<td data-label="Location">354 S. Halcyon Rd., Arroyo Grande <a href="#" class="map-link" data-lat="35.113647" data-lon="-120.592282" data-zoom="17" data-label="SLO County Mental Health Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-473-7060" aria-label="Call 805-473-7060">805-473-7060</a></td>
+</tr>
+<tr>
+<td data-label="Serves">Youths</td>
+<td data-label="Location">1666 Ramona Ave., Grover Beach <a href="#" class="map-link" data-lat="35.119877" data-lon="-120.612731" data-zoom="17" data-label="SLO County Behavioral Health">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-473-7060" aria-label="Call 805-473-7060">805-473-7060</a></td>
+</tr>
+<tr>
+<td data-label="Serves">Adults</td>
+<td data-label="Location">2178 Johnson Ave., SLO <a href="#" class="map-link" data-lat="35.275337" data-lon="-120.646539" data-zoom="17" data-label="SLO County Mental Health Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-4700" aria-label="Call 805-781-4700">805-781-4700</a></td>
+</tr>
+<tr>
+<td data-label="Serves">Youths</td>
+<td data-label="Location">2975 McMillan Ave. Suite 160, SLO <a href="#" class="map-link" data-lat="35.263533" data-lon="-120.648100" data-zoom="17" data-label="SLO County Mental Health Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-4179" aria-label="Call 805-781-4179">805-781-4179</a></td>
+</tr>
+<tr>
+<td data-label="Serves">Children</td>
+<td data-label="Location">2925 McMillan Ave. Suite 108, SLO <a href="#" class="map-link" data-lat="35.263382" data-lon="-120.648288" data-zoom="17" data-label="SLO County Mental Health Services">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-4948" aria-label="Call 805-781-4948">805-781-4948</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> (24hr) / <a href="tel:+1-805-540-6500" aria-label="Call 805-540-6500">805-540-6500</a></li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li><strong>How to access:</strong><ul>
+<li>Walk-ins OK at the Arroyo Grande adult clinic M/W 9–11am and at the SLO adult clinic Tu/Th 1–4:30pm </li>
+<li>For youths and children, call to make an appointment</li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Central access point for all <a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal"><strong>Medi-Cal</strong></a> mental health services</li>
+<li>Can refer you to the “Supported Employment” program</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-County-Office-of-Emergency-Services">SLO County Office of Emergency Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/administrative-office/office-of-emergency-services/contact-us" data-external-link="true">slocounty.ca.gov/departments/administrative-office/office-of-emergency-services</a></li>
+<li><strong>Location:</strong> 1055 Monterey St. #D430, SLO <a class="map-link" data-lat="35.282079" data-lon="-120.660193" data-zoom="17" data-label="SLO County Clerk-Recorder">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5678" aria-label="Call 805-781-5678">805-781-5678</a> </li>
+<li><strong>Email:</strong> <a href="mailto:oes@co.slo.ca.us" aria-label="Email oes@co.slo.ca.us">oes@co.slo.ca.us</a> </li>
+<li>Notes: For emergency alert signup, visit <a href="https://alertslo.org" data-external-link="true">AlertSLO.org</a> or <a href="https://www.prepareslo.org/" data-external-link="true">PrepareSLO.org</a></li>
+</ul>
+<h2><span><a id="SLO-County-Parks">SLO County Parks</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocountyparks.com/" data-external-link="true">slocountyparks.com</a></li>
+<li><strong>Location:</strong> 1144 Monterey St. #A, SLO <a href="#" class="map-link" data-lat="35.283374" data-lon="-120.659376" data-zoom="17" data-label="SLO County Parks &amp; Recreation">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5930" aria-label="Call 805-781-5930">805-781-5930</a> </li>
+<li><strong>Email:</strong> <a href="mailto:sloparks@co.slo.ca.us" aria-label="Email sloparks@co.slo.ca.us">sloparks@co.slo.ca.us</a> </li>
+<li>See also:<ul>
+<li><a href="#" data-directory-link="Coastal-Dunes" aria-label="View directory entry for Coastal Dunes RV Park &amp; Campground"><strong>Coastal Dunes RV Park &amp; Campground</strong></a></li>
+<li><a href="#" data-directory-link="El-Chorro-Regional-Park-Campground" aria-label="View directory entry for El Chorro Regional Park Campground"><strong>El Chorro Regional Park Campground</strong></a></li>
+<li><a href="#" data-directory-link="Lopez-Lake-Recreation-Area" aria-label="View directory entry for Lopez Lake Recreation Area"><strong>Lopez Lake Recreation Area</strong></a></li>
+<li><a href="#" data-directory-link="Oceano-Campground" aria-label="View directory entry for Oceano Campground"><strong>Oceano Campground</strong></a></li>
+<li><a href="#" data-directory-link="Santa-Margarita-Lake-Recreation-Area" aria-label="View directory entry for Santa Margarita Lake Recreation Area"><strong>Santa Margarita Lake Recreation Area</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-County-Public-Health-Department">SLO County Public Health Department</a></span></h2>
+<blockquote>
+<p><em>See also <a href="#" data-directory-link="SLO-County-Health-Department" aria-label="View directory entry for SLO County Health Department"><strong>SLO County Health Department</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/public-health" data-external-link="true">slocounty.ca.gov/departments/health-agency/public-health</a></li>
+<li><strong>Location:</strong><ul>
+<li>2180 Johnson Ave, SLO <a href="#" class="map-link" data-lat="35.274940" data-lon="-120.646298" data-zoom="17" data-label="SLO County Public Health Department">Map</a> </li>
+<li>2191 Johnson Ave, SLO <a href="#" class="map-link" data-lat="35.274391" data-lon="-120.646730" data-zoom="17" data-label="SLO County Public Health Department">Map</a> </li>
+<li>805 4th St., Paso Robles <a href="#" class="map-link" data-lat="35.618660" data-lon="-120.689219" data-zoom="17" data-label="SLO County Behavioral Health">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-788-2903" aria-label="Call 805-788-2903">805-788-2903</a> (24-hour info line) </li>
+<li><a href="tel:+1-805-781-5506" aria-label="Call 805-781-5506">805-781-5506</a> (to make an appointment) </li>
+<li><a href="tel:+1-805-237-3050" aria-label="Call 805-237-3050">805-237-3050</a> (Paso Robles) </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–5pm (closed Noon–1pm) </li>
+</ul>
+<h2><span><a id="SLO-County-Public-Libraries">SLO County Public Libraries</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slolibrary.org/" data-external-link="true">slolibrary.org</a></li>
+</ul>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Arroyo Grande: 800 W. Branch St. <a href="#" class="map-link" data-lat="35.124445" data-lon="-120.589730" data-zoom="17" data-label="SLO County Public Library">Map</a> </td>
+<td data-label="Phone"><a href="tel:+1-805-473-7161" aria-label="Call 805-473-7161">805-473-7161</a></td>
+<td data-label="Hours">Tu/W 1–6pm, F/Sa 1–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero: 6555 Capistrano Ave. <a href="#" class="map-link" data-lat="35.489127" data-lon="-120.663909" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-461-6161" aria-label="Call 805-461-6161">805-461-6161</a></td>
+<td data-label="Hours">Tu/W 10am–6pm, Th/Sa 9am–5pm, F 1–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Cambria: 1043 Main St. <a href="#" class="map-link" data-lat="35.564950" data-lon="-121.096263" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-927-4336" aria-label="Call 805-927-4336">805-927-4336</a></td>
+<td data-label="Hours">Tu/W 10am–6pm, Th 9am–5pm, F 1–5pm, Sa 9am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">Cayucos: 310 B St. <a href="#" class="map-link" data-lat="35.452277" data-lon="-120.905580" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-995-3312" aria-label="Call 805-995-3312">805-995-3312</a></td>
+<td data-label="Hours">Tu/W 9am–5pm (closed Noon–1pm)</td>
+</tr>
+<tr>
+<td data-label="Location">Creston: 6290 Adams St. <a href="#" class="map-link" data-lat="35.518522" data-lon="-120.523509" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-3010" aria-label="Call 805-237-3010">805-237-3010</a></td>
+<td data-label="Hours">Tu 1–6pm, W/Th Noon–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos: 2075 Palisades Ave. <a href="#" class="map-link" data-lat="35.313232" data-lon="-120.837558" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-528-1862" aria-label="Call 805-528-1862">805-528-1862</a></td>
+<td data-label="Hours">Tu/W 10am–6pm, Th 9am–5pm, F/Sa 1–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay: 625 Harbor St. <a href="#" class="map-link" data-lat="35.367165" data-lon="-120.846235" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-772-6394" aria-label="Call 805-772-6394">805-772-6394</a></td>
+<td data-label="Hours">Tu/W 10am–6pm, Th 9am–5pm, F 1–5pm, Sa 9am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">Nipomo: 918 W. Tefft St. <a href="#" class="map-link" data-lat="35.028904" data-lon="-120.497031" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-929-3994" aria-label="Call 805-929-3994">805-929-3994</a></td>
+<td data-label="Hours">Tu/W/Th 10am–6pm, F/Sa 10am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Oceano: 1511 19th St. <a href="#" class="map-link" data-lat="35.102919" data-lon="-120.610154" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-474-7478" aria-label="Call 805-474-7478">805-474-7478</a></td>
+<td data-label="Hours">Tu/W/Th 9am–1pm and 2–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO: 995 Palm St. <a href="#" class="map-link" data-lat="35.282263" data-lon="-120.662223" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-5991" aria-label="Call 805-781-5991">805-781-5991</a></td>
+<td data-label="Hours">Tu/W 10am–6pm, Th/Sa 9am–5pm, F 1–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">San Miguel: 254 13th St. <a href="#" class="map-link" data-lat="35.751188" data-lon="-120.698263" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-467-3224" aria-label="Call 805-467-3224">805-467-3224</a></td>
+<td data-label="Hours">W 11am–6pm (closed 12:30–1pm), Th 10am–5pm (closed 12:30–1pm), F 1–5pm, Sa 10am–5pm (closed 12:30–1pm)</td>
+</tr>
+<tr>
+<td data-label="Location">Santa Margarita: 9630 Murphy Ave. <a href="#" class="map-link" data-lat="35.388044" data-lon="-120.608302" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-438-5622" aria-label="Call 805-438-5622">805-438-5622</a></td>
+<td data-label="Hours">Tu/W 10am–6pm (closed 12:30–1pm), Sa 9am–5pm (closed 12:30–1pm)</td>
+</tr>
+<tr>
+<td data-label="Location">Shandon: 195 N. 2nd St. <a href="#" class="map-link" data-lat="35.656573" data-lon="-120.376358" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-3009" aria-label="Call 805-237-3009">805-237-3009</a></td>
+<td data-label="Hours">Tu/W 10am–6pm (closed 12:30–1pm), Sa 9am–5pm (closed 12:30–1pm)</td>
+</tr>
+<tr>
+<td data-label="Location">Shell Beach: 230 Leeward Ave. <a href="#" class="map-link" data-lat="35.154648" data-lon="-120.669678" data-zoom="17" data-label="SLO County Public Library">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-773-2263" aria-label="Call 805-773-2263">805-773-2263</a></td>
+<td data-label="Hours">Tu/W 10am–1pm and 2–6pm, Sa 9am–5pm</td>
+</tr>
+</tbody></table>
+<ul>
+<li><p>Note: <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a> has a “Library Outreach Team” that connects library patrons who are experiencing homelessness with a social worker and case manager to help them overcome barriers to accessing crucial social services. You can meet the Library Outreach Team at the following library branches (this schedule is subject to change; contact <a href="mailto:mvargas@t-mha.org" aria-label="Email mvargas@t-mha.org">mvargas@t-mha.org</a> for the most up-to-date schedule):</p>
+<ul>
+<li>Atascadero: W 10:30am–Noon</li>
+<li>Arroyo Grande: Th 9:30–11am</li>
+<li>Los Osos: F 1–2:30pm</li>
+<li>Morro Bay: Th. 12:30–2pm</li>
+<li>SLO: Tu 10–11:30am &amp; 2:30–4pm</li>
+</ul>
+<p>You can also make an appointment to meet with the team by calling <a href="tel:+1-805-540-0057" aria-label="Call 805-540-0057">805-540-0057</a></p>
+</li>
+</ul>
+
+
+<h2><span><a id="SLO-County-UndocuSupport">SLO County UndocuSupport</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.sloundocusupport.org/" data-external-link="true">sloundocusupport.org</a></li>
+<li><strong>Location:</strong> 981 Marsh St., SLO <a class="map-link" data-lat="35.279892" data-lon="-120.660341" data-zoom="17" data-label="SLO County Undocusupport">Map</a></li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-543-5451" aria-label="Call 805-543-5451">805-543-5451</a></li>
+<li><a href="tel:+1-805-549-8989" aria-label="Call 805-549-8989">805-549-8989</a> (hotline)</li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:UndocuSupport@cfsloco.org" aria-label="Email UndocuSupport@cfsloco.org">UndocuSupport@cfsloco.org</a></li>
+<li><strong>Hours:</strong> W 1–4:15pm</li>
+</ul>
+<h2><span><a id="SLO-County-YMCA">SLO County YMCA</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ciymca.org/locations/san-luis-obispo-county-ymca" data-external-link="true">ciymca.org/locations/san-luis-obispo-county-ymca</a><ul>
+<li><a href="https://www.ciymca.org/open-doors-scholarship-application" data-external-link="true">Open Doors Scholarship application</a> for people with low incomes</li>
+</ul>
+</li>
+<li><strong>Location:</strong> 1020 Southwood Dr., SLO <a class="map-link" data-lat="35.266421" data-lon="-120.643242" data-zoom="17" data-label="SLO County YMCA">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-8235" aria-label="Call 805-543-8235">805-543-8235</a> </li>
+<li><strong>Email:</strong> <a href="mailto:slo.info@ciymca.org" aria-label="Email slo.info@ciymca.org">slo.info@ciymca.org</a></li>
+<li><strong>Hours:</strong> M–Th 5:30am–9pm, F 5:30am–7pm, Sa 7am–5pm, Su closed </li>
+</ul>
+<h2><span><a id="SLO-Court-Self-Help-Services">SLO Court Self-Help Services</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slo.courts.ca.gov/self-help" data-external-link="true">slo.courts.ca.gov/self-help</a></li>
+<li><strong>Location:</strong> 1050 Monterey St., Room 220, SLO <a class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="SLO Court Self-Help Services">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-706-3617" aria-label="Call 805-706-3617">805-706-3617</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–4:30pm </li>
+<li><strong>How to access:</strong> Phone, or make an appointment at <a href="https://calendly.com/self-help-center/" data-external-link="true">calendly.com/self-help-center</a> </li>
+<li>Notes: Includes “Family Law Facilitator” and “Self-Help Center”</li>
+</ul>
+<h2><span><a id="SLO-Credit-Union">SLO Credit Union</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slocu.com/" data-external-link="true">slocu.com</a></li>
+<li><strong>Location:</strong> 1220 Osos St., SLO <a class="map-link" data-lat="35.280049" data-lon="-120.659510" data-zoom="17" data-label="SLO Credit Union">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-5839" aria-label="Call 805-543-5839">805-543-5839</a> </li>
+<li><strong>Hours:</strong> M–F 9am–4:30pm (lobby closed noon–2pm) </li>
+</ul>
+<h2><span><a id="SLO-Food-Bank">SLO Food Bank</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slofoodbank.org/" data-external-link="true">slofoodbank.org</a></li>
+<li><strong>Location:</strong> 1180 Kendall Rd., SLO <a class="map-link" data-lat="35.237752" data-lon="-120.630593" data-zoom="17" data-label="SLO Food Bank">Map</a> <ul>
+<li>Also has <a href="https://slofoodbank.org/en/food-locator/#neighborhood-food-distributions" data-external-link="true">many food distribution sites around SLO County</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-238-4664" aria-label="Call 805-238-4664">805-238-4664</a> </li>
+<li><strong>Hours:</strong> M–F 9:30am–4pm <ul>
+<li>Food pantry: M/W/F Noon–5pm </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-Grassroots">SLO Grassroots</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slograssroots.org/" data-external-link="true">slograssroots.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-540-1455" aria-label="Call 805-540-1455">805-540-1455</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slograssroots.com" aria-label="Email info@slograssroots.com">info@slograssroots.com</a> </li>
+</ul>
+<h2><span><a id="SLO-Hub">SLO Hub</a></span></h2>
+<blockquote>
+<p><em>See also: <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a></em></p>
+</blockquote>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/slo-hub/" data-external-link="true">capslo.org/slo-hub</a></li>
+<li><strong>Location:</strong> 40 Prado Rd., SLO <a class="map-link" data-lat="35.256164" data-lon="-120.672655" data-zoom="17" data-label="SLO Hub">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-441-6589" aria-label="Call 805-441-6589">805-441-6589</a> </li>
+<li><strong>Email:</strong> <a href="mailto:sreyes@capslo.org" aria-label="Email sreyes@capslo.org">sreyes@capslo.org</a> </li>
+<li><strong>Hours:</strong> M–F 9am–5pm</li>
+<li><strong>How to access:</strong> By appointment only</li>
+<li>Notes: a collaboration between <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for CAPSLO"><strong>CAPSLO</strong></a> and <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a> </li>
+</ul>
+<h2><span><a id="SLO-Legal-Assistance-Foundation">SLO Legal Assistance Foundation (SLOLAF)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slolaf.org/" data-external-link="true">slolaf.org</a></li>
+<li><strong>Locations:</strong><ul>
+<li>3232 S. Higuera St. #101D, SLO <a class="map-link" data-lat="35.256866" data-lon="-120.668734" data-zoom="17" data-label="SLO Legal Assistance Foundation">Map</a> </li>
+<li>102 S. Vine St. #C, Paso Robles <a href="#" class="map-link" data-lat="35.614368" data-lon="-120.692636" data-zoom="17" data-label="Lumina Alliance">Map</a> </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-5140" aria-label="Call 805-543-5140">805-543-5140</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slolaf.org" aria-label="Email info@slolaf.org">info@slolaf.org</a> </li>
+<li>Notes:<ul>
+<li>Operates <a href="#" data-directory-link="Senior-Legal-Services-Project" aria-label="View directory entry for Senior Legal Services Project"><strong>Senior Legal Services Project</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-Noor-Foundation">SLO Noor Foundation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slonoorfoundation.org/" data-external-link="true">slonoorfoundation.org</a></li>
+<li>Primary clinics<ul>
+<li><strong>Locations:</strong><ul>
+<li>1428 Phillips Lane #203, SLO <a href="#" class="map-link" data-lat="35.288103" data-lon="-120.657544" data-zoom="17" data-label="SLO Noor Foundation primary and vision clinic">Map</a> </li>
+<li>400 Oak Hill Rd., Paso Robles <a href="#" class="map-link" data-lat="35.613052" data-lon="-120.675974" data-zoom="17" data-label="SLO Noor Foundation">Map</a></li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-1797" aria-label="Call 805-439-1797">805-439-1797</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slonoorfoundation.org" aria-label="Email info@slonoorfoundation.org">info@slonoorfoundation.org</a> </li>
+<li><strong>Hours:</strong> SLO M–Th 8am–5pm; Paso Robles W 8am–5pm </li>
+</ul>
+</li>
+<li>Vision clinic<ul>
+<li><strong>Location:</strong> 1428 Phillips Lane #203, SLO <a href="#" class="map-link" data-lat="35.288103" data-lon="-120.657544" data-zoom="17" data-label="SLO Noor Foundation primary and vision clinic">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-1797" aria-label="Call 805-439-1797">805-439-1797</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slonoorfoundation.org" aria-label="Email info@slonoorfoundation.org">info@slonoorfoundation.org</a> </li>
+</ul>
+</li>
+<li>Dental care clinic<ul>
+<li><strong>Location:</strong> 3071 S. Higuera St. #110, SLO <a href="#" class="map-link" data-lat="35.258739" data-lon="-120.668378" data-zoom="17" data-label="SLO Noor Foundation dental clinic">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-592-2240" aria-label="Call 805-592-2240">805-592-2240</a> </li>
+<li><strong>Email:</strong> <a href="mailto:dental@slonoorfoundation.org" aria-label="Email dental@slonoorfoundation.org">dental@slonoorfoundation.org</a> </li>
+</ul>
+</li>
+<li>Women’s mobile health unit<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-756-5089" aria-label="Call 805-756-5089">805-756-5089</a> </li>
+<li><strong>Email:</strong> <a href="mailto:ccmacedo@calpoly.edu" aria-label="Email ccmacedo@calpoly.edu">ccmacedo@calpoly.edu</a> </li>
+</ul>
+</li>
+<li>Primary mobile health unit<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-1797" aria-label="Call 805-439-1797">805-439-1797</a> </li>
+<li><strong>Locations:</strong> Atascadero, Nipomo, Oceano, Paso Robles </li>
+</ul>
+</li>
+<li><strong>How to access:</strong><ul>
+<li>By appointment only</li>
+<li>Bring proof of income and a copy of your most recent income tax return to your first appointment</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-Partners">SLO Partners</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slopartners.org/" data-external-link="true">slopartners.org</a></li>
+<li><strong>Location:</strong> 3350 Education Dr. SLO <a class="map-link" data-lat="35.334344" data-lon="-120.742872" data-zoom="17" data-label="SLO Partners">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-782-7372" aria-label="Call 805-782-7372">805-782-7372</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@slopartners.org" aria-label="Email info@slopartners.org">info@slopartners.org</a> </li>
+</ul>
+<h2><span><a id="SLO-Public-Defenders">SLO Public Defenders</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slodefend.com/" data-external-link="true">slodefend.com</a></li>
+<li><strong>Location:</strong> 991 Osos Street #A, SLO <a class="map-link" data-lat="35.281851" data-lon="-120.661598" data-zoom="17" data-label="SLO Public Defenders">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-5715" aria-label="Call 805-541-5715">805-541-5715</a> </li>
+<li><strong>Hours:</strong> M–Th 8:30am–Noon &amp; 1pm–5pm; F 8:30am–Noon &amp; 1pm–4pm </li>
+<li><strong>How to access:</strong> Appear at first court hearing and ask judge to appoint attorney; meetings by appointment only</li>
+</ul>
+<h2><span><a id="SLO-RTA">SLO Regional Transit Authority</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slorta.org/" data-external-link="true">slorta.org</a></li>
+<li><strong>Location:</strong> 253 Elks Lane, SLO <a href="#" class="map-link" data-lat="35.256974" data-lon="-120.672616" data-zoom="17" data-label="SLO Regional Transit Authority">Map</a> (offices) </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-4472" aria-label="Call 805-781-4472">805-781-4472</a><ul>
+<li>Info/Dispatch: <a href="tel:+1-805-541-2228" aria-label="Call 805-541-2228">805-541-2228</a> </li>
+<li>Access program (reduced fares for people with low incomes): <a href="tel:+1-805-541-8797" aria-label="Call 805-541-8797">805-541-8797</a></li>
+<li>Runabout Paratransit: <a href="tel:+1-805-781-4833" aria-label="Call 805-781-4833">805-781-4833</a></li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@slorta.org" aria-label="Email info@slorta.org">info@slorta.org</a> </li>
+<li>Hours (office): M–Th 8am–4pm; Friday by appointment only </li>
+<li>Notes: Also operates “Runabout Paratransit,” <a href="#" data-directory-link="Senior-Go" aria-label="View directory entry for Senior Go! Shuttle"><strong>Senior Go! Shuttle</strong></a>, and “Dial-A-Ride”</li>
+</ul>
+<h2><span><a id="SLO-Senior-Center">SLO Senior Center</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs" data-external-link="true">slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs</a></li>
+<li><strong>Location:</strong> 1445 Santa Rosa St., SLO <a class="map-link" data-lat="35.278951" data-lon="-120.657079" data-zoom="17" data-label="SLO Senior Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-7306" aria-label="Call 805-781-7306">805-781-7306</a> </li>
+<li><strong>Hours:</strong> M–F 9am–4pm </li>
+<li>Membership: Open to SLO city residents 55+; includes monthly newsletter, center access, free coffee</li>
+<li>Notes:<ul>
+<li>Part of <a href="#" data-directory-link="City-of-SLO-Parks-and-Recreation" aria-label="View directory entry for City of SLO Parks and Recreation"><strong>City of SLO Parks and Recreation</strong></a></li>
+<li>Hosts <a href="#" data-directory-link="HiCAP" aria-label="View directory entry for HiCAP"><strong>HiCAP</strong></a> (Thursdays Noon–3:30pm by appointment)</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-Sobering-Center">SLO Sobering Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/sobering-center" data-external-link="true">slocounty.gov/soberingcenter</a></li>
+<li><strong>Location:</strong> 2180 Johnson Ave., SLO <a class="map-link" data-lat="35.274671" data-lon="-120.646514" data-zoom="17" data-label="SLO Sobering Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-820-280-0415" aria-label="Call 820-280-0415">820-280-0415</a> </li>
+<li><strong>Hours:</strong> 24/7 </li>
+</ul>
+<h2><span><a id="SLO-Superior-Court">SLO Superior Court</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slo.courts.ca.gov/" data-external-link="true">slo.courts.ca.gov</a></li>
+<li><strong>Locations:</strong><ul>
+<li>Civil &amp; Family Law Branch: 1050 Monterey St. Rm 220, SLO <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="SLO Superior Court">Map</a> </li>
+<li>Criminal Branch: 1050 Monterey St. Rm 220, SLO <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="SLO Superior Court">Map</a> </li>
+<li>Grover Beach Branch: 214 S. 16th St., Grover Beach <a href="#" class="map-link" data-lat="35.119856" data-lon="-120.612030" data-zoom="17" data-label="SLO Superior Court">Map</a> </li>
+<li>Juvenile Services Center: 1050 Monterey St., SLO <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="SLO Superior Court">Map</a> </li>
+<li>Juvenile Justice (Delinquency): 1065 Kansas Ave., SLO <a href="#" class="map-link" data-lat="35.321279" data-lon="-120.718836" data-zoom="17" data-label="PLACEHOLDER">Map</a> </li>
+<li>Paso Robles Branch: 901 Park St., Paso Robles <a href="#" class="map-link" data-lat="35.624257" data-lon="-120.690294" data-zoom="17" data-label="SLO Superior Court">Map</a> </li>
+<li>Veteran’s Memorial Branch: 801 Grand Ave., SLO <a href="#" class="map-link" data-lat="35.288803" data-lon="-120.652687" data-zoom="17" data-label="SLO Superior Court">Map</a> (temporarily closed as of December 2025) </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-706-3600" aria-label="Call 805-706-3600">805-706-3600</a> (Civil &amp; Family Law Branch and Criminal Branch)</li>
+<li><strong>Hours:</strong><ul>
+<li>Phone: M–F 8:30am–Noon</li>
+<li>Counter: M–Th 8:30am–Noon (Juvenile Justice, M 8am only; Paso Robles branch W/F 8:30am–Noon)</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="SLO-Thrift">SLO Thrift</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://slothrift.com/" data-external-link="true">slothrift.com</a></li>
+<li><strong>Location:</strong> 445 Higuera St., SLO <a href="#" class="map-link" data-lat="35.275984" data-lon="-120.668482" data-zoom="17" data-label="SLO Thrift">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-4434" aria-label="Call 805-439-4434">805-439-4434</a> </li>
+<li><strong>Hours:</strong> M–Sa 9am–5pm </li>
+<li>Note: Not yet open as of November 2025 (being remodeled)</li>
+</ul>
+<h2><span><a id="SLO-Transit">SLO Transit</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocity.org/government/department-directory/public-works/slo-transit-bus" data-external-link="true">slocity.org/government/department-directory/public-works/slo-transit-bus</a></li>
+<li><strong>Location</strong> (office): 1260 Chorro St. #B, SLO <a href="#" class="map-link" data-lat="35.278607" data-lon="-120.661582" data-zoom="17" data-label="SLO Transit">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-594-8090" aria-label="Call 805-594-8090">805-594-8090</a> (main office) </li>
+<li><a href="tel:+1-805-541-2877" aria-label="Call 805-541-2877">805-541-2877</a> (dispatch) </li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:slotransit@slocity.org" aria-label="Email slotransit@slocity.org">slotransit@slocity.org</a> </li>
+</ul>
+<h2><span><a id="SLO-Vet-Center">SLO Vet Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.va.gov/san-luis-obispo-vet-center/" data-external-link="true">va.gov/san-luis-obispo-vet-center</a></li>
+<li><strong>Location:</strong> 1070 Southwood Dr., SLO <a class="map-link" data-lat="35.265278" data-lon="-120.640912" data-zoom="17" data-label="SLO Vet Center">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-782-9101" aria-label="Call 805-782-9101">805-782-9101</a> <ul>
+<li>24/7: <a href="tel:+1-877-927-8387" aria-label="Call 877-927-8387">877-927-8387</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–4:30pm </li>
+<li><strong>How to access:</strong> call to make an appointment</li>
+</ul>
+<h2><span><a id="SmartShare-Housing-Solutions">SmartShare Housing Solutions</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.smartsharehousingsolutions.org/" data-external-link="true">smartsharehousingsolutions.org</a></li>
+<li><strong>Mailing address:</strong> PO Box 15034, SLO, CA 93406 </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-215-5474" aria-label="Call 805-215-5474">805-215-5474</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@smartsharehousingsolutions.org" aria-label="Email info@smartsharehousingsolutions.org">info@smartsharehousingsolutions.org</a> </li>
+</ul>
+<h2><span>Sobering Center</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Sobering-Center" aria-label="View directory entry for SLO Sobering Center"><strong>SLO Sobering Center</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Social-Security-Administration">Social Security Administration</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.ssa.gov/" data-external-link="true">ssa.gov</a></li>
+<li><strong>Location:</strong> 3240 S. Higuera St., SLO <a class="map-link" data-lat="35.256200" data-lon="-120.668801" data-zoom="17" data-label="Social Security Administration">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-855-207-4865" aria-label="Call 855-207-4865">855-207-4865</a> (TTY: <a href="tel:+1-800-325-0778" aria-label="Call 800-325-0778">800-325-0778</a>)</li>
+<li><strong>Hours:</strong> M–F 9am–4pm </li>
+<li><strong>How to access:</strong> Call to schedule an appointment</li>
+</ul>
+<h2><span>Social Services</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Society-of-St-Vincent-de-Paul">Society of Saint Vincent de Paul</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 751 Palm St., SLO <a class="map-link" data-lat="35.280750" data-lon="-120.665042" data-zoom="17" data-label="Society of Saint Vincent de Paul">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-544-7041" aria-label="Call 805-544-7041">805-544-7041</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>Tuesdays at Prado Center (43 Prado Rd., SLO <a href="#" class="map-link" data-lat="35.255032" data-lon="-120.672742" data-zoom="17" data-label="Society of Saint Vincent de Paul">Map</a>): 2–3:30pm </li>
+<li>Thursdays at Mission San Luis Obispo (751 Palm St., SLO <a href="#" class="map-link" data-lat="35.280750" data-lon="-120.665042" data-zoom="17" data-label="Society of Saint Vincent de Paul">Map</a>): by appointment only </li>
+</ul>
+</li>
+<li><strong>How to access:</strong> drop-in at Prado, or call to schedule an appointment at the Mission</li>
+</ul>
+
+
+<h2><span><a id="South-Bay-Community-Center">South Bay Community Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://southbaycommunitycenter.com/" data-external-link="true">southbaycommunitycenter.com</a></li>
+<li><strong>Location:</strong> 2180 Palisades Ave., Los Osos <a class="map-link" data-lat="35.312984" data-lon="-120.836284" data-zoom="17" data-label="South Bay Community Center">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-528-4169" aria-label="Call 805-528-4169">805-528-4169</a> </li>
+<li><strong>Email:</strong> <a href="mailto:sbcc@sbcommunitycenter.net" aria-label="Email sbcc@sbcommunitycenter.net">sbcc@sbcommunitycenter.net</a> </li>
+<li><strong>Hours:</strong> M/Tu/F 1–4pm (office) </li>
+<li>Notes:<ul>
+<li>Hosts Early Risers A.A. meetings </li>
+<li>Hosts <a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a> senior nutrition program </li>
+<li>Hosts <a href="#" data-directory-link="Los-Osos-Cares" aria-label="View directory entry for Los Osos Cares"><strong>Los Osos Cares</strong></a> Community Dinner </li>
+<li><a href="#" data-directory-link="South-Bay-Seniors-People-Helping-People" aria-label="View directory entry for South Bay Seniors People Helping People"><strong>South Bay Seniors People Helping People</strong></a> operates their food bank and medical equipment loan program from this facility (M/W/F 9am–1pm) </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="South-Bay-Seniors-People-Helping-People">South Bay Seniors People Helping People</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://southbayseniorspeoplehelpingpeople.com/" data-external-link="true">southbayseniorspeoplehelpingpeople.com</a></li>
+<li><strong>Location:</strong> 2180 Palisades Ave., Los Osos <a class="map-link" data-lat="35.312984" data-lon="-120.836284" data-zoom="17" data-label="South Bay Seniors People Helping People">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-528-2626" aria-label="Call 805-528-2626">805-528-2626</a> </li>
+<li><strong>Hours:</strong> M/W/F 9am–1pm </li>
+</ul>
+<h2><span>Stand Strong</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Lumina-Alliance" aria-label="View directory entry for Lumina Alliance"><strong>Lumina Alliance</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Steves-Recycling">Steve’s Recycling</a></span></h2>
+
+
+<ul>
+<li><strong>Location:</strong> 1130 Los Osos Valley Rd., Los Osos <a class="map-link" data-lat="35.311838" data-lon="-120.829993" data-zoom="17" data-label="Steve’s Recycling — Los Osos">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-801-1627" aria-label="Call 805-801-1627">805-801-1627</a> </li>
+<li><strong>Hours:</strong> Sa 9am–11am </li>
+<li>Notes: CRV recycling for cash (5¢ for containers &lt;24oz, 10¢ for ≥24oz)</li>
+</ul>
+<h2><span><a id="Sunny-Acres">Sunny Acres</a></span></h2>
+<p>“Sunny Acres” may refer to two different locations in the city of SLO:</p>
+<ol>
+<li>a former orphanage in the hills above Johnson Avenue that is now “Bishop Street Studios” operated by <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a></li>
+<li>a former sober living compound near Laguna Lake that is now the <a href="#" data-directory-link="Healing-and-Restoration-Campus" aria-label="View directory entry for Healing and Restoration Campus"><strong>Healing and Restoration Campus</strong></a> operated by <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a></li>
+</ol>
+<h2><span>Sunshine House</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Casa-Solana" aria-label="View directory entry for Casa Solana"><strong>Casa Solana</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Sun-Street-Centers">Sun Street Centers</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://sunstreetcenters.org/counseling/san-luis-obispo-residential-program/" data-external-link="true">sunstreetcenters.org/counseling/san-luis-obispo-residential-program</a></li>
+<li><strong>Location:</strong> 34 Prado Rd., SLO <a class="map-link" data-lat="35.256247" data-lon="-120.672862" data-zoom="17" data-label="Sun Street Centers">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-457-3331" aria-label="Call 805-457-3331">805-457-3331</a> / <a href="tel:+1-805-457-5150" aria-label="Call 805-457-5150">805-457-5150</a> </li>
+<li><strong>Email:</strong> <a href="mailto:atorrente@sunstreet.org" aria-label="Email atorrente@sunstreet.org">atorrente@sunstreet.org</a> </li>
+<li><strong>Hours:</strong> 24/7 (intake: M–F 8am–5pm) </li>
+<li><strong>How to access:</strong> Get a referral from <a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a>, from your healthcare provider, or from your health insurer; you can also refer yourself </li>
+</ul>
+<h2><span>Superior Court</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Superior-Court" aria-label="View directory entry for SLO Superior Court"><strong>SLO Superior Court</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Supportive-Services-for-Veteran-Families">Supportive Services for Veteran Families</a></span></h2>
+
+<ul>
+<li>5 Cities:<ul>
+<li><strong>Website:</strong> <a href="https://5chc.org/programs/ssvf-supportive-services-for-veteran-families" data-external-link="true">5chc.org/programs/ssvf-supportive-services-for-veteran-families</a></li>
+<li><strong>Location:</strong> 150 S. 6th St. #A-B, Grover Beach <a href="#" class="map-link" data-lat="35.121072" data-lon="-120.624206" data-zoom="17" data-label="Supportive Services for Veteran Families">Map</a> </li>
+</ul>
+ 
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-574-1638" aria-label="Call 805-574-1638">805-574-1638</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-202-3056" aria-label="Call 805-202-3056">805-202-3056</a> </li>
+</ul>
+</li>
+<li>North County:<ul>
+<li><strong>Location:</strong> 935 Riverside Ave. #6, Paso Robles <a href="#" class="map-link" data-lat="35.624229" data-lon="-120.687359" data-zoom="17" data-label="Supportive Services for Veteran Families">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-237-0352" aria-label="Call 805-237-0352">805-237-0352</a> </li>
+<li><strong>Email:</strong> <a href="mailto:jrogers@capslo.org" aria-label="Email jrogers@capslo.org">jrogers@capslo.org</a></li>
+</ul>
+</li>
+<li>SLO:<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/ssvf/" data-external-link="true">capslo.org/ssvf</a></li>
+<li><strong>Location:</strong> 265 South St. #H, SLO <a href="#" class="map-link" data-lat="35.269139" data-lon="-120.666800" data-zoom="17" data-label="Supportive Services for Veteran Families">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-534-1698" aria-label="Call 805-534-1698">805-534-1698</a> </li>
+<li><strong>Email:</strong> <a href="mailto:jerwin@capslo.org" aria-label="Email jerwin@capslo.org">jerwin@capslo.org</a></li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>Operated by <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo"><strong>Community Action Partnership San Luis Obispo</strong></a> </li>
+<li>Operated by <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> with <a href="#" data-directory-link="Good-Samaritan-Shelter" aria-label="View directory entry for Good Samaritan Shelter"><strong>Good Samaritan Shelter</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span>Surgery Without Medical Insurance</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="CSF-Medical-Non-Profit-Foundation" aria-label="View directory entry for CSF Medical Non Profit Foundation"><strong>CSF Medical Non Profit Foundation</strong></a></em></p>
+</blockquote>
+<h2><span>Tax-Aide</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="AARP-Tax-Aide" aria-label="View directory entry for AARP Tax-Aide Program"><strong>AARP Tax-Aide Program</strong></a></em></p>
+</blockquote>
+<h2><span>The Teen’s Closet</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Childrens-Resource-Network-of-the-Central-Coast" aria-label="View directory entry for Children’s Resource Network of the Central Coast"><strong>Children’s Resource Network of the Central Coast</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Teen-Wellness">Teen Wellness</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://capslo.org/teen-programs-2/" data-external-link="true">capslo.org/teen-programs-2</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-602-2883" aria-label="Call 805-602-2883">805-602-2883</a> </li>
+<li><strong>Email:</strong> <a href="mailto:teenwellness@capslo.org" aria-label="Email teenwellness@capslo.org">teenwellness@capslo.org</a> </li>
+<li>Notes:<ul>
+<li>A program of <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a></li>
+<li>Focus on enhancing youth mental health in SLO and Northern Santa Barbara Counties</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Templeton-Adult-School">Templeton Adult School</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.templetonusd.org/schools/tae/tas" data-external-link="true">templetonusd.org/schools/tae/tas</a></li>
+<li><strong>Location:</strong> 964 Old Country Road, Templeton <a href="#" class="map-link" data-lat="35.545208" data-lon="-120.710961" data-zoom="17" data-label="Templeton Adult School">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-434-5827" aria-label="Call 805-434-5827">805-434-5827</a> </li>
+<li><strong>Email:</strong> <a href="mailto:clondon@templetonusd.org" aria-label="Email clondon@templetonusd.org">clondon@templetonusd.org</a> </li>
+</ul>
+<h2><span>T-MHA</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association"><strong>Transitions Mental Health Association</strong></a></em></p>
+</blockquote>
+<h2><span><a id="TMHA">Transitions Mental Health Association (TMHA)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.t-mha.org" data-external-link="true">www.t-mha.org</a></li>
+</ul>
+<table>
+<thead>
+<tr>
+<th>Office</th>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Office">Main</td>
+<td data-label="Location">784 High Street, SLO <a href="#" class="map-link" data-lat="35.272462" data-lon="-120.656466" data-zoom="17" data-label="Transitions Mental Health Association (TMHA)">Map</a> </td>
+<td data-label="Phone"><a href="tel:+1-805-540-6500" aria-label="Call 805-540-6500">805-540-6500</a> </td>
+</tr>
+<tr>
+<td data-label="Office">SLO</td>
+<td data-label="Location">1306 Nipomo St. <a href="#" class="map-link" data-lat="35.276666" data-lon="-120.663904" data-zoom="17" data-label="Transitions Mental Health Association (TMHA)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-541-6813" aria-label="Call 805-541-6813">805-541-6813</a> / <a href="tel:+1-805-801-3536" aria-label="Call 805-801-3536">805-801-3536</a></td>
+</tr>
+<tr>
+<td data-label="Office">Arroyo Grande</td>
+<td data-label="Location">203 Bridge St. <a href="#" class="map-link" data-lat="35.121565" data-lon="-120.577572" data-zoom="17" data-label="Transitions Mental Health Association (TMHA)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-305-3724" aria-label="Call 805-305-3724">805-305-3724</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong> <a href="tel:+1-805-540-6500" aria-label="Call 805-540-6500">805-540-6500</a><ul>
+<li><a href="tel:+1-800-783-0607" aria-label="Call 800-783-0607">800-783-0607</a> (24/7 crisis line) </li>
+<li><a href="tel:+1-805-540-0057" aria-label="Call 805-540-0057">805-540-0057</a> (library outreach team)</li>
+<li><a href="tel:+1-805-540-6576" aria-label="Call 805-540-6576">805-540-6576</a> (behavioral health care system navigation help)</li>
+<li><a href="tel:+1-805-540-6551" aria-label="Call 805-540-6551">805-540-6551</a> (Supported Employment program)</li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@t-mha.org" aria-label="Email info@t-mha.org">info@t-mha.org</a> <ul>
+<li><a href="mailto:mmurchison@t-mha.org" aria-label="Email mmurchison@t-mha.org">mmurchison@t-mha.org</a> (Supported Employment program)</li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–5pm</li>
+<li>Notes:<ul>
+<li>also runs “Wellness Centers” with a variety of programs <ul>
+<li>See <a href="https://www.t-mha.org/wellness-calendars.php" data-external-link="true">t-mha.org/wellness-calendars.php</a> for a schedule:</li>
+</ul>
+</li>
+<li>operates <a href="#" data-directory-link="BHBH" aria-label="View directory entry for Behavioral Health Bridge Housing (BHBH) Program"><strong>Behavioral Health Bridge Housing (BHBH) Program</strong></a></li>
+<li>operates “Bishop Street Studios” </li>
+<li>operates “Growing Grounds Downtown,” “Growing Grounds Farm,” and “Growing Grounds Nursery” </li>
+<li>operates “Library Outreach Team” (see <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a>)</li>
+<li>operates the “Supported Employment” program </li>
+<li>operates “T-MHA Community Residential Housing” </li>
+<li>operates “VetWell”</li>
+<li>entry-point for the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Tri-Counties-Regional-Center">Tri Counties Regional Center</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.tri-counties.org" data-external-link="true">tri-counties.org</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">(main office) 520 E. Montecito St., Santa Barbara <a href="#" class="map-link" data-lat="34.420363" data-lon="-119.686756" data-zoom="17" data-label="Tri Counties Regional Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-962-7881" aria-label="Call 805-962-7881">805-962-7881</a></td>
+</tr>
+<tr>
+<td data-label="Location">7305 Morro Rd. #101, Atascadero <a href="#" class="map-link" data-lat="35.478709" data-lon="-120.666798" data-zoom="17" data-label="Tri Counties Regional Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-461-7402" aria-label="Call 805-461-7402">805-461-7402</a></td>
+</tr>
+<tr>
+<td data-label="Location">1146 Farmhouse Ln., SLO <a href="#" class="map-link" data-lat="35.239987" data-lon="-120.634147" data-zoom="17" data-label="Tri Counties Regional Center">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-543-2833" aria-label="Call 805-543-2833">805-543-2833</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Hours:</strong> M–F 8:30am–5pm </li>
+<li><strong>How to access:</strong> Apply at <a href="https://www.tri-counties.org/our-services/apply/" data-external-link="true">tri-counties.org/our-services/apply/</a></li>
+</ul>
+<h2><span><a id="Trinity-United-Methodist-Church">Trinity United Methodist Church (Los Osos)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://trinitylososos.org/" data-external-link="true">trinitylososos.org</a></li>
+<li><strong>Location:</strong> 490 Los Osos Valley Rd., Los Osos <a class="map-link" data-lat="35.313346" data-lon="-120.845536" data-zoom="17" data-label="Trinity United Methodist Church (Los Osos)">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-528-1649" aria-label="Call 805-528-1649">805-528-1649</a> </li>
+<li><strong>Email:</strong> <a href="mailto:church@trinitylososos.org" aria-label="Email church@trinitylososos.org">church@trinitylososos.org</a> </li>
+<li>Hours (food pantry): Tu/F 10am–Noon </li>
+</ul>
+<h2><span><a id="Tri-County-GLAD">Tri-County GLAD</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://tcglad.org/" data-external-link="true">tcglad.org</a></li>
+<li><strong>Location:</strong> 702 County Square Dr. #101, Ventura <a href="#" class="map-link" data-lat="34.269044" data-lon="-119.214757" data-zoom="17" data-label="Tri-County GLAD">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-256-1053" aria-label="Call 805-256-1053">805-256-1053</a> (videophone) </li>
+<li><a href="tel:+1-805-644-6323" aria-label="Call 805-644-6323">805-644-6323</a> (TTY) </li>
+<li><a href="tel:+1-805-644-6322" aria-label="Call 805-644-6322">805-644-6322</a> (voice)</li>
+</ul>
+</li>
+<li><strong>Email:</strong> <a href="mailto:info@tcglad.org" aria-label="Email info@tcglad.org">info@tcglad.org</a> </li>
+<li><strong>Hours:</strong> M–F 8:30am–5pm (closed Noon–1pm) </li>
+</ul>
+
+
+<h2><span><a id="UC-Cooperative-Extension">U.C. Cooperative Extension — SLO County</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://cesanluisobispo.ucanr.edu/" data-external-link="true">cesanluisobispo.ucanr.edu</a></li>
+<li><strong>Location:</strong> 2156 Sierra Way #C, SLO <a href="#" class="map-link" data-lat="35.274187" data-lon="-120.647553" data-zoom="17" data-label="U.C. Cooperative Extension">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5940" aria-label="Call 805-781-5940">805-781-5940</a> </li>
+<li>Notes: Research-based educational programs including Master Gardener Program, Master Food Preserver Program, Forest Stewardship Workshops, agriculture, and horticulture; cost varies by program</li>
+</ul>
+<h2><span>UndocuSupport</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-UndocuSupport" aria-label="View directory entry for SLO County UndocuSupport"><strong>SLO County UndocuSupport</strong></a></em></p>
+</blockquote>
+<h2><span><a id="UUSLO">Unitarian Universalists San Luis Obispo</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://uuslo.org/" data-external-link="true">uuslo.org</a></li>
+<li><strong>Location:</strong> 2201 Lawton Avenue <a class="map-link" data-lat="35.269386" data-lon="-120.657033" data-zoom="17" data-label="Unitarian Universalists San Luis Obispo">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-439-0188" aria-label="Call 805-439-0188">805-439-0188</a> </li>
+<li><strong>Email:</strong> <a href="mailto:minister.uuslo@gmail.com" aria-label="Email minister.uuslo@gmail.com">minister.uuslo@gmail.com</a> </li>
+<li><strong>Hours:</strong><ul>
+<li>We Care Foodshare food pantry: W 3–4:30pm </li>
+<li>Refugee and Immigrant Services Education: first &amp; third Sunday each month, 12:30–2:30pm </li>
+</ul>
+</li>
+<li><strong>How to access:</strong><ul>
+<li>We Care Foodshare food pantry: arrive during hours of operation </li>
+<li>Minister’s Discretionary Fund: email with a specific request </li>
+<li>Refugee and Immigrant Services Education: arrive during hours of operation (no appointment necessary) </li>
+</ul>
+</li>
+<li>Notes:<ul>
+<li>operates the “Minister’s Discretionary Fund,” “Refugee and Immigrant Services Education,” and “We Care Foodshare” </li>
+<li>hosts <a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a> on Tuesdays and Thursdays </li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="UnitedHealthcare-Childrens-Foundation">UnitedHealthcare Children’s Foundation</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.uhccf.org/" data-external-link="true">uhccf.org</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-855-698-4223" aria-label="Call 855-698-4223">855-698-4223</a> </li>
+<li><strong>Email:</strong> <a href="mailto:uhccfcustomerservice@uhc.com" aria-label="Email uhccfcustomerservice@uhc.com">uhccfcustomerservice@uhc.com</a> </li>
+</ul>
+<h2><span><a id="United-Voluntary-Services-Thrift">United Voluntary Services Thrift</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 474 Marsh St., SLO <a class="map-link" data-lat="35.276489" data-lon="-120.667039" data-zoom="17" data-label="United Voluntary Services Thrift">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-1545" aria-label="Call 805-543-1545">805-543-1545</a> </li>
+<li><strong>Hours:</strong> M–Sa 11am–3pm </li>
+</ul>
+<h2><span><a id="United-Way">United Way</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://unitedwayslo.org/" data-external-link="true">unitedwayslo.org</a><ul>
+<li><a href="https://unitedwayslo.org/family-financial-stability/taxes/" data-external-link="true">tax return assistance program</a></li>
+</ul>
+</li>
+<li><strong>Location:</strong> 1288 Morro St. #10, SLO <a class="map-link" data-lat="35.279286" data-lon="-120.660392" data-zoom="17" data-label="United Way">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-541-1234" aria-label="Call 805-541-1234">805-541-1234</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@unitedwayslo.org" aria-label="Email info@unitedwayslo.org">info@unitedwayslo.org</a> <ul>
+<li>tax return assistance program: <a href="mailto:taxes@unitedwayslo.org" aria-label="Email taxes@unitedwayslo.org">taxes@unitedwayslo.org</a></li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Urgent-Care">Urgent Care</a></span></h2>
+<p>There are several urgent care options, including:</p>
+<ul>
+<li><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Center"><strong>Community Health Center</strong></a> (Arroyo Grande)</li>
+<li><a href="#" data-directory-link="Carbon-Health-Urgent-Care-Atascadero" aria-label="View directory entry for Carbon Health Urgent Care"><strong>Carbon Health Urgent Care</strong></a> (Atascadero)</li>
+<li><a href="#" data-directory-link="Dignity-Health-Urgent-Care" aria-label="View directory entry for Dignity Health Urgent Care"><strong>Dignity Health Urgent Care</strong></a> (Atascadero)</li>
+<li><a href="#" data-directory-link="Urgent-Care-of-Atascadero" aria-label="View directory entry for Urgent Care of Atascadero"><strong>Urgent Care of Atascadero</strong></a></li>
+<li><a href="#" data-directory-link="Urgent-Care-of-Morro-Bay" aria-label="View directory entry for Urgent Care of Morro Bay"><strong>Urgent Care of Morro Bay</strong></a></li>
+<li><a href="#" data-directory-link="Carbon-Health-Urgent-Care-Paso-Robles" aria-label="View directory entry for Carbon Health Urgent Care"><strong>Carbon Health Urgent Care</strong></a> (Paso Robles)</li>
+<li><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Center"><strong>Community Health Center</strong></a> (Paso Robles)</li>
+<li><a href="#" data-directory-link="North-County-Care" aria-label="View directory entry for North County Care Minor Emergency Services"><strong>North County Care Minor Emergency Services</strong></a> (Paso Robles)</li>
+<li><a href="#" data-directory-link="Dignity-Health-Urgent-Care" aria-label="View directory entry for Dignity Health Urgent Care"><strong>Dignity Health Urgent Care</strong></a> (Pismo Beach)</li>
+<li><a href="#" data-directory-link="Urgent-Care-Pismo-Beach" aria-label="View directory entry for Urgent Care Pismo Beach"><strong>Urgent Care Pismo Beach</strong></a></li>
+<li><a href="#" data-directory-link="Cottage-Urgent-Care" aria-label="View directory entry for Cottage Urgent Care"><strong>Cottage Urgent Care</strong></a> (SLO)</li>
+<li><a href="#" data-directory-link="Family-and-Industrial-Medical-Center" aria-label="View directory entry for Family and Industrial Medical Center"><strong>Family and Industrial Medical Center</strong></a> (SLO)</li>
+<li><a href="#" data-directory-link="MedStop" aria-label="View directory entry for MedStop"><strong>MedStop</strong></a> (SLO)</li>
+<li><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Center"><strong>Community Health Center</strong></a> (Templeton)</li>
+</ul>
+<h2><span><a id="Urgent-Care-of-Atascadero">Urgent Care of Atascadero</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 9700 El Camino Real #100, Atascadero <a class="map-link" data-lat="35.464970" data-lon="-120.648491" data-zoom="17" data-label="Urgent Care of Atascadero">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-466-1330" aria-label="Call 805-466-1330">805-466-1330</a> </li>
+<li><strong>Hours:</strong> M–Sa 7am–6:30pm, Su 8am–3:30pm </li>
+<li><strong>How to access:</strong> Walk-ins accepted until 30 minutes before closing</li>
+<li>Notes: Accepts Medicare and Medi-Cal; most insurances accepted — call to verify coverage</li>
+</ul>
+<h2><span><a id="Urgent-Care-of-Morro-Bay">Urgent Care of Morro Bay</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 783 Quintana Rd., Morro Bay <a class="map-link" data-lat="35.367708" data-lon="-120.842253" data-zoom="17" data-label="Urgent Care of Morro Bay">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-771-0108" aria-label="Call 805-771-0108">805-771-0108</a> </li>
+<li><strong>Hours:</strong> M–Sa 7am–6:30pm, Su 8am–3:30pm </li>
+<li>Notes: Accepts Medicare and Medi-Cal</li>
+</ul>
+<h2><span><a id="Urgent-Care-Pismo-Beach">Urgent Care Pismo Beach</a></span></h2>
+<ul>
+<li><strong>Location:</strong> 2 James Way #214, Pismo Beach <a class="map-link" data-lat="35.138798" data-lon="-120.632225" data-zoom="17" data-label="Urgent Care Pismo Beach">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-295-6594" aria-label="Call 805-295-6594">805-295-6594</a> </li>
+<li><strong>Hours:</strong> M–Sa. 7am–6:30pm, Su. 8am–3:30pm </li>
+</ul>
+<h2><span>Vet Center</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-Vet-Center" aria-label="View directory entry for SLO Vet Center"><strong>SLO Vet Center</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Veterans-Administration-Outpatient-Clinic">Veterans Administration Outpatient Clinic</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.va.gov/greater-los-angeles-health-care/locations/san-luis-obispo-va-clinic/" data-external-link="true">va.gov/greater-los-angeles-health-care/locations/san-luis-obispo-va-clinic</a></li>
+<li><strong>Location:</strong> 1288 Morro St. #200, SLO <a class="map-link" data-lat="35.279286" data-lon="-120.660392" data-zoom="17" data-label="Veterans Administration Outpatient Clinic">Map</a> </li>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-543-1233" aria-label="Call 805-543-1233">805-543-1233</a> (main) </li>
+<li><a href="tel:+1-877-252-4866" aria-label="Call 877-252-4866">877-252-4866</a> (VA health connect) </li>
+<li><a href="tel:+1-877-251-7295" aria-label="Call 877-251-7295">877-251-7295</a> (mental health) </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–F 8am–4:30pm </li>
+</ul>
+<h2><span>Veterans Express Shuttle</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="Ride-On-Transportation" aria-label="View directory entry for Ride-On Transportation"><strong>Ride-On Transportation</strong></a></em></p>
+</blockquote>
+
+
+<h2><span><a id="Veterans-Services">Veterans Services (SLO County)</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/veterans-services" data-external-link="true">slocounty.ca.gov/Departments/Veterans-Services</a></li>
+<li><strong>Locations:</strong><ul>
+<li>800 West Branch St., Arroyo Grande <a href="#" class="map-link" data-lat="35.124547" data-lon="-120.589385" data-zoom="17" data-label="Veterans Services">Map</a> (currently closed for renovations) </li>
+<li>240 Scott St., Paso Robles <a href="#" class="map-link" data-lat="35.608124" data-lon="-120.655868" data-zoom="17" data-label="Veterans Services">Map</a> (Tu–Th 8am–5pm) </li>
+<li>801 Grand Ave., SLO <a class="map-link" data-lat="35.288803" data-lon="-120.652687" data-zoom="17" data-label="Veterans Services">Map</a> (daily 8am–5pm) </li>
+</ul>
+</li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5766" aria-label="Call 805-781-5766">805-781-5766</a> </li>
+<li><strong>Email:</strong> <a href="mailto:slovets@co.slo.ca.us" aria-label="Email slovets@co.slo.ca.us">slovets@co.slo.ca.us</a></li>
+<li><strong>How to access:</strong> In-person and phone appointments only; no walk-ins; book appointments <a href="https://sanluisobispocountyveteransservices.as.me/schedule/970de54e" data-external-link="true">online</a> or by phone</li>
+<li>Notes: SLO office has a small <a href="https://www.slocounty.ca.gov/departments/veterans-services/veterans-services-food-pantry" data-external-link="true">food pantry</a></li>
+</ul>
+
+
+<h2><span><a id="Veterans-Transportation-Service">Veterans Transportation Service</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.vetride.va.gov/" data-external-link="true">vetride.va.gov</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-1233" aria-label="Call 805-543-1233">805-543-1233</a></li>
+</ul>
+
+
+
+
+<h2><span><a id="Victim-Witness-Assistance-Program">Victim Witness Assistance Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center" data-external-link="true">slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center</a></li>
+<li><strong>Location:</strong> 1050 Monterey St. (Courthouse Annex Room 384), SLO <a href="#" class="map-link" data-lat="35.282937" data-lon="-120.661267" data-zoom="17" data-label="Victim Witness Assistance Program">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-781-5821" aria-label="Call 805-781-5821">805-781-5821</a> (toll-free: <a href="tel:+1-866-781-5821" aria-label="Call 866-781-5821">866-781-5821</a>) </li>
+</ul>
+<h2><span><a id="Vituity-Cares-Mobile-Clinic">Vituity Cares Mobile Clinic</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://vituitycares.org/" data-external-link="true">vituitycares.org</a></li>
+<li><strong>Location:</strong> 995 Palm St., SLO <a class="map-link" data-lat="35.282263" data-lon="-120.662223" data-zoom="17" data-label="Vituity Cares Mobile Clinic">Map</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-480-828-4319" aria-label="Call 480-828-4319">480-828-4319</a> </li>
+<li><strong>Email:</strong> <a href="mailto:vituitycares@gmail.com" aria-label="Email vituitycares@gmail.com">vituitycares@gmail.com</a> </li>
+<li><strong>Hours:</strong> Second Sunday of the month, 12:30–3:30 pm</li>
+</ul>
+<h2><span><a id="Helping-Friends-Program">Voice for the Animals Helping Friends Program</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.vftafoundation.org/helping_friends" data-external-link="true">www.vftafoundation.org/helping_friends</a></li>
+<li><strong>Phone:</strong> <a href="tel:+1-310-392-5153" aria-label="Call 310-392-5153">310-392-5153</a> </li>
+<li><strong>Email:</strong> <a href="mailto:info@vftafoundation.org" aria-label="Email info@vftafoundation.org">info@vftafoundation.org</a> </li>
+</ul>
+<h2><span><a id="Womenade">Womenade</a></span></h2>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Website</th>
+<th>Location</th>
+<th>Phone</th>
+<th>Email</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">SLO city</td>
+<td data-label="Website"><a href="https://www.womenadeslo.org/" data-external-link="true">womenadeslo.org</a></td>
+<td data-label="Location">6099 Marshall Way, SLO <a href="#" class="map-link" data-lat="35.213169" data-lon="-120.622298" data-zoom="17" data-label="Womenade">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-674-9450" aria-label="Call 805-674-9450">805-674-9450</a></td>
+<td data-label="Email"><a href="mailto:elaine@womenadeslo.org" aria-label="Email elaine@womenadeslo.org">elaine@womenadeslo.org</a></td>
+</tr>
+<tr>
+<td data-label="Location">South SLO County</td>
+<td data-label="Website"><a href="https://www.sslocw.org/" data-external-link="true">sslocw.org</a></td>
+<td data-label="Location">1793 Farroll Road, Grover Beach <a href="#" class="map-link" data-lat="35.112441" data-lon="-120.609956" data-zoom="17" data-label="Womenade">Map</a></td>
+<td data-label="Phone"></td>
+<td data-label="Email"><a href="mailto:sslocwomenade@gmail.com" aria-label="Email sslocwomenade@gmail.com">sslocwomenade@gmail.com</a></td>
+</tr>
+</tbody></table>
+<h2><span><a id="Waterman-Village">Waterman Village</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.smartsharehousingsolutions.org/co-living-collaborative" data-external-link="true">smartsharehousingsolutions.org/co-living-collaborative</a></li>
+<li><strong>Location:</strong> 466 Dana St., SLO <a class="map-link" data-lat="35.278012" data-lon="-120.669144" data-zoom="17" data-label="Waterman Village">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-215-5474" aria-label="Call 805-215-5474">805-215-5474</a> </li>
+<li>Notes: A project of <a href="#" data-directory-link="SmartShare-Housing-Solutions" aria-label="View directory entry for SmartShare Housing Solutions"><strong>SmartShare Housing Solutions</strong></a></li>
+</ul>
+<h2><span>We Care Foodshare</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Welcome-Home-Village">Welcome Home Village</a></span></h2>
+
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/welcomehomevillage.aspx" data-external-link="true">slocounty.ca.gov/welcomehomevillage</a></li>
+<li><strong>Location:</strong> Health Agency Campus, intersection of Johnson Ave. &amp; Bishop St., SLO <a href="#" class="map-link" data-lat="35.274108" data-lon="-120.645697" data-zoom="17" data-label="Welcome Home Village">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-591-4544" aria-label="Call 805-591-4544">805-591-4544</a> (Margaret Shepard-Moore, Program Manager) </li>
+<li><strong>Email:</strong> <a href="mailto:mshepard-moore@co.slo.ca.us" aria-label="Email mshepard-moore@co.slo.ca.us">mshepard-moore@co.slo.ca.us</a> </li>
+<li><strong>How to access:</strong> Through the <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a> or contact City of SLO Homelessness Response Team for outreach</li>
+<li>Notes:<ul>
+<li>Operated by <a href="#" data-directory-link="Good-Samaritan-Shelter" aria-label="View directory entry for Good Samaritan Shelter"><strong>Good Samaritan Shelter</strong></a></li>
+</ul>
+</li>
+</ul>
+<h2><span>Wellness Centers</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a></em></p>
+</blockquote>
+<h2><span><a id="WIC">Women, Infants, and Children (WIC)</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-promotion/women,-infants-and-children-%28wic%29" data-external-link="true">Slocountygov/wic</a></li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Atascadero: 5575 Hospital Dr. <a href="#" class="map-link" data-lat="35.492648" data-lon="-120.662938" data-zoom="17" data-label="Women, Infants, and Children (WIC)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-3065" aria-label="Call 805-237-3065">805-237-3065</a> or <a href="tel:+1-805-781-5570" aria-label="Call 805-781-5570">805-781-5570</a></td>
+</tr>
+<tr>
+<td data-label="Location">Grover Beach: 286 S. 16th St. #B <a href="#" class="map-link" data-lat="35.119277" data-lon="-120.611998" data-zoom="17" data-label="Women, Infants, and Children (WIC)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-473-7130" aria-label="Call 805-473-7130">805-473-7130</a></td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles: 805 4th St. #B <a href="#" class="map-link" data-lat="35.618660" data-lon="-120.689219" data-zoom="17" data-label="Women, Infants, and Children (WIC)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-3065" aria-label="Call 805-237-3065">805-237-3065</a></td>
+</tr>
+<tr>
+<td data-label="Location">SLO: 2191 Johnson Ave. <a href="#" class="map-link" data-lat="35.274391" data-lon="-120.646730" data-zoom="17" data-label="Women, Infants, and Children (WIC)">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-781-5570" aria-label="Call 805-781-5570">805-781-5570</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Phone:</strong><ul>
+<li><a href="tel:+1-805-781-5570" aria-label="Call 805-781-5570">805-781-5570</a> </li>
+<li>Text: <a href="sms:+1-888-417-6180">888-417-6180</a> </li>
+</ul>
+</li>
+<li><strong>Hours:</strong> M–Th 8am–5pm; Fri. 8am–4:30pm (closed on the last Wednesday of the month) </li>
+<li><strong>How to access:</strong> by appointment only (call or text to make an appointment) </li>
+<li>Eligibility: This program is restricted to people for whom both of the following requirements are true:<ul>
+<li>You are pregnant, breastfeeding, gave birth or had a pregnancy loss in the past six months, or you care for a child under the age of five</li>
+<li>And you live in California and have income below a certain threshold, or receive Medi-Cal, <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs">CalWORKs</a>, or CalFresh benefits.</li>
+</ul>
+</li>
+</ul>
+<h2><span><a id="Woods-Humane-Society">Woods Humane Society</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://woodshumanesociety.org/" data-external-link="true">woodshumanesociety.org</a><ul>
+<li><a href="https://woodshumanesociety.org/pet-pantry/" data-external-link="true">Pet Pantry</a></li>
+</ul>
+</li>
+</ul>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">2300 Ramona Rd., Atascadero <a href="#" class="map-link" data-lat="35.510264" data-lon="-120.698978" data-zoom="17" data-label="Woods Humane Society">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-466-5403" aria-label="Call 805-466-5403">805-466-5403</a></td>
+</tr>
+<tr>
+<td data-label="Location">875 Oklahoma Ave, SLO <a class="map-link" data-lat="35.318418" data-lon="-120.715209" data-zoom="17" data-label="Woods Human Society">Map</a></td>
+<td data-label="Phone"><a href="tel:+1-805-543-9316" aria-label="Call 805-543-9316">805-543-9316</a></td>
+</tr>
+</tbody></table>
+<ul>
+<li><strong>Email:</strong> <a href="mailto:rcoleman@woodshumanesociety.org" aria-label="Email rcoleman@woodshumanesociety.org">rcoleman@woodshumanesociety.org</a> (Robin Coleman, Community Engagement Manager)</li>
+<li><strong>Hours:</strong> (adoption) daily 11am–4pm (Atascadero) or daily Noon–4pm (SLO) </li>
+</ul>
+<h2><span>YMCA</span></h2>
+<blockquote>
+<p><em>See <a href="#" data-directory-link="SLO-County-YMCA" aria-label="View directory entry for SLO County YMCA"><strong>SLO County YMCA</strong></a></em></p>
+</blockquote>
+<h2><span><a id="Zion-Lutheran-Church">Zion Lutheran Church</a></span></h2>
+<ul>
+<li><strong>Website:</strong> <a href="https://www.zionslo.com/" data-external-link="true">zionslo.com</a></li>
+<li><strong>Location:</strong> 1010 Foothill Blvd., SLO <a class="map-link" data-lat="35.294563" data-lon="-120.667386" data-zoom="17" data-label="Zion Lutheran Church">Map</a> </li>
+<li><strong>Phone:</strong> <a href="tel:+1-805-543-8327" aria-label="Call 805-543-8327">805-543-8327</a> </li>
+<li><strong>Email:</strong> <a href="mailto:zion@zionslo.com" aria-label="Email zion@zionslo.com">zion@zionslo.com</a> </li>
+<li><strong>Hours</strong> (food pantry): W 9:30–11:30am </li>
+</ul>

--- a/web-app/public/processed/resources.html
+++ b/web-app/public/processed/resources.html
@@ -1,0 +1,3800 @@
+<h1><span><em>VivaSLO!</em></span></h1>
+<h2><span>Avoiding, Surviving, and Escaping Homelessness in SLO County</span></h2>
+<p><strong>Note:</strong> This guide is currently being beta tested (if you have found it, welcome to the beta test!).
+Shower the People hopes to formally launch this guide in early 2026.</p>
+<p>This guide helps you find free and low-cost resources that can help you if you are experiencing homelessness, are threatened with homelessness, or are just short on money.
+It is specific to San Luis Obispo County.</p>
+<p>San Luis Obispo County is especially challenging for people trying to avoid or to escape homelessness.
+Fortunately, there is a lot of help available.
+Unfortunately, it can be difficult to find this help or to understand how to access it.
+This guide makes it easier.</p>
+<p>The guide is organized into sections like “Shelter and Housing” or “Food.”
+Each section briefly describes resources available in San Luis Obispo County.
+Many descriptions contain blue-highlighted, boldface links to the <a href="?section=directory"><strong>Directory</strong></a>.
+This Directory page lists resources in alphabetical order, with information like the website, phone number, email address, location, and operating hours.
+If you find a resource in the guide that may be useful to you, click the boldface link to go to the Directory and learn how to access that resource.</p>
+<p>Volunteers from <a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a> created this guide.
+If you want to suggest corrections or improvements, or to join the VivaSLO development team, contact VivaSLO at <a href="mailto:showerthepeopleslo@gmail.com" aria-label="Email showerthepeopleslo@gmail.com">showerthepeopleslo@gmail.com</a>.</p>
+<hr>
+<h2><span><a id="table-of-contents">Table of Contents</a> <span style="text-shadow: 0 0 3px rgba(255, 255, 255, 0.9), 0 0 6px rgba(255, 255, 255, 0.7), 0 0 9px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.8), 1px 1px 2px rgba(0, 0, 0, 0.6);">📖</span></span></h2>
+<div class="toc-section-wrapper" role="navigation" aria-label="Table of contents with visual icons"><div class="toc-lozenge-grid"><a href="#emergency-contacts" class="toc-lozenge" aria-label="Hotlines and Emergencies"><span class="toc-lozenge-icon" aria-hidden="true">📞</span><span class="toc-lozenge-text">Hotlines and Emergencies</span></a><a href="#self-advocacy" class="toc-lozenge" aria-label="Self-Advocacy"><span class="toc-lozenge-icon" aria-hidden="true">🗣️</span><span class="toc-lozenge-text">Self-Advocacy</span></a><a href="#shelter-housing" class="toc-lozenge" aria-label="Shelter &amp; Housing"><span class="toc-lozenge-icon" aria-hidden="true">🏠</span><span class="toc-lozenge-text">Shelter &amp; Housing</span></a><a href="#property-storage" class="toc-lozenge" aria-label="Property Storage"><span class="toc-lozenge-icon" aria-hidden="true">📦</span><span class="toc-lozenge-text">Property Storage</span></a><a href="#food" class="toc-lozenge" aria-label="Food"><span class="toc-lozenge-icon" aria-hidden="true">🍎</span><span class="toc-lozenge-text">Food</span></a><a href="#refill-a-water-bottle" class="toc-lozenge" aria-label="Water Refill"><span class="toc-lozenge-icon" aria-hidden="true">💧</span><span class="toc-lozenge-text">Water Refill</span></a><a href="#transportation" class="toc-lozenge" aria-label="Transportation"><span class="toc-lozenge-icon" aria-hidden="true">🚌</span><span class="toc-lozenge-text">Transportation</span></a><a href="#clothing" class="toc-lozenge" aria-label="Clothing"><span class="toc-lozenge-icon" aria-hidden="true">👕</span><span class="toc-lozenge-text">Clothing</span></a><a href="#laundry" class="toc-lozenge" aria-label="Laundry"><span class="toc-lozenge-icon" aria-hidden="true">🧺</span><span class="toc-lozenge-text">Laundry</span></a><a href="#showers-and-hygiene" class="toc-lozenge" aria-label="Showers &amp; Hygiene"><span class="toc-lozenge-icon" aria-hidden="true">🚿</span><span class="toc-lozenge-text">Showers &amp; Hygiene</span></a><a href="#health-medical-care" class="toc-lozenge" aria-label="Health &amp; Medical Care"><span class="toc-lozenge-icon" aria-hidden="true">⚕️</span><span class="toc-lozenge-text">Health &amp; Medical Care</span></a><a href="#drug-use-and-recovery" class="toc-lozenge" aria-label="Drug Use &amp; Recovery"><span class="toc-lozenge-icon" aria-hidden="true">🪷</span><span class="toc-lozenge-text">Drug Use &amp; Recovery</span></a><a href="#tattoo-removal" class="toc-lozenge" aria-label="Tattoo Removal"><span class="toc-lozenge-icon" aria-hidden="true">✨</span><span class="toc-lozenge-text">Tattoo Removal</span></a><a href="#end-of-life-help" class="toc-lozenge" aria-label="End-of-Life Help"><span class="toc-lozenge-icon" aria-hidden="true">🕊️</span><span class="toc-lozenge-text">End-of-Life Help</span></a><a href="#personal-safety" class="toc-lozenge" aria-label="Personal Safety"><span class="toc-lozenge-icon" aria-hidden="true">🛡️</span><span class="toc-lozenge-text">Personal Safety</span></a><a href="#legal-help" class="toc-lozenge" aria-label="Legal Help"><span class="toc-lozenge-icon" aria-hidden="true">⚖️</span><span class="toc-lozenge-text">Legal Help</span></a><a href="#ids-and-other-documents" class="toc-lozenge" aria-label="IDs &amp; Documents"><span class="toc-lozenge-icon" aria-hidden="true">🪪</span><span class="toc-lozenge-text">IDs &amp; Documents</span></a><a href="#mail-drops-post-office-boxes" class="toc-lozenge" aria-label="Mail &amp; PO Boxes"><span class="toc-lozenge-icon" aria-hidden="true">📬</span><span class="toc-lozenge-text">Mail &amp; PO Boxes</span></a><a href="#banking-and-money-management" class="toc-lozenge" aria-label="Banking &amp; Money"><span class="toc-lozenge-icon" aria-hidden="true">💰</span><span class="toc-lozenge-text">Banking &amp; Money</span></a><a href="#tax-preparation" class="toc-lozenge" aria-label="Tax Preparation"><span class="toc-lozenge-icon" aria-hidden="true">📋</span><span class="toc-lozenge-text">Tax Preparation</span></a><a href="#emergency-financial-help" class="toc-lozenge" aria-label="Emergency Financial Help"><span class="toc-lozenge-icon" aria-hidden="true">💵</span><span class="toc-lozenge-text">Emergency Financial Help</span></a><a href="#navigating-social-security" class="toc-lozenge" aria-label="Social Security &amp; Benefits"><span class="toc-lozenge-icon" aria-hidden="true">🏛️</span><span class="toc-lozenge-text">Social Security &amp; Benefits</span></a><a href="#employment-job-boards" class="toc-lozenge" aria-label="Obtaining Employment"><span class="toc-lozenge-icon" aria-hidden="true">💼</span><span class="toc-lozenge-text">Obtaining Employment</span></a><a href="#education-job-skills-training" class="toc-lozenge" aria-label="Education &amp; Job Training"><span class="toc-lozenge-icon" aria-hidden="true">💼</span><span class="toc-lozenge-text">Education &amp; Job Training</span></a><a href="#phones" class="toc-lozenge" aria-label="Phones &amp; Phone Service"><span class="toc-lozenge-icon" aria-hidden="true">📱</span><span class="toc-lozenge-text">Phones &amp; Phone Service</span></a><a href="#internet-and-email" class="toc-lozenge" aria-label="Internet &amp; Email"><span class="toc-lozenge-icon" aria-hidden="true">📬</span><span class="toc-lozenge-text">Internet &amp; Email</span></a><a href="#charging-stations" class="toc-lozenge" aria-label="Device Charging"><span class="toc-lozenge-icon" aria-hidden="true">🔌</span><span class="toc-lozenge-text">Device Charging</span></a><a href="#children-youth-parents" class="toc-lozenge" aria-label="Children &amp; Parents"><span class="toc-lozenge-icon" aria-hidden="true">🚸</span><span class="toc-lozenge-text">Children &amp; Parents</span></a><a href="#peer-support-groups" class="toc-lozenge" aria-label="Peer Support"><span class="toc-lozenge-icon" aria-hidden="true">🤝🏽</span><span class="toc-lozenge-text">Peer Support</span></a><a href="#recreation-fitness-socializing-connection" class="toc-lozenge" aria-label="Recreation &amp; Community"><span class="toc-lozenge-icon" aria-hidden="true">🏓</span><span class="toc-lozenge-text">Recreation &amp; Community</span></a><a href="#pet-care-and-pet-supplies" class="toc-lozenge" aria-label="Pet Care"><span class="toc-lozenge-icon" aria-hidden="true">🐾</span><span class="toc-lozenge-text">Pet Care</span></a><a href="#disaster-preparedness" class="toc-lozenge" aria-label="Disaster Preparedness"><span class="toc-lozenge-icon" aria-hidden="true">🌪️</span><span class="toc-lozenge-text">Disaster Preparedness</span></a><a href="#advocacy-and-organizing" class="toc-lozenge" aria-label="Advocacy &amp; Organizing"><span class="toc-lozenge-icon" aria-hidden="true">🗣️</span><span class="toc-lozenge-text">Advocacy &amp; Organizing</span></a><a href="#miscellaneous-free-items" class="toc-lozenge" aria-label="Free Stuff"><span class="toc-lozenge-icon" aria-hidden="true">🎁</span><span class="toc-lozenge-text">Free Stuff</span></a><a href="#other-guides" class="toc-lozenge" aria-label="Other Guides"><span class="toc-lozenge-icon" aria-hidden="true">📖</span><span class="toc-lozenge-text">Other Guides</span></a><a href="?section=directory" class="toc-lozenge" aria-label="Directory"><span class="toc-lozenge-icon" aria-hidden="true">📇</span><span class="toc-lozenge-text">Directory</span></a></div></div>
+<hr>
+<h2><span><a id="emergency-contacts">Hotlines and Emergency Contacts</a></span></h2>
+<table>
+ <thead>
+  <tr><th>Phone Number</th><th>Description</th></tr>
+ </thead><tbody>
+  <tr><th colspan="2" style="text-align:left;">⇨ Emergency and Crisis Lines:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-911" aria-label="Call 911">911</a></td><td data-label="Description">Medical and safety emergencies</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-988" aria-label="Call 988">988</a> / <a href="sms:988">988</a></td><td data-label="Description">National Suicide Prevention Lifeline</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-783-0607" aria-label="Call 800-783-0607">800-783-0607</a></td><td data-label="Description">Central Coast Hotline: 24/7 suicide prevention and mental health crisis line that provides immediate emotional support</td></tr>
+   <tr><td data-label="Phone Number">Text “HOME” to <a href="sms:741741?&amp;body=HOME">741741</a></td><td data-label="Description">Crisis Text Line for immediate emotional support, or <a href="https://connect.crisistextline.org/chat" data-external-link="true">connect.crisistextline.org/chat</a> on-line</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-833-317-4673" aria-label="Call 833-317-HOPE">833-317-HOPE</a> (español: <a href="tel:+1-833-642-7696" aria-label="Call 833-642-7696">833-642-7696</a>)</td><td data-label="Description">The Warm Line: free, confidential emotional support</td></tr>
+  
+  <tr><th colspan="2" style="text-align:left;">⇨ For Young People:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-843-5200" aria-label="Call 800-843-5200">800-843-5200</a></td><td data-label="Description">Youth Crisis Line, for people in California ages 12–24; call or text</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-786-2929" aria-label="Call 800-RUN-AWAY">800-RUN-AWAY</a> / <a href="sms:+1-800-786-2929">800-786-2929</a></td><td data-label="Description">National Runaway Safeline: 24/7 confidential support for runaway and homeless youth</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-866-331-9474" aria-label="Call 866-331-9474">866-331-9474</a> / text “LOVEIS” to <a href="sms:22522?&amp;body=LOVEIS">22522</a></td><td data-label="Description"><a href="https://www.loveisrespect.org/" data-external-link="true">"Love is Respect"</a> information and support for young people with concerns about their romantic relationship</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ For LGBTQ People:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-866-488-7386" aria-label="Call 866-488-7386">866-488-7386</a> or text “START” to <a href="sms:678678?&amp;body=START">678678</a></td><td data-label="Description">Trevor Lifeline: Crisis intervention and suicide prevention for LGBTQ+ youth</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-877-565-8860" aria-label="Call 877-565-8860">877-565-8860</a></td><td data-label="Description">Trans Lifeline: Crisis hotline for transgender people</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ For Victims of Sexual Assault and Intimate Partner Violence:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-545-8888" aria-label="Call 805-545-8888">805-545-8888</a></td><td data-label="Description">Local sexual assault, sexual abuse, and intimate partner violence crisis line</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-799-7233" aria-label="Call 800-799-SAFE">800-799-SAFE</a> / text “START” to <a href="sms:88788?&amp;body=START">88788</a></td><td data-label="Description">National Domestic Violence Hotline</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ For Parents:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-833-852-6262" aria-label="Call 833-TLC-MAMA">833-TLC-MAMA</a> / <a href="sms:1-833-852-6262">833-TLC-MAMA</a></td><td data-label="Description">National Maternal Mental Health Hotline (call or text)</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-888-431-2229" aria-label="Call 888-431-2229">888-431-2229</a></td><td data-label="Description">Fussy Baby Network Warmline</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-877-222-9723" aria-label="Call 877-BABYSAF">877-BABYSAF</a></td><td data-label="Description">Safe Surrender Site locations in California (where to confidentially give up a newborn you cannot take care of)</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ Other Specialized Crisis Lines:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-781-1790" aria-label="Call 805-781-1790">805-781-1790</a> (M–F, 8am–5pm), or <a href="tel:+1-805-729-8011" aria-label="Call 805-729-8011">805-729-8011</a></td><td data-label="Description">Adult Protective Services</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-781-5437" aria-label="Call 805-781-KIDS">805-781-KIDS</a></td><td data-label="Description">Child Welfare Services emergency suspected child abuse reporting line</td></tr>
+   <tr><td data-label="Phone Number"><a href="sms:838255">838255</a> (text)</td><td data-label="Description">Veterans Crisis Text Line</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-985-5990" aria-label="Call 800-985-5990">800-985-5990</a></td><td data-label="Description">Disaster Distress Helpline (in case of emotional distress due to natural or man-made disaster)</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ Health and Behavioral Health Information:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-222-1222" aria-label="Call 800-222-1222">800-222-1222</a></td><td data-label="Description">Poison Hotline: Treatment advice from experts in poisoning care</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-877-435-7443" aria-label="Call 877-435-7443">877-435-7443</a></td><td data-label="Description">Help-4-Hep Helpline: peer-to-peer support for anyone with concerns about hepatitis C (M–F 9am–5pm Eastern Time)</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a></td><td data-label="Description">SLO County Behavioral Health Access Line: Main number for scheduling appointments and getting information about all behavioral health services including navigation and peer support</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-540-6576" aria-label="Call 800-540-6576">800-540-6576</a></td><td data-label="Description">Behavioral Health Navigator: Get help finding the help you need and understanding the local behavioral health system</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-855-600-9276" aria-label="Call 855-600-WARM">855-600-WARM</a></td><td data-label="Description">California Peer Run Warm Line (also available as a web-based text chat <a href="https://www.mentalhealthsf.org/warm-line" data-external-link="true">here</a>) for people with “a wide range of challenges, including anxiety, depression, and substance use” (M/Tu/W/F 7am–11pm; Th 8am–10pm)</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-300-8086" aria-label="Call 800-300-8086">800-300-8086</a></td><td data-label="Description">Kick It California, smoking cessation help</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-662-4357" aria-label="Call 800-662-HELP">800-662-HELP</a></td><td data-label="Description">Substance Abuse and Mental Health Service Administration (SAMHSA) national helpline (free, confidential, 24/7 substance abuse treatment referral and info)</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-541-3211" aria-label="Call 800-541-3211">800-541-3211</a></td><td data-label="Description">Central Coast Alcoholics Anonymous 24/7 helpline</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-549-7730" aria-label="Call 800-549-7730">800-549-7730</a></td><td data-label="Description">Central Coast Narcotics Anonymous 24/7 helpline</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ Finding Help:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-211" aria-label="Call 211">211</a></td><td data-label="Description">Connects you to expert, caring, confidential help of all sorts</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ Legal Aid and Consumer Protection:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-834-5001" aria-label="Call 800-834-5001">800-834-5001</a></td><td data-label="Description">Community Legal Aid SoCal Hotline for housing discrimination, tenant rights, and consumer protection</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-800-399-4529" aria-label="Call 800-399-4529">800-399-4529</a></td><td data-label="Description">Legal Aid Foundation of Los Angeles (LAFLA) for legal assistance</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ Housing and Homeless Services:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-574-1638" aria-label="Call 805-574-1638">805-574-1638</a></td><td data-label="Description">5Cities Homeless Coalition for housing assistance and coordinated entry</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-781-7025" aria-label="Call 805-781-7025">805-781-7025</a></td><td data-label="Description">City of SLO Homelessness Response Manager</td></tr>
+  <tr><th colspan="2" style="text-align:left;">⇨ Immigration:</th></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-805-870-8855" aria-label="Call 805-870-8855">805-870-8855</a></td><td data-label="Description">Immigrant Rapid Response Hotline (report ICE activity or connect with legal support); register for text alerts by <a href="sms:+1-805-870-8855?&amp;body=ALERT">texting “ALERT” to this number</a>)</td></tr>
+   <tr><td data-label="Phone Number"><a href="tel:+1-888-373-7888" aria-label="Call 888-373-7888">888-373-7888</a> or text <a href="sms:233733">233733</a></td><td data-label="Description">National Human Trafficking Hotline</td></tr>
+ </tbody>
+</table>
+
+<hr>
+<h2><span><a id="self-advocacy">Standing Up for Yourself and Communicating with Service Providers</a></span></h2>
+<p>When you meet with case managers and service providers, you can make it more likely that they can help you.
+This section of the guide gives some tips about how to do this.</p>
+<h3><span><a id="build-good-relationships">Build Good Relationships with Case Managers and Service Providers</a></span></h3>
+<p>You can get better results by being prepared.
+Bring your ID, any paperwork about your situation, and a list of questions or needs.</p>
+<p>Be honest and direct when you explain your situation, your needs, and any problems you face.
+Ask questions if you need help understanding programs, requirements, or next steps.
+When providers help you, tell them you appreciate it.
+Good relationships help everyone.</p>
+<p>Stay in touch with providers who are especially helpful, even when you’re not actively using their services.</p>
+<h3><span><a id="manage-appointments">Manage Appointments and Commitments</a></span></h3>
+<p>Set phone alarms or ask for reminder calls when they are available so you do not miss appointments.
+Make sure you have a way to travel to appointments (see the <a href="#transportation">Transportation</a> section).
+Bring something to do in case there is a wait, and expect some delays in busy service settings.
+If you need to change an appointment, call ahead rather than just not attending.</p>
+<p>Arrive early to appointments if you can.
+If you will be late, call ahead.
+Keep a notebook or use your phone to note appointments, contacts, and any promises people make to you.
+If someone promises to do something for you but you don’t hear back in a reasonable time, check back with them.</p>
+<h3><span><a id="know-your-rights">Know Your Rights</a></span></h3>
+<p>Many service providers have non-discrimination policies and try to treat people with respect, though policies vary between agencies.
+Some services have specific rules about who can use them (like veterans-only programs, or programs with income limits).
+Privacy policies vary by agency.</p>
+<p>Government homeless service providers (and service providers that get government grants and contracts) often share information about their clients through the HMIS (Homeless Management Information System).
+Before such a service provider enters information about you into the HMIS, you will receive <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-management-information-system/forms-documents/2025/san-luis-obispo-county-coc-privacy-notice-2024-final" data-external-link="true">a privacy notice</a> (<a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-management-information-system/forms-documents/2025/san-luis-obispo-coc-hmis-consent-for-release-of-information-2024-final-%28sp%29" data-external-link="true">español</a>) and will be asked for your consent.
+You can ask to review this privacy notice at any time. 
+This privacy notice states: “You are still eligible for services if you refuse to have your standard information shared in HMIS.” 
+Ask about HMIS Consent for Release of Information (ROI) forms and what they mean before you sign them.
+You have the right to see the information that has been collected about you in the HMIS, to have your own copy of this information, to request changes to it, and to have it marked private (so that it will not be shared with other service providers who use HMIS). 
+The privacy of the information in the HMIS is protected by law, but the government does not always follow the law, so be cautious.</p>
+<p>Many programs have procedures for appealing decisions or for filing complaints.
+Ask program staff or search online to find the specific process.
+Legal aid organizations can help with appeals (see the <a href="#legal-help">Legal assistance</a> section).</p>
+<h3><span><a id="document-everything">Document Everything</a></span></h3>
+<p>Keep copies of important documents and applications.
+Store documents in waterproof bags.
+Use your backpack as a pillow when you sleep.
+Keep your most important items in clothes pockets.
+If you have enough income, consider getting a safety deposit box for the most important or hard-to-replace documents.</p>
+<p>Use your phone to take photos of important paperwork.
+Activate automatic cloud backup (iCloud for iPhone, Google Photos for Android) so your photos survive if your phone is lost or stolen.
+Phones (iPhones &amp; Androids) typically come with some amount of free cloud storage, so you can keep access to your photos even if you lose your phone.</p>
+<p>Keep the dates, names, and outcomes of important conversations.
+Keep case numbers, application numbers, and confirmation numbers.</p>
+<h3><span><a id="focus-on-goals">Focus on Your Goals and Strengths</a></span></h3>
+<p>Tell people clearly what you are working toward (housing, employment, healthcare, etc.).
+Share your skills, experience, education, and personal strengths when they matter for the services you want.
+For example, tell employment services about your work experience.</p>
+<p>Come to meetings with ideas about what might work for your situation.
+Follow through on promises you make and take active steps toward your goals.</p>
+<h3><span><a id="navigate-system-barriers">Navigate System Barriers</a></span></h3>
+<p>Learn the rules for programs: who can use them, when applications are due, and what steps you need to take.
+If you don’t qualify for one program, ask about other options.
+If you have disabilities or special needs that make it difficult to access a program, ask about help they can provide.</p>
+<p>If you’re not getting the help you think you should be getting, ask to speak with supervisors.
+Use formal complaint procedures and appeal processes.
+Or find someone who knows the system well to help you (like a case manager, behavioral health navigator, legal aid worker, or peer advocate).</p>
+<h3><span><a id="work-with-multiple-providers">Work with Multiple Service Providers</a></span></h3>
+<p>Tell each provider about other services you get, when it matters.
+For example, tell housing programs about your income sources.
+But casual services like showers don’t need to know about each other.</p>
+<p>If an agency plans to apply for a service in your name, tell them if you already applied on your own.
+This prevents duplicate applications and wasted time.
+Keep track of which applications you made or that others made for you.
+This helps you avoid doing the same thing twice.</p>
+<p>Share information with service providers that relates directly to the services you want.
+For example, share your income for benefits applications or your medical history for healthcare.
+Keep other personal details private if you don’t feel like sharing them.</p>
+<p>Keep a list of contact information for all your service providers.
+Ask for direct phone numbers or business cards from people who work with you.
+This helps you avoid phone trees if you need to call back.</p>
+<h3><span><a id="set-goals-and-track-progress">Set Goals and Track Progress</a></span></h3>
+<p>Make your goals “S.M.A.R.T.” (Specific, Measurable, Achievable, Relevant, and Time-bound). 
+Divide big goals (like getting housing) into smaller steps you can manage.
+Notice and celebrate your achievements, even small ones.
+Be flexible and willing to change your goals as your situation changes.</p>
+<h3><span><a id="when-things-go-wrong">When Things Go Wrong</a></span></h3>
+<p>Even when you feel frustrated, stay calm and speak respectfully.
+This approach usually gets better results and faster solutions than arguing.
+Note details about problems, including dates, names, and what went wrong.
+Don’t quit too soon.
+Persevering often pays off when you work with complex systems.</p>
+<h3><span><a id="find-and-use-resources">Find and Use Resources</a></span></h3>
+<p>Use this guide or call <a href="tel:+1-211" aria-label="Call 211">211</a> to get information about available services. 
+Talk with other people in similar situations—they often have valuable information and tips.</p>
+<p>The <a href="#other-guides">Other Guides</a> section of this guide lists some other resource guides that may have information this guide missed.</p>
+<p>Things change.
+Contact service providers directly to verify their most current information before you travel to their locations.</p>
+<hr>
+<h2><span><a id="shelter-housing">Shelter &amp; Housing</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#eviction-protection">Eviction Prevention</a></li>
+<li><a href="#warming-cooling-centers">Warming/Cooling Centers</a></li>
+<li><a href="#overnight-shelter">Overnight Shelter</a></li>
+<li><a href="#camping-parking-rv-parks">Legal Camping, Safe Parking, and RV Parks</a></li>
+<li><a href="#transitional-and-long-term-housing">Transitional and Long-Term Housing</a></li>
+<li><a href="#housing-veterans">For U.S. Military Veterans</a></li>
+<li><a href="#sober-living-homes">Sober Living Homes and Residential Treatment Options</a></li>
+</ul>
+<h3><span><a id="eviction-protection">Eviction Prevention</a></span></h3>
+<p>If you are homeless or are threatened with eviction with a “pay rent or quit” notice, or if you have had to move your family into a hotel, you can get immediate help from the <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs Homeless Assistance Program"><strong>CalWORKs Homeless Assistance Program</strong></a>. 
+This program can pay your security deposit, one month’s rent, or a utility deposit payment. 
+To qualify you must have “apparent eligibility” for CalWORKs and less than $100 in liquid assets. 
+You must first get a referral from the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>. 
+The first step in this process is to apply for CalWORKs, which you can do on-line at <a href="https://benefitscal.com/" data-external-link="true">BenefitsCal</a>.</p>
+<p>If you are homeless or are threatened with eviction with a “pay rent or quit” notice, or if you have had to move your family into a hotel, you can get help from the <a href="#" data-directory-link="Housing-Support-Program" aria-label="View directory entry for Housing Support Program (HSP)"><strong>Housing Support Program (HSP)</strong></a>. 
+This program will help you find housing, and give you rent and moving assistance, among other things. 
+You must be eligible for <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs"><strong>CalWORKs</strong></a> to participate, and you can only use this program once in your lifetime. 
+The first step in this process is to apply for CalWORKs, which you can do on-line at <a href="https://benefitscal.com/" data-external-link="true">BenefitsCal</a>. </p>
+<p><a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition (5CHC)"><strong>5Cities Homeless Coalition (5CHC)</strong></a> operates a <a href="https://5chc.org/programs/housing-assistance" data-external-link="true">housing assistance program</a> that offers financial assistance for rent, security deposit, or other immediate needs for people who are homeless in danger of becoming homeless. 
+Contact 5CHC to arrange a confidential coordinated entry interview. 
+You need to bring identification, including social security cards and birth certificates for you and those living with you, an account of how much income you received during the previous three months, your lease agreement if any, and any eviction notice you received. </p>
+<blockquote>
+<p>See the <a href="#legal-help">Legal Help, Mediation, and Crime Victim Protection</a> section for options about preventing illegal evictions.</p>
+</blockquote>
+<blockquote>
+<p>See the <a href="#emergency-financial-help">Emergency Financial Help</a> section for more possible ways to get short-term financial help in a crisis.</p>
+</blockquote>
+<h3><span><a id="warming-cooling-centers">Warming/Cooling Centers</a></span></h3>
+<p>Warming centers open only on unusually cold or rainy nights (temperatures expected to drop below 38°F or a 50% chance of rain).
+They offer overnight shelter beds.
+Cooling centers open only during the day when the weather is unusually hot.
+They offer you an air-conditioned place where you can get out of the sun.
+It can be difficult to know on any particular day whether or not these centers are open, so it is a good idea to call ahead.</p>
+<ul>
+<li><a href="https://www.emergencyslo.org/en/adverse-weather-centers.aspx" data-external-link="true">This web page</a> may show the current status of the county’s warming/cooling centers.</li>
+<li>You can <a href="https://lp.constantcontactpages.com/sl/Jg4jVHc/warmingcenter" data-external-link="true">register here</a> to receive notifications about the county’s warming centers.</li>
+</ul>
+<p>The SLO city warming/cooling center is at the <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a>.
+When it operates as a warming center, check in is between 7pm and 9pm, and you must leave by 8am. 
+People with P.C. 290 convictions are not allowed in the center. 
+When it operates as a cooling center, you must leave by 6pm. 
+Cooling center guests can get breakfast, lunch, and dinner. 
+Pets with rabies vaccinations are allowed in their kennel. 
+The warming center offers a free hot meal. 
+Transportation is available between the warming center and Morro Bay and Los Osos. 
+Pick-up times from those areas are as follows: </p>
+<ul>
+<li>6:15pm: Morro Bay Park (<a href="#" class="map-link" data-lat="35.366428" data-lon="-120.844717" data-zoom="17" data-label="Warming Center Shuttle">734 Harbor St., Morro Bay</a>) </li>
+<li>6:00pm: South Bay Community Center (<a href="#" class="map-link" data-lat="35.312849" data-lon="-120.836370" data-zoom="17" data-label="Warming Center Shuttle">2180 Palisades Ave., Los Osos</a>) </li>
+</ul>
+<p>The <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> warming center at <a href="#" class="map-link" data-lat="35.118597" data-lon="-120.594462" data-zoom="17" data-label="5CHC Warming Center">1023 E. Grand Ave. in Arroyo Grande</a> operates between 5:30pm and 7am. 
+You must check in between 5:30pm and 8pm. 
+Pets are OK if you have proof of license/vaccinations. </p>
+
+<p>People with P.C. 290 convictions are not allowed in the center. 
+Call <a href="tel:+1-805-202-3615" aria-label="Call 805-202-3615">805-202-3615</a> to verify the center is open and to learn about free transportation options to the center from Grover Beach, Oceano, and Pismo Beach. 
+The warming center offers dinner and a light breakfast. 
+Text “Add Me” to <a href="sms:+1-805-295-1501?&amp;body=Add%20Me">805-295-1501</a> to receive text updates to your phone when the Warming Center opens, or email <a href="mailto:info@5chc.org" aria-label="Email info@5chc.org">info@5chc.org</a> and ask to be added to their notification list. </p>
+<p>The <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> runs a ten-bed warming center at its Paso Robles shelter location. 
+It operates between 6:00pm and 7:00am. Check in between 4:30pm and 5:30pm. 
+They will also serve you a meal. 
+No dogs except for service dogs are allowed in the warming center. </p>
+<p><a href="#" data-directory-link="Nipomo-Senior-Center" aria-label="View directory entry for Nipomo Senior Center"><strong>Nipomo Senior Center</strong></a> operates an air-conditioned cooling center any time the temperature is above 90°F outside. 
+You do not have to be a senior center member to shelter there when the cooling center is open. </p>
+<h3><span><a id="overnight-shelter">Overnight Shelter</a></span></h3>
+<p>If you are unsheltered and need a place to sleep tonight, these are some options:</p>
+<p>The <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> has a hundred overnight shelter beds. 
+Many are reserved for people who have previously registered with 40 Prado, but a limited number are available on a walk-in basis. 
+To get a bed, first come on-site and complete the intake process. 
+Thereafter, on any day when you need an overnight shelter bed, check in to secure a bed or to be placed on the waiting list. 
+Priority is given to SLO county residents. 
+They offer meals (breakfast, lunch, and dinner), showers, laundry, mail/phone services, an integrated medical clinic (primary and urgent care five days a week with an on-site pharmacy), recuperative care beds, and animal kennels. 
+To stay at the shelter, you must have a valid photo ID, you must not be a P.C. 290 registered sex offender, and you must participate in case management. 
+You must also be able to care for yourself independently (bathing, feeding, dressing, etc.). </p>
+<p>The 40 Prado center is the only walk-in, overnight homeless shelter in SLO County.
+The <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> used to operate a shelter in the north county, but now only offers 90-day transitional housing there (<a href="#transitional-and-long-term-housing">see below</a>) and an occasional warming shelter.</p>
+<p>The <a href="#" data-directory-link="Good-Samaritan-Shelter" aria-label="View directory entry for Good Samaritan Shelter"><strong>Good Samaritan Shelter</strong></a> operates a set of shelters in Santa Maria and other places in Santa Barbara County. 
+Call ahead during office hours to learn which shelter has room for you. 
+They also have laundry facilities, hot meals, substance use treatment, and mental health services. </p>
+<p>If you are homeless because you are escaping dangerous circumstances of domestic violence or sexual assault, you can get safe, confidential, emergency shelter at safe houses operated by <a href="#" data-directory-link="Lumina-Alliance" aria-label="View directory entry for Lumina Alliance"><strong>Lumina Alliance</strong></a>. 
+Call their crisis and information line to get access to this program. 
+They will also help you with trained advocacy, accompaniment to medical/legal appointments, case management, and therapy for survivors and children. 
+They operate throughout SLO County, and are open to people of all genders, ages, and backgrounds. </p>
+<p>If you are homeless and have a medically verified need for 24/7 temporary housing because you are seriously ill, recovering from surgery or injury or high-risk pregnancy, or something of that nature, you may qualify for the <a href="#" data-directory-link="Medically-Fragile-Homeless-Program" aria-label="View directory entry for Medically Fragile Homeless Program"><strong>Medically Fragile Homeless Program</strong></a>. 
+They will help you with immediate housing, supportive services and coordinated case management to ensure physical recovery, access to income sources, connection to services, and a more permanent housing alternative when you exit the program. 
+You cannot apply for this program yourself, but you must get a referral from an agency like <a href="#" data-directory-link="Adult-Protective-Services" aria-label="View directory entry for Adult Protective Services"><strong>Adult Protective Services</strong></a>,
+<a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>, 
+<a href="#" data-directory-link="Housing-Support-Program" aria-label="View directory entry for Housing Support Program (HSP)"><strong>Housing Support Program (HSP)</strong></a>,
+<a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening (CFS)"><strong>Center for Family Strengthening (CFS)</strong></a>, 
+or <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs"><strong>CalWORKs</strong></a>. 
+If you are being treated by a hospital or other medical professionals, consider telling them that you are homeless and asking them if they can help you with this process.</p>
+<p>If you need shelter because you have a medical condition that requires you to have some medical supervision, you may be able to get a referral to a rehabilitative care or skilled nursing or assistive living facility. 
+You can get such a referral from your primary care physician. 
+You may also be able to get some help from <a href="#" data-directory-link="Adult-Protective-Services" aria-label="View directory entry for Adult Protective Services"><strong>Adult Protective Services</strong></a>. </p>
+<h4><span>A Note About “In-Home” Supportive Services</span></h4>
+
+
+<p>The <a href="#" data-directory-link="In-Home-Supportive-Services" aria-label="View directory entry for In-Home Supportive Services (IHSS)"><strong>In-Home Supportive Services (IHSS)</strong></a> Program helps pay for services provided to senior, blind, or disabled people who have difficulty caring for themselves and cannot live at home safely without in-home care. 
+Despite the “in-home” name, this program is potentially also available to people who shelter at homeless shelters or safe-parking sites.
+Among the services that this program can help pay for are meal preparation, laundry, grocery shopping, personal care services (such as bowel and bladder care, bathing, grooming and paramedical services, help getting dressed, help getting into and out of a wheelchair), and accompaniment to medical appointments. </p>
+<p>To qualify for IHSS, you must be disabled, blind, or age 65 or older. 
+You must also be unable to live safely in your current home or shelter environment without assistance, and you must be financially needy. 
+The process of applying for IHSS is difficult, so it is a good idea for you to get some help from a case manager or other social worker. </p>
+<h3><span><a id="camping-parking-rv-parks">Legal Camping, Safe Parking, and RV Parks</a></span></h3>
+<p>If you sleep in your vehicle, there are some free, legal “safe parking” spots available at the <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> where you can stay from 6pm to 7am. 
+To register for one of these spots, first complete the referral form at the <a href="https://capslo.org/safe-parking/" data-external-link="true">CAPSLO website</a>. 
+You will also have access to the various other services offered at 40 Prado (such as meals, showers, laundry, mail/phone services, an integrated medical clinic, and an animal kennel). 
+Your vehicle must be registered and you must have proof of insurance. 
+You must participate in case management. 
+You must not be a P.C. 290 registered sex offender to use this service. 
+SLO county residents get priority. 
+Contact Sam Neal (<a href="mailto:sneal@capslo.org" aria-label="Email sneal@capslo.org">sneal@capslo.org</a>, <a href="tel:+1-805-459-1073" aria-label="Call 805-459-1073">805-459-1073</a>) with questions. </p>
+<p>There are some free, legal “safe parking” spots available in the SLO city area through the <a href="#" data-directory-link="Rotating-Overnight-Safe-Parking-Program" aria-label="View directory entry for Rotating Overnight Safe Parking Program"><strong>Rotating Overnight Safe Parking Program</strong></a>.
+To register for one of these spots, first complete the intake process at the 40 Prado offices any day from 8am to 2pm.
+You get a place to park overnight for 90 days, with a possible 30 day extension.
+You must move your vehicle away from the site during the day.
+You have access to water, trash, and restrooms, and there will be occasional security checks.
+No illegal drugs, alcohol, weapons, or fires are allowed.
+Your vehicle must fit into a standard parking space.
+You must not be a P.C. 290 registered sex offender to participate.
+SLO county residents get priority.
+You must participate in case management.</p>
+<p>You can camp overnight legally at various <a href="#" data-directory-link="SLO-County-Parks" aria-label="View directory entry for SLO County Parks"><strong>SLO County Parks</strong></a>, but for a fee (roughly $25–50 per night, plus a $10 reservation fee and sometimes also a per-vehicle fee). 
+Some parks have both tent camping and RV hook-up sites. 
+None have dump stations. 
+All have restrooms, some also have coin-operated showers. 
+Stays are limited to 15 consecutive days in any 30-day period during the summer, or a maximum of 30 days in any 60-day period during the winter, and to a maximum of 60 days in any 12-month period. </p>
+<p>There are several RV parks in SLO County, including short-term campsites (ranging from $52 to $104 per night plus reservation fee) and longer-term RV parks ($600–$750/month).
+These include:</p>
+<ul>
+<li><a href="#" data-directory-link="Bella-Vista-by-the-Sea" aria-label="View directory entry for Bella Vista by the Sea"><strong>Bella Vista by the Sea</strong></a> (Cayucos)</li>
+<li><a href="#" data-directory-link="Coastal-Dunes" aria-label="View directory entry for Coastal Dunes RV Park &amp; Campground"><strong>Coastal Dunes RV Park &amp; Campground</strong></a> (Grover Beach)</li>
+<li><a href="#" data-directory-link="El-Chorro-Regional-Park-Campground" aria-label="View directory entry for El Chorro Regional Park Campground"><strong>El Chorro Regional Park Campground</strong></a> (between SLO and Morro Bay)</li>
+<li><a href="#" data-directory-link="Flying-Flags-Avila-Beach" aria-label="View directory entry for Flying Flags Avila Beach"><strong>Flying Flags Avila Beach</strong></a></li>
+<li><a href="#" data-directory-link="Le-Sage-Riviera-RV-Park" aria-label="View directory entry for Le Sage Riviera RV Park"><strong>Le Sage Riviera RV Park</strong></a> (Grover Beach)</li>
+<li><a href="#" data-directory-link="Lopez-Lake-Recreation-Area" aria-label="View directory entry for Lopez Lake Recreation Area"><strong>Lopez Lake Recreation Area</strong></a></li>
+<li><a href="#" data-directory-link="Port-San-Luis-Harbor-District" aria-label="View directory entry for Port San Luis Harbor District RV Camping"><strong>Port San Luis Harbor District</strong> RV Camping</a> (Avila Beach)</li>
+<li><a href="#" data-directory-link="Santa-Margarita-KOA-Holiday" aria-label="View directory entry for Santa Margarita KOA Holiday"><strong>Santa Margarita KOA Holiday</strong></a></li>
+<li><a href="#" data-directory-link="Silver-City-Resort" aria-label="View directory entry for Silver City Resort"><strong>Silver City Resort</strong></a> (Morro Bay)</li>
+</ul>
+<p>Some sites have RV size limits and other restrictions.
+See the Directory entries for specific information about rates, size limits, available hookups, and amenities at each location.</p>
+<p>If you are an Elks Lodge member, <a href="https://rv.elks322.org" data-external-link="true">SLO Elks Lodge #322</a> at <a href="#" class="map-link" data-lat="35.263006" data-lon="-120.671993" data-zoom="18" data-label="Elks Lodge #322">222 Elks Lane in SLO</a> also has several $30/night RV spots and a free dump station. 
+Contact them at <a href="tel:+1-805-543-0322" aria-label="Call 805-543-0322">805-543-0322</a> (M–F, 10am–4pm) or <a href="mailto:RVcamping@elks322.org" aria-label="Email RVcamping@elks322.org">RVcamping@elks322.org</a>. </p>
+<h3><span><a id="transitional-and-long-term-housing">Transitional and Long-Term Housing</a></span></h3>
+<p>This section discusses more long-term housing options including <em>transitional housing</em> (a temporary home while you search for more long-term housing) and <em>affordable housing</em> or <em>subsidized housing</em> (a long-term home).</p>
+<p>The <a href="#" data-directory-link="CES" aria-label="View directory entry for Coordinated Entry System (CES)"><strong>Coordinated Entry System (CES)</strong></a> is SLO county’s system for matching people in need with transitional or long-term housing that is appropriate for them.
+If you want to get such housing, you should try to enter this system.
+This can be more effective than trying to contact the many individual transitional or long-term housing programs one at a time.
+To enter this system, contact one of the many participating agencies, such as <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>, <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a>, <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a>, <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association"><strong>Transitions Mental Health Association</strong></a>, <a href="#" data-directory-link="Good-Samaritan-Shelter" aria-label="View directory entry for Good Samaritan Shelter"><strong>Good Samaritan Shelter</strong></a>, or <a href="#" data-directory-link="SLO-County-Health-Department" aria-label="View directory entry for SLO County Health Department"><strong>SLO County Health Department</strong></a>. </p>
+<p>A program called <a href="#" data-directory-link="Housing-Now" aria-label="View directory entry for Housing Now"><strong>Housing Now</strong></a> finds homes for the most vulnerable chronically homeless people from SLO County.
+You cannot apply directly to participate in this program, but if you enter the Coordinated Entry System (see above), that system may eventually place you in this program so that you can quickly get a home. </p>
+<p>The <a href="#" data-directory-link="BHBH" aria-label="View directory entry for Behavioral Health Bridge Housing (BHBH)"><strong>Behavioral Health Bridge Housing (BHBH)</strong></a> has some quality, affordable short-term (less than 90 days) and medium term (90 days to two years) housing for people in SLO county who have severe behavioral health issues who are homeless or at risk of homelessness. 
+For information on the application process, how to demonstrate eligibility, and bed availability call Mark Lamore, Director of Homeless Services at <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a>, at <a href="tel:+1-805-540-6500" aria-label="Call 805-540-6500">805-540-6500</a>. </p>
+<p><a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition (5CHC)"><strong>5Cities Homeless Coalition (5CHC)</strong></a> operates a <a href="https://5chc.org/programs/housing-assistance" data-external-link="true">housing assistance program</a> that offers case management and financial assistance for rent, deposit, and immediate needs, and housing assistance through various funding grants. 
+This is available both to currently homeless people and to people in danger of becoming homeless. 
+Contact 5CHC to arrange a confidential coordinated entry interview. </p>
+<p><a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> operates transitional (90-day) shelters in Atascadero and Paso Robles that serve people experiencing homelessness. 
+People who live in these shelters also get individualized case management services to help them find employment and long-term housing. 
+There is often a long waiting list for shelter beds. 
+They will not admit P.C. 290 registered sex offenders. </p>
+<p>The <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs Homeless Assistance Program"><strong>CalWORKs Homeless Assistance Program</strong></a> can pay a one-time security deposit and/or last month’s rent and/or utility deposit for families who are homeless or who received a “Pay Rent or Quit” notice on their current rental home. 
+To qualify you must meet CalWORKs eligibility requirements and have less than $100 in liquid assets. </p>
+<p><a href="#" data-directory-link="Family-Care-Network" aria-label="View directory entry for Family Care Network"><strong>Family Care Network</strong></a>’s <a href="#" data-directory-link="Housing-Support-Program" aria-label="View directory entry for Housing Support Program (HSP)"><strong>Housing Support Program (HSP)</strong></a> provides financial assistance for housing deposits and rent to families that are experiencing homelessness or are at risk of homelessness in SLO County.
+They also offer case management and life skills workshops (budgeting, credit repair, communication), bus passes, gas cards, and paperwork assistance. </p>
+<p><a href="#" data-directory-link="Balay-Ko-on-Barka" aria-label="View directory entry for Balay Ko on Barka"><strong>Balay Ko on Barka</strong></a> (a.k.a. “My Home for Hope”) and <a href="#" data-directory-link="Cabins-for-Change" aria-label="View directory entry for Cabins for Change"><strong>Cabins for Change</strong></a>, both in Grover Beach, operate many individual “tiny homes” that serve as transitional housing. 
+The cabins come with 24/7 support, case management, connections to food services and recovery, and house stabilization guidance. 
+They have on-site showers. 
+They accept vaccinated, well-behaved dogs. 
+They will not admit P.C. 290 registered sex offenders. 
+They typically have a long waiting list. 
+Apply through <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> to get on the waiting list. </p>
+<p><a href="#" data-directory-link="HASLO" aria-label="View directory entry for Housing Authority of SLO (HASLO)"><strong>Housing Authority of SLO (HASLO)</strong></a> operates several affordable housing properties in SLO county.
+Typically in these projects, residents pay part of the rent, while the rest of the rent is paid for them by subsidies or vouchers. 
+To qualify to rent one of these housing units, you must have enough income to pay your part of the rent, but you must not have so much income that you could afford non-subsidized housing. 
+Typically this means households that earn less than 30% of the area median income. 
+Preference is given to SLO County residents and to veterans. 
+Some housing is restricted to seniors (age 62 and above). 
+You need to provide proof of income and your prior rental history. 
+Most of these housing units have wait lists, and only some of them accept new applications at any time. </p>
+<p><a href="#" data-directory-link="Paso-Robles-Housing-Authority" aria-label="View directory entry for Paso Robles Housing Authority"><strong>Paso Robles Housing Authority</strong></a> operates several affordable housing properties in Paso Robles designed for people who have around 30–60% of the area median income. 
+You can download an application from their website. 
+If your application is accepted, you will be put on the waiting list. 
+You must include copies of the latest three months’ paycheck stubs, proof of other sources of income, and a copy of your last two years’ federal income tax returns. 
+You may be rejected if you recently were evicted, defaulted on debts, or have certain criminal convictions. </p>
+<p><a href="#" data-directory-link="Lumina-Alliance" aria-label="View directory entry for Lumina Alliance"><strong>Lumina Alliance</strong></a> operates a six- to 24-month <a href="https://luminaalliance.org/transitional-housing/" data-external-link="true">transitional housing program</a> for individuals and families who are fleeing domestic violence, dating violence, sexual assault, and/or stalking. 
+People housed through this program also get access to advocacy services, employment assistance, counseling, legal help, children’s services, life skills development, and help obtaining permanent housing. 
+If you are homeless or need housing due to fleeing abusive situation, have low or very low income, and are willing to participate in Lumina’s program and to cooperate with them in following a safety plan, you may qualify for transitional housing through this program. </p>
+<p>SLO County adults with mental illness may qualify for supportive housing in multiple county locations through the <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a> <a href="https://www.t-mha.org/housing.php" data-external-link="true">residential housing program</a>.</p>
+<p>The <a href="#" data-directory-link="HomeShare-SLO" aria-label="View directory entry for HomeShare SLO"><strong>HomeShare SLO</strong></a> program matches property owners who have an extra room with people who need a place to live. </p>
+
+
+<p><a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a> runs a <a href="https://restorativepartners.org/housing/" data-external-link="true">housing program</a> with multiple transitional housing programs for men, women, and families in various SLO County locations. 
+These programs are for people in recovery from addiction and people transitioning from incarceration. 
+Some are specific to women with children. 
+Along with housing, residents get help with employment support, financial literacy, life skills, addiction recovery, and help finding permanent housing. 
+There is a wait list. </p>
+<p><a href="#" data-directory-link="Salvation-Army" aria-label="View directory entry for Salvation Army"><strong>Salvation Army</strong></a> has a “Rapid Rehousing Program” that helps people find and qualify for long-term housing. 
+Contact Hattie Davis (<a href="mailto:hattie.davis@usw.salvationarmy.org" aria-label="Email hattie.davis@usw.salvationarmy.org">hattie.davis@usw.salvationarmy.org</a>) for details. </p>
+<p>The <a href="#" data-directory-link="HouseKeys" aria-label="View directory entry for HouseKeys"><strong>HouseKeys</strong></a> program is the city of SLO’s affordable home-ownership program.
+It serves households with about 30–50% of the area median income. 
+Their idea of “affordable” may not be yours.
+If you want to apply for housing through this program, begin the <a href="https://www.housekeys.org/applicationprocess" data-external-link="true">application process</a> described on their website.</p>
+<p><a href="#" data-directory-link="Habitat-for-Humanity" aria-label="View directory entry for Habitat for Humanity SLO County"><strong>Habitat for Humanity SLO County</strong></a> operates a home ownership program for first-time low-income home buyers and home preservation assistance (minor repairs, landscaping, painting) for low-income homeowners. 
+Apply via their website. </p>
+<p><a href="#" data-directory-link="Peoples-Self-Help-Housing" aria-label="View directory entry for Peoples’ Self-Help Housing"><strong>Peoples’ Self-Help Housing</strong></a> operates a “sweat equity” homeownership program in which families help to build their own homes. 
+They also operate affordable rental housing developments and supportive housing programs. 
+They serve low-income families, farmworkers, seniors, veterans, people with disabilities, and formerly-homeless people. 
+Contact them directly to access the program. </p>
+<p>Some other low-income options include:</p>
+<ul>
+<li><a href="https://www.rooseveltfamilyapts.com/" data-external-link="true">Roosevelt Family Apartments</a> in Nipomo. </li>
+<li><a href="https://www.gsfpi.com/" data-external-link="true">San Luis Bay Apartments</a> in Nipomo. </li>
+</ul>
+<p>If you are a refugee from another country, you may be able to get some help establishing housing from <a href="#" data-directory-link="SLO4Home" aria-label="View directory entry for SLO for HOME"><strong>SLO for HOME</strong></a>. </p>
+<h4><span>For Seniors</span></h4>
+
+
+<p><a href="#" data-directory-link="HASLO" aria-label="View directory entry for Housing Authority of SLO (HASLO)"><strong>Housing Authority of SLO (HASLO)</strong></a>, <a href="#" data-directory-link="Paso-Robles-Housing-Authority" aria-label="View directory entry for Paso Robles Housing Authority"><strong>Paso Robles Housing Authority</strong></a>, and <a href="#" data-directory-link="Peoples-Self-Help-Housing" aria-label="View directory entry for Peoples’ Self-Help Housing"><strong>Peoples’ Self-Help Housing</strong></a> operate several affordable senior housing rental properties. </p>
+<p>There are some additional subsidized and affordable housing options especially for seniors (sometimes defined as age 55 and above, or as 62 and above).
+These include:</p>
+<ul>
+<li><a href="https://cortinadarroyograndeseniorapts.com/" data-external-link="true">Cortina d’Arroyo Grande Senior Apartments</a> (<a href="#" class="map-link" data-lat="35.122208" data-lon="-120.607207" data-zoom="17" data-label="Cortina d’Arroyo Grande Senior Apartments">241 N. Courtland Ave., Arroyo Grande</a>) — <a href="tel:+1-805-489-6888" aria-label="Call 805-489-6888">805-489-6888</a> </li>
+<li>Parkview Manor (<a href="#" class="map-link" data-lat="35.113380" data-lon="-120.600175" data-zoom="17" data-label="Parkview Manor">365 South Elm St., Arroyo Grande</a>) — <a href="tel:+1-805-489-5101" aria-label="Call 805-489-5101">805-489-5101</a> </li>
+<li><a href="#" data-directory-link="Judson-Terrace" aria-label="View directory entry for Judson Terrace"><strong>Judson Terrace</strong></a> (SLO), has 107 low-income affordable apartments for people aged 55 and up, and 32 low-income affordable apartments for people aged 62 and up. They only accept applications when the waiting list is open. </li>
+</ul>
+<p>Affordable housing options for seniors with Section 8 vouchers include:</p>
+<ul>
+<li>Morro del Mar Senior Apartments (<a href="#" class="map-link" data-lat="35.363321" data-lon="-120.849837" data-zoom="17" data-label="Morro del Mar Senior Apartments">555 Main St., Morro Bay</a>) — <a href="tel:+1-805-225-1837" aria-label="Call 805-225-1837">805-225-1837</a> </li>
+<li><a href="https://villapaseo.com/" data-external-link="true">Villa Paseo Senior Apartments</a> (<a href="#" class="map-link" data-lat="35.578160" data-lon="-120.696694" data-zoom="17" data-label="Villa Paseo Palms">2800 Ramada Dr., Paso Robles</a>) — <a href="tel:+1-805-227-4588" aria-label="Call 805-227-4588">805-227-4588</a> </li>
+<li><a href="https://www.sunshineretirementliving.com/las-brisas-independent-senior-living-san-luis-obispo-ca/" data-external-link="true">Las Brisas Retirement Community</a> (SLO) </li>
+</ul>
+<p>Affordable housing options for disabled / handicapped seniors can be found at:</p>
+<ul>
+<li><a href="https://www.buckinghampm.com/homes/california-manor" data-external-link="true">California Manor</a> (<a href="#" class="map-link" data-lat="35.462401" data-lon="-120.645271" data-zoom="17" data-label="California Manor">10165 El Camino Real, Atascadero</a>) — <a href="tel:+1-805-466-0759" aria-label="Call 805-466-0759">805-466-0759</a> </li>
+<li><a href="https://www.mbspminc.com/property/1606/Hacienda-Del-Norte/" data-external-link="true">Hacienda Del Norte</a> (<a href="#" class="map-link" data-lat="35.624894" data-lon="-120.693013" data-zoom="17" data-label="Hacienda Del Norte">529 10th St., Paso Robles</a>) — <a href="tel:+1-805-238-5793" aria-label="Call 805-238-5793">805-238-5793</a> </li>
+<li>Brizzolara St. Apartments (<a href="#" class="map-link" data-lat="35.280660" data-lon="-120.668432" data-zoom="17" data-label="Brizzolara Street Apartments">611 Brizzolara, SLO</a>) </li>
+<li>Marvin Gardens (<a href="#" class="map-link" data-lat="35.262116" data-lon="-120.642638" data-zoom="17" data-label="Marvin Gardens">1105 Laurel Lane, SLO</a>) </li>
+</ul>
+<p>You can find additional <a href="https://centralcoastseniors.org/senior-independent-housing-options/" data-external-link="true">senior housing listings</a> at the <a href="#" data-directory-link="Central-Coast-Commission-for-Senior-Citizens" aria-label="View directory entry for Central Coast Commission for Senior Citizens"><strong>Central Coast Commission for Senior Citizens</strong></a> website.</p>
+<p>If you need Assistive Living or Residential Care for the Elderly (RCFE) housing, there are some options in SLO County, but none of them accept Medi-Cal. 
+If you need such housing and Medi-Cal is your only health insurance, you can get on a waiting list for a facility outside of SLO County. 
+This is a lengthy process, so if you think you might need such a living situation in the future (even as long as a year or more from now), you should try to start this process now. 
+Discuss this with your case manager if you have one, or with the <a href="#" data-directory-link="Long-Term-Care-Ombudsman" aria-label="View directory entry for Long-Term Care Ombudsman"><strong>Long-Term Care Ombudsman</strong></a>.</p>
+
+
+<h3><span><a id="housing-veterans">For U.S. Military Veterans</a></span></h3>
+<p>U.S. military veterans who have low incomes and who are homeless or at risk of homelessness can get help from <a href="#" data-directory-link="Supportive-Services-for-Veteran-Families" aria-label="View directory entry for Supportive Services for Veteran Families"><strong>Supportive Services for Veteran Families</strong></a>.
+This help includes housing assistance, case management, and financial assistance; rapid re-housing and homelessness prevention services; temporary financial assistance for rent, deposits, and utilities; housing barriers assessments, emergency housing stability assistance, housing counseling, rental agreement education, landlord-tenant mediation, and future housing stability planning. 
+You must have a DD214 with discharge other than dishonorable. </p>
+<p>The <a href="#" data-directory-link="RVs-for-Veterans" aria-label="View directory entry for RVs for Veterans"><strong>RVs for Veterans</strong></a> program can get you a free RV (e.g. motorhome, travel trailer, or fifth wheel). 
+These are donated by other members of the community, and are available as they are donated. 
+Contact them to be put on a waiting list for the next RV. 
+Priority is given to homeless veterans, veterans who receive insufficient benefits to pay rent, veterans who do not qualify for VA assistance, and veterans who need to live alone because of PTSD. 
+Sometimes the program also has RVs available for people who are experiencing homelessness who are not veterans. 
+The RVs are in working condition, with no leaks; you must obtain insurance. </p>
+<p>Homeless veterans can get help from the U.S. Department of Housing and Urban Development’s V.A. Supportive Housing (VASH) program, which can give you vouchers to pay for permanent housing. 
+Call <a href="tel:+1-877-424-3838" aria-label="Call 877-4AID-VET">877-4AID-VET</a> or ask for help from <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for SLO County Veterans Services"><strong>SLO County Veterans Services</strong></a>. </p>
+<blockquote>
+<p>See <a href="#auto-insurance-and-repair">Automobile Insurance and Repair</a> for tips on how to obtain low-cost auto insurance.</p>
+</blockquote>
+<h3><span><a id="sober-living-homes">Sober Living Homes and Residential Treatment Options</a></span></h3>
+<p><a href="#" data-directory-link="SLO-Hub" aria-label="View directory entry for SLO Hub"><strong>SLO Hub</strong></a> helps you find a residential (live-in) recovery program that’s right for you, and can pay the deposit and rent for the opening months of your residency if you cannot afford it or if your insurance does not cover it. </p>
+<p><a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health Department"><strong>SLO County Behavioral Health Department</strong></a> contracts with sober living environments throughout SLO County (from Oceano to Paso Robles) at rates of $35–55 per day. 
+These facilities accept Medi-Cal and offer sliding scale fees based on ability to pay. 
+Visit <a href="Directory.md##SLO-County-Drug-and-Alcohol-Services"><strong>SLO County Drug and Alcohol Services</strong></a> or contact the Behavioral Health access line at <a href="tel:+1-800-838-1381" aria-label="Call 800-838-1381">800-838-1381</a> for referrals. </p>
+<p>Here are some residential treatment options in SLO County:</p>
+
+
+
+<ul>
+<li><a href="#" data-directory-link="Captive-Hearts" aria-label="View directory entry for Captive Hearts"><strong>Captive Hearts</strong></a> (Grover Beach) for women only </li>
+<li><a href="#" data-directory-link="Casa-Solana" aria-label="View directory entry for Casa Solana"><strong>Casa Solana</strong></a> (Grover Beach) for women only. Also known as “Sunshine House.” </li>
+<li><a href="#" data-directory-link="Gryphon-Society" aria-label="View directory entry for Gryphon Society"><strong>Gryphon Society</strong></a> (Grover Beach) for men only </li>
+<li><a href="#" data-directory-link="Discipleship-Home" aria-label="View directory entry for Discipleship Home"><strong>Discipleship Home</strong></a> (Oceano) for men only </li>
+<li><a href="#" data-directory-link="Gryphon-Society" aria-label="View directory entry for Gryphon Society"><strong>Gryphon Society</strong></a> (SLO) for women only </li>
+<li><a href="#" data-directory-link="Middlehouse" aria-label="View directory entry for Middlehouse"><strong>Middlehouse</strong></a> (SLO) for men only </li>
+<li><a href="#" data-directory-link="Sun-Street-Centers" aria-label="View directory entry for Sun Street Centers"><strong>Sun Street Centers</strong></a> (SLO) for men only </li>
+</ul>
+<hr>
+<h2><span><a id="property-storage">Property Storage Options</a></span></h2>
+<h3><span><a id="short-term-property-storage">Short-Term</a></span></h3>
+<p>If you need to securely store a small amount of property for a few hours or overnight, you have a few options:</p>
+<p>The <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> has storage lockers available  for people who complete intake for day services there. 
+You must provide your own padlock. </p>
+<p>The commercial service <a href="https://bounce.com/" data-external-link="true">Bounce</a> partners with multiple locations (in SLO County, these are typically UPS Stores) to offer short-term luggage storage that typically runs about $7 per day or $20–80 per month (depending on weight and size).
+You can find the specific locations, terms and conditions, and costs at their website. </p>
+<p>In a few locations in SLO County (Morro St. in SLO, at Cal Poly, and at the Curbaril Park-n-Ride in Atascadero) you can find <a href="https://rideshare.org/bike-lockers/" data-external-link="true">on-demand bike lockers</a>.
+These cost 5¢ per hour and can be rented for up to seven consecutive days. 
+Use the <a href="https://www.bikelink.org/" data-external-link="true">BikeLink</a> app to access and pay for these lockers. 
+They are for bicycles only (you cannot use them to store other personal belongings like carts or suitcases), but you can probably get away with storing pannier bags along with your bicycle. </p>
+<h3><span><a id="long-term-property-storage">Long-Term</a></span></h3>
+<p>There are several commercial long-term storage options in SLO County.
+You can find these by doing a web search for terms like “self storage” or “mini storage”.
+They typically rent spaces by the month, and have different-sized units available at different prices.
+5′×5′, 5′×10′, and 10′×10′ units are typical.
+You can expect to pay about $60–75 per month for the least-expensive and smallest sizes, up to $150 for larger sizes. 
+Most storage facilities have daytime hours of operation when you can access the storage units to add or remove property, and are closed to everyone at night.</p>
+<h3><span><a id="recovering-seized-property">Recovering Property Taken During Arrests or Encampment Sweeps</a></span></h3>
+<p>Different agencies take responsibility for clearing homeless camps, depending on where the camps are located.
+These agencies have different policies about whether, to what extent, and for how long they will store property that they clear from encampments, so that the owners of that property can recover it.</p>
+<p>They typically will only store certain items of property, and will discard things that are hazardous, soiled, or decayed or that seem to them like mere trash.
+They often store all items taken from an encampment sweep in one big pile, which can make it difficult for you to find your own items.</p>
+<p>Grover Beach will post a notice <em>after</em> they do an encampment sweep, at the encampment’s former location, “stating where the personal property is being stored, and listing the phone number and hours a person claiming ownership can collect or make arrangements to collect their personal property.” 
+They will store some belongings for 90 days before discarding them. </p>
+<p>Morro Bay stores some property taken during encampment sweeps for 90 days before discarding it. 
+Their policy is to post a notice where they plan to do encampment sweeps 72 hours before they begin, and those notices should include the address, phone number, and operating hours of the location where personal property will be stored. </p>
+<p>SLO City stores some property taken during encampment sweeps for 90 days before discarding it. 
+If you have had property taken in this way, call either the Public Works Department (<a href="tel:+1-805-781-7220" aria-label="Call 805-781-7220">805-781-7220</a>) or the Ranger Service Department (<a href="tel:+1-805-781-7302" aria-label="Call 805-781-7302">805-781-7302</a>) and give them a detailed description of your property. 
+If they think they may have it, you can make an appointment to retrieve it. </p>
+<p>If your property was seized from an camp sweep along the highway, on-ramp / off-ramp, or overpass / underpass, this may have been done by Caltrans.
+They should post notices where they plan to do encampment sweeps 72 hours before they begin, and those notices should include a phone number you can call to get assistance in retrieving your property. 
+If they failed to post notices ahead of time, they should post notices afterwards that describe where items were removed from, a contact number to call to reclaim them, and the date by which they must be reclaimed. 
+They will not sift through belongings to identify valuable items, but if they see “items of apparent value” in plain sight, they will treat them as privately owned, lost, discarded, abandoned, or stolen property and hold it for 90 days after removing it before disposing of it. </p>
+<p>If a different agency from those was responsible for the sweep, try discovering which agency it was, and then contact them directly.</p>
+<p>If you were separated from your property because you were arrested, it is possible that those who arrested you did not make any attempt to secure your belongings.
+They may have just left them wherever they were when you were arrested.
+If they did secure your belongings, they should return these to you when you are released from jail or they should tell you the process you can use to retrieve them, unless they are keeping the property as evidence.</p>
+<p>In the case of the SLO County Sheriff, if they were keeping the property as evidence but then decide to return it to you, they will inform you by sending you a letter that tells you where to retrieve the property. 
+You then have 30 days to retrieve the property, or it may be destroyed. 
+If you do not have a stable mailing address, or if the Sheriffs Department does not know your mailing address, you may never see this letter!
+In such a case, you may want to contact the Sheriffs department to let them know how to contact you if they decide to release your property.</p>
+<hr>
+<h2><span><a id="food">Food</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#free-meals">Free Meals</a></li>
+<li><a href="#free-food-pantries">Free Food Pantries</a></li>
+<li><a href="#little-free-pantries">Little Free Pantries</a></li>
+<li><a href="#food-box-distributions">Food Box Distributions</a></li>
+<li><a href="#summer-meal-sites">Summer Meal Sites (for Children)</a></li>
+<li><a href="#senior-meal-programs">Senior Meal Programs</a></li>
+<li><a href="#calfresh-ebt-wic">CalFresh / EBT (Food Stamps) and WIC</a></li>
+<li><a href="#edible-wild-plants">Edible Wild Plants</a></li>
+</ul>
+
+
+<h3><span><a id="free-meals">Free Meals</a></span></h3>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Meal Provider</th>
+<th>When</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a></td>
+<td data-label="When">5pm daily</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Refuge-Church-Atascadero" aria-label="View directory entry for Refuge Church (Atascadero)"><strong>Refuge Church (Atascadero)</strong></a></td>
+<td data-label="When">5pm Tuesdays &amp; 6pm Wednesdays</td>
+</tr>
+<tr>
+<td data-label="Location">Cal Poly</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Front-Porch" aria-label="View directory entry for Front Porch"><strong>Front Porch</strong></a></td>
+<td data-label="When">Wednesday dinner</td>
+</tr>
+<tr>
+<td data-label="Location">Grover Beach</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Peoples-Kitchen-GB" aria-label="View directory entry for People’s Kitchen (Grover Beach)"><strong>People’s Kitchen (Grover Beach)</strong></a></td>
+<td data-label="When">noon lunch daily</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Los-Osos-Cares" aria-label="View directory entry for Los Osos Cares"><strong>Los Osos Cares</strong></a></td>
+<td data-label="When">5pm Wednesdays</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Morro-Bay-Lions-Foundation" aria-label="View directory entry for Morro Bay Lions Foundation"><strong>Morro Bay Lions Foundation</strong></a></td>
+<td data-label="When">5:30pm Mondays</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a></td>
+<td data-label="When">4:30pm daily</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Meal Provider">Men of <a href="#" data-directory-link="Agape-Church" aria-label="View directory entry for Agape Church"><strong>Agape Church</strong></a></td>
+<td data-label="When">11am most Thursdays</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Blessed-to-Serve" aria-label="View directory entry for Blessed to Serve"><strong>Blessed to Serve</strong></a></td>
+<td data-label="When">5pm Mondays &amp; Thursdays</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Food-Not-Bombs" aria-label="View directory entry for Food Not Bombs"><strong>Food Not Bombs</strong></a></td>
+<td data-label="When">1pm Sundays</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Meal Provider"><a href="#" data-directory-link="Peoples-Kitchen-SLO" aria-label="View directory entry for People’s Kitchen (SLO)"><strong>People’s Kitchen (SLO)</strong></a></td>
+<td data-label="When">noon lunch daily</td>
+</tr>
+</tbody></table>
+<h3><span><a id="free-food-pantries">Free Food Pantries</a></span></h3>
+<p>Food pantries give away unprepared food (such as fresh produce, canned goods, and packaged food).
+Some pantries have special no-cook, no-refrigeration, ready-to-eat options for people who do not have access to kitchens.
+Some give you a pre-prepared box or bag of food, others allow you to select particular items you want.</p>
+
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Pantry</th>
+<th>When</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Nipomo-Community-Presbyterian" aria-label="View directory entry for Nipomo Community Presbyterian"><strong>Nipomo Community Presbyterian</strong></a></td>
+<td data-label="When">Fridays 12:45–1:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="Pantry"><a href="#" data-directory-link="St-Patricks-Church" aria-label="View directory entry for Saint Patrick’s Church"><strong>Saint Patrick’s Church</strong></a> (South County residents only; bring photo ID)</td>
+<td data-label="When">Tuesday–Thursday 4–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Salvation-Army" aria-label="View directory entry for Salvation Army"><strong>Salvation Army</strong></a></td>
+<td data-label="When">Mondays, Wednesdays, Fridays 10am–Noon</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Legacy-Church-Pantry" aria-label="View directory entry for Legacy Church Pantry"><strong>Legacy Church Pantry</strong></a></td>
+<td data-label="When">Thursdays 1–2pm</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Loaves-and-Fishes-Atascadero" aria-label="View directory entry for Loaves and Fishes"><strong>Loaves and Fishes</strong></a> (North County residents only)</td>
+<td data-label="When">Monday–Friday 1–3pm</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Refuge-Church-Atascadero" aria-label="View directory entry for Refuge Church (Atascadero)"><strong>Refuge Church (Atascadero)</strong></a></td>
+<td data-label="When">Tuesday 5–6pm &amp; Wednesday 6–6:30pm, or by appt.</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Restoration-Church" aria-label="View directory entry for Restoration Church"><strong>Restoration Church</strong></a></td>
+<td data-label="When">first Saturday of the month 1–2:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">Cal Poly</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Cal-Poly-Food-Pantry" aria-label="View directory entry for Cal Poly Food Pantry"><strong>Cal Poly Food Pantry</strong></a> (for Cal Poly students and staff)</td>
+<td data-label="When">Monday–Friday 8:30am–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">Cambria</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Cambria-Vineyard-Church" aria-label="View directory entry for Cambria Vineyard Church"><strong>Cambria Vineyard Church</strong></a></td>
+<td data-label="When">second &amp; fourth Thursday Noon–2pm</td>
+</tr>
+<tr>
+<td data-label="Location">Cayucos</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Cayucos-Community-Church" aria-label="View directory entry for Cayucos Community Church"><strong>Cayucos Community Church</strong></a></td>
+<td data-label="When">Wednesdays 10:30–11am</td>
+</tr>
+<tr>
+<td data-label="Location">Cayucos</td>
+<td data-label="Pantry"><a href="#" data-directory-link="St-Josephs-Church" aria-label="View directory entry for St. Joseph’s Catholic Church"><strong>St. Joseph’s Catholic Church</strong></a></td>
+<td data-label="When">Fridays 10am–Noon (Thursdays 7:30–7:45 by appt.)</td>
+</tr>
+<tr>
+<td data-label="Location">Cuesta College</td>
+<td data-label="Pantry"><a href="https://www.cuesta.edu/student-support/support-programs/basic-needs-center/food-resources/index.html" data-external-link="true">Cougar Food Pantry</a> (must be a Cuesta student)</td>
+<td data-label="When">Monday–Friday 9am–4:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">Grover Beach</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Five-Cities-Christian-Women-Food-Pantry" aria-label="View directory entry for Five Cities Christian Women Food Pantry"><strong>Five Cities Christian Women Food Pantry</strong></a> (bring photo ID)</td>
+<td data-label="When">Monday–Friday 2–3:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Kings-Cupboard" aria-label="View directory entry for King’s Cupboard at El Morro Church"><strong>King’s Cupboard at El Morro Church</strong></a></td>
+<td data-label="When">Tuesdays 8–10am</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos</td>
+<td data-label="Pantry"><a href="#" data-directory-link="South-Bay-Seniors-People-Helping-People" aria-label="View directory entry for South Bay Seniors People Helping People"><strong>South Bay Seniors People Helping People</strong></a></td>
+<td data-label="When">Wednesdays 9:30–10:30am</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Trinity-United-Methodist-Church" aria-label="View directory entry for Trinity United Methodist Church (Los Osos)"><strong>Trinity United Methodist Church (Los Osos)</strong></a></td>
+<td data-label="When">Tuesdays &amp; Fridays 10am–Noon</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Morro-Bay-Lions-Foundation" aria-label="View directory entry for Morro Bay Lions Foundation"><strong>Morro Bay Lions Foundation</strong></a></td>
+<td data-label="When">4:30–6:30pm Mondays</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Open-Arms-Pantry" aria-label="View directory entry for Open Arms Pantry at Rock Harbor"><strong>Open Arms Pantry at Rock Harbor</strong></a></td>
+<td data-label="When">Saturdays 9:30–10:30am</td>
+</tr>
+<tr>
+<td data-label="Location">Nipomo</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Nipomo-Food-Basket" aria-label="View directory entry for Nipomo Food Basket"><strong>Nipomo Food Basket</strong></a> (Nipomo residents only)</td>
+<td data-label="When">M/Tu/Th/F 10am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">Nipomo</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Santa-Maria-Valley-Hispanic-Church" aria-label="View directory entry for Santa Maria Valley Hispanic Church"><strong>Santa Maria Valley Hispanic Church</strong></a></td>
+<td data-label="When">Saturdays 11am–12:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a></td>
+<td data-label="When">Monday–Friday 9am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Loaves-and-Fishes-Paso-Robles" aria-label="View directory entry for Loaves and Fishes"><strong>Loaves and Fishes</strong></a></td>
+<td data-label="When">Monday–Thursday 2–4pm (or by appt.)</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a> (for seniors)</td>
+<td data-label="When">second &amp; fourth Tuesday 9:30–11am</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Salvation-Army" aria-label="View directory entry for Salvation Army"><strong>Salvation Army</strong></a> (bring photo ID)</td>
+<td data-label="When">Tuesdays 10–11am</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Pantry">The Link, <a href="#" class="map-link" data-lat="35.639659" data-lon="-120.692709" data-zoom="17" data-label="The Link">626 26th St.</a> admin building #1, <a href="tel:+1-805-503-9638" aria-label="Call 805-503-9638">805-503-9638</a></td>
+<td data-label="When">M–Th 9am–3pm; F 9am–1pm</td>
+</tr>
+<tr>
+<td data-label="Location">Pismo Beach</td>
+<td data-label="Pantry"><a href="#" data-directory-link="New-Life-U-Pick-Pantry" aria-label="View directory entry for New Life U-Pick Pantry"><strong>New Life U-Pick Pantry</strong></a> (1 visit per household per week; bring photo ID)</td>
+<td data-label="When">Tu 6–7pm, W 10am–Noon, Th 1:30–3:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">San Miguel</td>
+<td data-label="Pantry">Children and the Country Life, <a href="#" class="map-link" data-lat="35.744692" data-lon="-120.697947" data-zoom="17" data-label="Children and the Country Life">795 Monterey Rd.</a> (Mission), <a href="tel:+1-805-467-2131;ext=115" aria-label="Call 805-467-2131&nbsp;x115">805-467-2131&nbsp;x115</a></td>
+<td data-label="When">first, third, &amp; fifth Wednesday, 5–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Agape-Church" aria-label="View directory entry for Agape Church"><strong>Agape Church</strong></a></td>
+<td data-label="When">Sundays Noon–12:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Arise-Central-Coast" aria-label="View directory entry for Arise Central Coast"><strong>Arise Central Coast</strong></a></td>
+<td data-label="When">Mondays 2:30–4:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry">Breakthrough Ministry, <a href="#" class="map-link" data-lat="35.241737" data-lon="-120.676108" data-zoom="17" data-label="Breakthrough Ministry">4251 South Higuera #200</a>, <a href="tel:+1-805-234-7441" aria-label="Call 805-234-7441">805-234-7441</a></td>
+<td data-label="When">Tuesdays 2–3pm, or by appt.</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="GALA" aria-label="View directory entry for GALA Pride &amp; Diversity Center"><strong>GALA Pride &amp; Diversity Center</strong></a></td>
+<td data-label="When">Monday–Friday 10am–3pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Grace-Central-Coast" aria-label="View directory entry for Grace Central Coast"><strong>Grace Central Coast</strong></a> “God’s Storehouse”</td>
+<td data-label="When">Saturdays 8:30–9:15am</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Outreach-and-Engagement-Services" aria-label="View directory entry for Outreach and Engagement Services"><strong>Outreach and Engagement Services</strong></a></td>
+<td data-label="When">Monday–Friday 10am–3pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Renovate-Church" aria-label="View directory entry for Renovate Church"><strong>Renovate Church</strong></a></td>
+<td data-label="When">Mondays 4–6pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Salvation-Army" aria-label="View directory entry for Salvation Army"><strong>Salvation Army</strong></a> (bring photo ID)</td>
+<td data-label="When">W/F 10am–Noon, Th 2–4pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="SLO-Food-Bank" aria-label="View directory entry for SLO Food Bank"><strong>SLO Food Bank</strong></a></td>
+<td data-label="When">Mondays, Wednesdays, Fridays Noon–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="SLO-Grassroots" aria-label="View directory entry for SLO Grassroots"><strong>SLO Grassroots</strong></a></td>
+<td data-label="When">by appointment only</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a> “We Care Food Share”</td>
+<td data-label="When">Wednesdays 3–4:30pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for Veterans Services"><strong>Veterans Services</strong></a> (for veterans only)</td>
+<td data-label="When">daily 8am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location">SLO</td>
+<td data-label="Pantry"><a href="#" data-directory-link="Zion-Lutheran-Church" aria-label="View directory entry for Zion Lutheran Church"><strong>Zion Lutheran Church</strong></a></td>
+<td data-label="When">Wednesdays 9:30–11:30am</td>
+</tr>
+</tbody></table>
+
+
+<h3><span><a id="little-free-pantries">Little Free Pantries</a></span></h3>
+<p>Little free pantries are small boxes erected in neighborhoods and maintained by the people who live nearby.
+They are self-serve and open 24/7.
+They are stocked by people who have extra things to give away.
+You never know quite what you will find there, but there is usually some canned and packaged non-perishable food, and sometimes toiletries and other small essentials.</p>
+<p>Sometimes people put perishable food in little free pantries, but you should beware of eating such food as it may have been there for a while and may no longer be safe to eat.</p>
+<p>See <a href="#" data-directory-link="Little-Free-Pantries" aria-label="View directory entry for Little Free Pantries"><strong>Little Free Pantries</strong></a> in the <a href="Directory.md">Directory</a> for a list of locations.</p>
+<h3><span><a id="food-box-distributions">Food Box Distributions</a></span></h3>
+<p>The <a href="#" data-directory-link="SLO-Food-Bank" aria-label="View directory entry for SLO Food Bank"><strong>SLO Food Bank</strong></a> gives away food boxes on a regular schedule at a variety of locations in SLO County.
+Visit <a href="https://findfoodslo.org/" data-external-link="true">findfoodslo.org</a> for a complete list and schedule of these “Neighborhood Food Distributions.”</p>
+<h3><span><a id="summer-meal-sites">Summer Meal Sites (for Children)</a></span></h3>
+<p>The California Department of Education has a “Summer Food Service Program” to help children during the Summer school break who usually get meals at school. 
+This program is open to all children in the community. 
+You can find a list of <a href="https://www.cde.ca.gov/ds/sh/sn/summersites.asp" data-external-link="true">Summer Meal Sites</a> in San Luis Obispo County at the California Department of Education website.</p>
+<h3><span><a id="senior-meal-programs">Senior Meal Programs</a></span></h3>
+<p><a href="#" data-directory-link="Meals-that-Connect" aria-label="View directory entry for Meals that Connect"><strong>Meals that Connect</strong></a> has several sites in SLO County where they serve free, hot communal lunches every weekday. 
+The program is for people aged 60 and above. 
+You must complete an application to join the program, and you must reserve your meals two days in advance. 
+They also can deliver meals to your home if you are homebound. </p>
+<p><a href="#" data-directory-link="5Cities-Meals-on-Wheels" aria-label="View directory entry for Five Cities Meals on Wheels"><strong>Five Cities Meals on Wheels</strong></a> is a similar program specific to the Five Cities area that provides daily meals, delivered to the homes of people who cannot prepare nutritious meals for themselves and do not have caretakers who can do so. 
+They serve homebound neighbors in Arroyo Grande, Grover Beach, Oceano, Pismo Beach, and Shell Beach. 
+They serve seniors and people with temporary or permanent disabilities. </p>
+<p>Low-income seniors (aged 60 and above) can get $20–50 in credit to use at participating farmers markets from the California Department of Food and Agriculture. 
+There is limited availability, so if the program runs out of credits you may have to wait until their next budget to apply.
+Learn more about the program and apply to join it at <a href="https://www.cdfa.ca.gov/SeniorFarmersMrktNutritionPrgm/" data-external-link="true">their website</a>.
+Qualifying farmers markets include: </p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>When</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="When">Saturday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="When">Wednesday morning</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="When">Wednesday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Cambria</td>
+<td data-label="When">Friday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos (Baywood)</td>
+<td data-label="When">Monday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="When">Saturday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="When">Thursday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="When">Tuesday morning</td>
+</tr>
+<tr>
+<td data-label="Location">SLO (downtown)</td>
+<td data-label="When">Thursday evening</td>
+</tr>
+<tr>
+<td data-label="Location">SLO (Madonna)</td>
+<td data-label="When">Saturday morning</td>
+</tr>
+<tr>
+<td data-label="Location">SLO (Tank Farm)</td>
+<td data-label="When">Tuesday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Templeton</td>
+<td data-label="When">Saturday morning</td>
+</tr>
+</tbody></table>
+<h3><span><a id="calfresh-ebt-wic">CalFresh / EBT (Food Stamps) and WIC</a></span></h3>
+<p>The CalFresh program is California’s version of the federal nutrition program known as “SNAP” or “food stamps.” 
+If you have a low income, California gives you an “EBT card” which you can use like a debit card at grocery stores and farmers markets to buy healthy foods. </p>
+<p>You can apply for CalFresh on-line at either of the following sites:</p>
+<ul>
+<li><a href="https://benefitscal.com/" data-external-link="true">BenefitsCal.com</a> </li>
+<li><a href="https://www.getcalfresh.org/" data-external-link="true">GetCalFresh.org</a> </li>
+</ul>
+<p>You can also apply in person at the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>. </p>
+<p>If you are a Cal Poly student, you can get assistance from the <a href="https://www.calfreshcalpoly.org/" data-external-link="true">Cal Poly CalFresh Program</a>.</p>
+<p>You will need some identification document, proof of income, and (for students) indication of student status, and (for non-citizens) immigration status. 
+Suitable proof of income includes pay stubs from last 30 days, an employer letter on company letterhead, tax forms (1040, W-2, 1099), self-employment profit/loss statement or ledger, or a signed written statement if you do not have those documents. 
+See <a href="https://calfresh.guide/verifications-the-calfresh-office-requires/" data-external-link="true">calfresh.guide</a> for more details.</p>
+<p>Some local farmers markets will double up to $15 in CalFresh benefits that you spend at the market, so you can get twice as much food for your money (see <a href="https://www.slocountyfarmers.org/snap" data-external-link="true">slocountyfarmers.org</a> for details): </p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>When</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="When">Wednesday morning</td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="When">Wednesday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Cambria</td>
+<td data-label="When">Friday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Los Osos (Baywood)</td>
+<td data-label="When">Monday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="When">Thursday afternoon</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="When">Tuesday morning</td>
+</tr>
+<tr>
+<td data-label="Location">SLO (downtown)</td>
+<td data-label="When">Thursday evening</td>
+</tr>
+<tr>
+<td data-label="Location">SLO (Madonna)</td>
+<td data-label="When">Saturday morning</td>
+</tr>
+<tr>
+<td data-label="Location">Templeton</td>
+<td data-label="When">Saturday morning</td>
+</tr>
+</tbody></table>
+<p>The <a href="#" data-directory-link="WIC" aria-label="View directory entry for Women, Infants, and Children (WIC)"><strong>Women, Infants, and Children (WIC)</strong></a> program also provides E-WIC debit cards with which you can buy certain types of food from farmers markets and WIC-approved groceries. </p>
+<h3><span><a id="edible-wild-plants">Edible Wild Plants</a></span></h3>
+<p>There are many edible wild plants available in SLO County.
+When they are in season, they can add nutrition to your diet.</p>
+<blockquote>
+<p><strong>Caution:</strong> Some wild plants are poisonous.
+You should only forage for wild plants if you know what you are doing.
+Also: beware of foraging plants in agricultural or well-tended areas, as they may have been treated with pesticides.
+Don’t forage plants from waste sites, stagnant water areas, or areas subject to agricultural or industrial run-off, as the plants may absorb toxins or parasites from the soil or water.</p>
+</blockquote>
+<p>Some common edible plants in SLO County are: </p>
+<table>
+<thead>
+<tr>
+<th>Plant</th>
+<th>Season</th>
+<th>Edible Part</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Fragaria_chiloensis" data-external-link="true">Beach Strawberry</a></td>
+<td data-label="Season">Spring–Summer</td>
+<td data-label="Edible Part">Berries</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Rubus_ursinus" data-external-link="true">Blackberries</a></td>
+<td data-label="Season">Summer</td>
+<td data-label="Edible Part">Berries</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Scirpus_microcarpus" data-external-link="true">Bulrush</a></td>
+<td data-label="Season">All year</td>
+<td data-label="Edible Part">Most parts, but should be cooked</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Typha_latifolia" data-external-link="true">Cattail</a></td>
+<td data-label="Season">All year</td>
+<td data-label="Edible Part">Most parts, but should be cooked</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Ribes_malvaceum" data-external-link="true">Chaparral Currant</a></td>
+<td data-label="Season">Spring</td>
+<td data-label="Edible Part">Berries</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Salvia_columbariae" data-external-link="true">Chia</a></td>
+<td data-label="Season">Fall</td>
+<td data-label="Edible Part">Seeds</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Chrysolepis_chrysophylla" data-external-link="true">Chinquapin</a></td>
+<td data-label="Season">Fall</td>
+<td data-label="Edible Part">Nuts</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Cyperus_esculentus" data-external-link="true">Chufa/Nutgrass</a></td>
+<td data-label="Season">Fall</td>
+<td data-label="Edible Part">Tubers</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Taraxacum_officinale" data-external-link="true">Dandelion</a></td>
+<td data-label="Season">Spring–Fall</td>
+<td data-label="Edible Part">All parts</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Gooseberry" data-external-link="true">Gooseberry</a></td>
+<td data-label="Season">Spring</td>
+<td data-label="Edible Part">Berries</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Prunus_ilicifolia" data-external-link="true">Hollyleaf Cherry</a></td>
+<td data-label="Season">Summer–Fall</td>
+<td data-label="Edible Part">Berries</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Claytonia_perfoliata" data-external-link="true">Miner’s Lettuce</a></td>
+<td data-label="Season">All year</td>
+<td data-label="Edible Part">All parts</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Tropaeolum_majus" data-external-link="true">Nasturtium</a></td>
+<td data-label="Season">Spring–Summer</td>
+<td data-label="Edible Part">Flowers and leaves</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Opuntia" data-external-link="true">Prickly Pear</a></td>
+<td data-label="Season">Summer–Fall</td>
+<td data-label="Edible Part">Fruit (but covered in annoying spines)</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Rubus_parviflorus" data-external-link="true">Thimbleberry</a></td>
+<td data-label="Season">Summer</td>
+<td data-label="Edible Part">Berries</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Watercress" data-external-link="true">Watercress</a></td>
+<td data-label="Season">Spring–Summer</td>
+<td data-label="Edible Part">Leaves</td>
+</tr>
+<tr>
+<td data-label="Plant"><a href="https://en.wikipedia.org/wiki/Mustard_plant" data-external-link="true">Wild Mustard</a></td>
+<td data-label="Season">Spring</td>
+<td data-label="Edible Part">Flowers and leaves</td>
+</tr>
+</tbody></table>
+<p>Sometimes you will also see edible fruit trees like plums or cherries on sidewalks, in parks, or in other public places.</p>
+<p>Sometimes also people plant fruit trees on their own property but then neglect to harvest the fruit, perhaps because there is more than they need.
+In such a case you can ask the property owner for permission to harvest from their trees.</p>
+<hr>
+<h2><span><a id="refill-a-water-bottle">Where to Refill a Water Bottle</a></span></h2>
+<p>Most major parks and recreation facilities have water fountains and/or water bottle refill stations, as do some public libraries. </p>
+<p>The city of SLO also has a water bottle filling station network.
+Some of these stations are inside buildings and are only accessible when the building is open for business.
+Others are outside and are available 24/7.
+You can find a map of these hydration stations <a href="https://storymaps.arcgis.com/stories/ac825840143c4d718e06397d5306fa89" data-external-link="true">at this link</a> or at <a href="https://www.google.com/maps/d/u/0/viewer?mid=1ojOfK6l3mkAh6JIfFJZwA5ej5Qj232No&amp;ll=35.27079109833796%2C-120.65453885&amp;z=15" data-external-link="true">Google Maps</a>.</p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>How to find it</th>
+<th>Hours</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.251283" data-lon="-120.645911" data-zoom="17" data-label="Hydration Station">Damon/Garcia field</a></td>
+<td data-label="How to find it">across from restroom</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.280356" data-lon="-120.662272" data-zoom="17" data-label="Hydration Station">872 Higuera St.</a></td>
+<td data-label="How to find it">outside</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2795637" data-lon="-120.6613599" data-zoom="17" data-label="Hydration Station">893 Marsh St.</a></td>
+<td data-label="How to find it">outside</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.282128" data-lon="-120.662857" data-zoom="17" data-label="Hydration Station">919 Palm St.</a></td>
+<td data-label="How to find it">just inside the door</td>
+<td data-label="Hours">M–F 8am–4pm</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2828735" data-lon="-120.6626363" data-zoom="17" data-label="Hydration Station">990 Palm St. </a></td>
+<td data-label="How to find it">down the hall</td>
+<td data-label="Hours">M–F 8am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2827766" data-lon="-120.662756" data-zoom="17" data-label="Hydration Station">990 Palm St. </a></td>
+<td data-label="How to find it">down the hall</td>
+<td data-label="Hours">M–F 8am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2827536" data-lon="-120.6626956" data-zoom="17" data-label="Hydration Station">990 Palm St. </a></td>
+<td data-label="How to find it">downstairs</td>
+<td data-label="Hours">M–F 8am–5pm</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2897302" data-lon="-120.6643515" data-zoom="17" data-label="Hydration Station">Santa Rosa Park</a></td>
+<td data-label="How to find it">near parking lot</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2902945" data-lon="-120.6644515" data-zoom="17" data-label="Hydration Station">Santa Rosa Park</a></td>
+<td data-label="How to find it">near skate park</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.284345" data-lon="-120.660815" data-zoom="17" data-label="Hydration Station">864 Santa Rosa St.</a></td>
+<td data-label="How to find it">inside, near gym</td>
+<td data-label="Hours">M–F 9am–6pm</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2902945" data-lon="-120.6644515" data-zoom="17" data-label="Hydration Station">Sinsheimer Park</a></td>
+<td data-label="How to find it">near playground</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2673584" data-lon="-120.6467609" data-zoom="17" data-label="Hydration Station">Sinsheimer Park</a></td>
+<td data-label="How to find it">outside statium</td>
+<td data-label="Hours">24/7</td>
+</tr>
+<tr>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.2666459" data-lon="-120.6446262" data-zoom="17" data-label="Hydration Station">900 Southwood</a></td>
+<td data-label="How to find it">in the swim center</td>
+<td data-label="Hours">M–F 6–8am, 11:30–3:30pm, 5:30–7pm; Sa/Su 11:30–1:30pm</td>
+</tr>
+</tbody></table>
+<hr>
+<h2><span><a id="transportation">Transportation</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#public-transit">Public Transit</a></li>
+<li><a href="#transportation-for-seniors">Transportation Resources for Seniors</a></li>
+<li><a href="#transportation-to-medical-appointments">Transportation to Medical Appointments</a></li>
+<li><a href="#bicycles">Bicycles</a></li>
+<li><a href="#auto-insurance-and-repair">Automobile Insurance and Repair</a></li>
+</ul>
+<h3><span><a id="public-transit">Public Transit</a></span></h3>
+<p>There are many public transit options in SLO County.
+The <a href="https://rideshare.org/" data-external-link="true">Rideshare</a> website and the <a href="tel:+1-511" aria-label="Call 511">511</a> phone service can give you an overview of most of them and can help you plan your trips.</p>
+<p>The <a href="#" data-directory-link="SLO-RTA" aria-label="View directory entry for SLO Regional Transit Authority"><strong>SLO Regional Transit Authority</strong></a> system includes several bus routes that connect cities in SLO County.
+They also govern the city bus routes in Morro Bay and Paso Robles, and the dial-a-ride and Runabout Paratransit services.
+You can buy bus passes on the bus or by using the <a href="https://tokentransit.com/riders/download" data-external-link="true">Token Transit</a> app.</p>
+<p>There are discounts for seniors (age 65+), medicare card holders, and people with disabilities. 
+You must apply in person at the RTA office to get a discount card. 
+People over the age of 80 and people with an ADA-certified disability ride free. </p>
+<table>
+<thead>
+<tr>
+<th>RTA Line</th>
+<th>Destinations</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-9/" data-external-link="true">9</a></td>
+<td data-label="Destinations">San Miguel, Paso Robles, Templeton, Atascadero, Santa Margarita, SLO</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-10/" data-external-link="true">10</a></td>
+<td data-label="Destinations">Santa Maria, Nipomo, Arroyo Grande, Pismo Beach, SLO</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-12-2/" data-external-link="true">12</a></td>
+<td data-label="Destinations">Los Osos, Morro Bay, SLO</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-15/" data-external-link="true">15</a></td>
+<td data-label="Destinations">San Simeon, Cambria, Cayucos, Morro Bay</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-21/" data-external-link="true">21</a></td>
+<td data-label="Destinations">Pismo Beach, Arroyo Grande, Grover Beach</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-24/" data-external-link="true">24</a></td>
+<td data-label="Destinations">Pismo Beach, Grover Beach</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/route-27/" data-external-link="true">27</a> &amp; <a href="https://www.slorta.org/schedules-fares/route-28/" data-external-link="true">28</a></td>
+<td data-label="Destinations">Grover Beach, Arroyo Grande, Oceano</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/paso-express/" data-external-link="true">A &amp; B</a></td>
+<td data-label="Destinations">Paso Robles</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/avila-trolley/" data-external-link="true">Avila-Pismo Beach Trolley</a></td>
+<td data-label="Destinations">Port San Luis, Avila Beach, Pismo Beach</td>
+</tr>
+<tr>
+<td data-label="RTA Line"><a href="https://www.slorta.org/schedules-fares/morro-bay-transit/" data-external-link="true">Morro Bay Transit</a></td>
+<td data-label="Destinations">Morro Bay</td>
+</tr>
+</tbody></table>
+<p><a href="https://www.slorta.org/services/runabout-paratransit/" data-external-link="true">Runabout Paratransit</a> is a county-wide transit service for people who cannot always use the fixed-route SLO RTA buses because of disability. 
+This service will take you door-to-door within ¾-mile of the RTA fixed routes during the same hours RTA operates. 
+One personal care attendant can accompany you free-of-charge. 
+You have to apply and have an in-person interview to be eligible for this service (see <a href="#" data-directory-link="SLO-RTA" aria-label="View directory entry for SLO Regional Transit Authority"><strong>SLO Regional Transit Authority</strong></a> for contact information). 
+After you register, make ride reservations 1–7 days in advance by calling <a href="tel:+1-805-541-2544" aria-label="Call 805-541-2544">805-541-2544</a>. 
+Rides are not free; they cost about twice as much as ordinary RTA rides. 
+However people who qualify to use Runabout Paratransit can also ride the ordinary RTA service for free. </p>
+<p><a href="#" data-directory-link="SLO-Transit" aria-label="View directory entry for SLO Transit"><strong>SLO Transit</strong></a> is the San Luis Obispo city bus system.
+You can use the <a href="https://slo.rider.peaktransit.com/" data-external-link="true">SLO Transit RiderPortal</a> website or phone app (<a href="https://itunes.apple.com/us/app/slo-transit/id458554556?mt=8" data-external-link="true">iPhone</a>, <a href="https://play.google.com/store/apps/details?id=edu.calpoly.android.SloBusMapper&amp;hl=en" data-external-link="true">Android</a>) to view routes and to see when the next bus is due to arrive.
+You can buy bus passes on the bus or by using the <a href="https://tokentransit.com/riders/download" data-external-link="true">Token Transit</a> app.
+(Another option for viewing bus arrival times and for planning travel is the <a href="https://moovitapp.com/index/en/public_transit-San_Luis_Obispo_CA-4003" data-external-link="true">moovit</a> app.)
+There are discounts for seniors and disabled people (you may need to <a href="https://forms.slocity.org/Forms/SDPassApp" data-external-link="true">apply for a special card</a>), and for children. 
+If you buy a regional day pass from SLO RTA, that also lets you ride SLO Transit buses. </p>
+<p>Some service providers can give you a bus pass if you cannot afford to buy one.
+For example, <a href="#" data-directory-link="Catholic-Charities" aria-label="View directory entry for Catholic Charities"><strong>Catholic Charities</strong></a> 
+and the <a href="#" data-directory-link="Society-of-St-Vincent-de-Paul" aria-label="View directory entry for Society of St. Vincent de Paul"><strong>Society of St. Vincent de Paul</strong></a> often have bus passes available to people who need them. 
+Clients of <a href="#" data-directory-link="Tri-Counties-Regional-Center" aria-label="View directory entry for Tri-Counties Regional Center"><strong>Tri-Counties Regional Center</strong></a> can get bus passes from them. 
+The <a href="#" data-directory-link="Family-Care-Network" aria-label="View directory entry for Family Care Network"><strong>Family Care Network</strong></a> can help you get a bus pass if you cannot afford one on your own (you may first need to get a referral from a <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> Employment Resource Specialist). </p>
+<p>You can find carpool options locally by using the <a href="https://irideshare.org/#/" data-external-link="true">iRideshare</a> web application, a free program for SLO County commuters.
+The application matches commuters based on their locations, routes, destinations, and schedules to try to match them into compatible carpools.</p>
+<p>If you register for iRideshare and you commute to work by walking, biking, taking the bus, or in a carpool or vanpool, and you need to get home from work in some other way (for example, because the carpool is leaving at the wrong time, or because your bike broke), the <a href="https://rideshare.org/program/guaranteed-ride-home/" data-external-link="true">Guaranteed Ride Home</a> program will pay for your taxi, Uber, or Lyft ride home.
+(You need to register for their Commuter Club program, save your ride payment receipt, and you can only get a limited number of guaranteed rides home.) </p>
+<p>There are <a href="https://www.slorta.org/services/dial-a-ride/" data-external-link="true">Dial-A-Ride</a> services in Atascadero, Morro Bay, Nipomo, Paso Robles, Shandon, and Templeton.
+They typically offer curb-to-curb service and charge $2.25–8.00 each way (sometimes less for seniors, disabled people, and children): </p>
+
+<table>
+<thead>
+<tr>
+<th>Dial-a-Ride Service</th>
+<th>Phone Number</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Dial-a-Ride Service">Atascadero</td>
+<td data-label="Phone Number"><a href="tel:+1-805-466-7433" aria-label="Call 805-466-7433">805-466-7433</a></td>
+<td data-label="Notes">Operates M–F 7:30am–3:30pm.</td>
+</tr>
+<tr>
+<td data-label="Dial-a-Ride Service">Morro Bay</td>
+<td data-label="Phone Number"><a href="tel:+1-805-541-2228;ext=3" aria-label="Call 805-541-2228&nbsp;x3">805-541-2228&nbsp;x3</a></td>
+<td data-label="Notes">Must be within ¾-mile of a transit bus route. Call M–F 7:30am–6:30pm to request a ride.</td>
+</tr>
+<tr>
+<td data-label="Dial-a-Ride Service">Nipomo</td>
+<td data-label="Phone Number"><a href="tel:+1-805-929-2881" aria-label="Call 805-929-2881">805-929-2881</a></td>
+<td data-label="Notes">Reserve a ride at least two hours ahead of time. Operates M–F 7am–6:30pm.</td>
+</tr>
+<tr>
+<td data-label="Dial-a-Ride Service">Paso Robles</td>
+<td data-label="Phone Number"><a href="tel:+1-805-239-8747" aria-label="Call 805-239-8747">805-239-8747</a></td>
+<td data-label="Notes">Reserve a ride at least two hours ahead of time. Operates M–F 7am–1pm.</td>
+</tr>
+<tr>
+<td data-label="Dial-a-Ride Service">Shandon</td>
+<td data-label="Phone Number"><a href="tel:+1-805-541-2544" aria-label="Call 805-541-2544">805-541-2544</a></td>
+<td data-label="Notes">Reserve a ride by noon the day ahead of time. Operates M,W,F 8am–5pm.</td>
+</tr>
+<tr>
+<td data-label="Dial-a-Ride Service">Templeton</td>
+<td data-label="Phone Number"><a href="tel:+1-805-541-2544" aria-label="Call 805-541-2544">805-541-2544</a></td>
+<td data-label="Notes">Reserve a ride by noon the day ahead of time. Operates Tu,Th 8am–5pm.</td>
+</tr>
+</tbody></table>
+<p><a href="https://www.greyhound.com/" data-external-link="true">Greyhound</a> and <a href="https://trailways.com/" data-external-link="true">Trailways</a> operate between-cities bus routes.
+<a href="https://www.amtrak.com/" data-external-link="true">Amtrak</a> has rail lines and buses that run all over the U.S.
+Although they are best-known for their trains, their bus service can often out-compete Trailways and Greyhound on price, speed, and convenience.
+You can catch these trains and buses from the following locations in SLO County:</p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Greyhound</th>
+<th>Trailways</th>
+<th>Amtrak train</th>
+<th>Amtrak bus</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">Atascadero Amtrak Bus Stop, <a href="#" class="map-link" data-lat="35.488920" data-lon="-120.664716" data-zoom="17" data-label="Amtrak Bus Stop">6000 Capistrano Ave., Atascadero</a></td>
+<td data-label="Greyhound">Yes</td>
+<td data-label="Trailways">No</td>
+<td data-label="Amtrak train">No</td>
+<td data-label="Amtrak bus">Yes</td>
+</tr>
+<tr>
+<td data-label="Location">Grover Beach Amtrak Station, <a href="#" class="map-link" data-lat="35.120481" data-lon="-120.629016" data-zoom="17" data-label="Amtrak Station">180 W. Grand Ave., Grover Beach</a></td>
+<td data-label="Greyhound">Yes</td>
+<td data-label="Trailways">No</td>
+<td data-label="Amtrak train">Yes</td>
+<td data-label="Amtrak bus">Yes</td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles Train Station, <a href="#" class="map-link" data-lat="35.622688" data-lon="-120.687770" data-zoom="17" data-label="Train Station">800 Pine St., Paso Robles</a></td>
+<td data-label="Greyhound">Yes</td>
+<td data-label="Trailways">No</td>
+<td data-label="Amtrak train">Yes</td>
+<td data-label="Amtrak bus">Yes</td>
+</tr>
+<tr>
+<td data-label="Location">Cal Poly, <a href="#" class="map-link" data-lat="35.298858" data-lon="-120.655675" data-zoom="17" data-label="Bus Stop">1 Grand Ave., SLO</a></td>
+<td data-label="Greyhound">Yes</td>
+<td data-label="Trailways">No</td>
+<td data-label="Amtrak train">No</td>
+<td data-label="Amtrak bus">Yes</td>
+</tr>
+<tr>
+<td data-label="Location">Railroad Museum, <a href="#" class="map-link" data-lat="35.273127" data-lon="-120.655653" data-zoom="17" data-label="Railroad Museum">1940 Santa Barbara Ave., SLO</a></td>
+<td data-label="Greyhound">Yes</td>
+<td data-label="Trailways">Yes</td>
+<td data-label="Amtrak train">No</td>
+<td data-label="Amtrak bus">No</td>
+</tr>
+<tr>
+<td data-label="Location">Train Station, <a href="#" class="map-link" data-lat="35.275632" data-lon="-120.655133" data-zoom="17" data-label="Train Station">1011 Railroad Ave., SLO </a></td>
+<td data-label="Greyhound">Yes</td>
+<td data-label="Trailways">No</td>
+<td data-label="Amtrak train">Yes</td>
+<td data-label="Amtrak bus">Yes</td>
+</tr>
+</tbody></table>
+<p>Recent refugees from other countries can also get help with transportation from <a href="#" data-directory-link="SLO4Home" aria-label="View directory entry for SLO for HOME"><strong>SLO for HOME</strong></a>. </p>
+<h3><span><a id="transportation-for-seniors">Transportation Resources for Seniors</a></span></h3>
+<p>Many transit services offer reduced fares for seniors.
+People aged 80 and older ride for free on all SLO RTA and SLO Transit routes. 
+In addition, there are some transit options specifically for seniors.</p>
+<p>For example, the <a href="#" data-directory-link="Senior-Go" aria-label="View directory entry for Senior Go!"><strong>Senior Go!</strong></a> service serves people aged 65 and up. 
+It serves all of SLO County, and all trips must be in SLO County. 
+Call to book a curb-to-curb ride two to three days in advance. 
+You can reserve up to four round-trips per month. 
+The cost is $5 for short trips (0–20 miles) or $10 for longer trips. </p>
+<p>The <a href="https://www.cambriacommunitycouncil.org/community-bus" data-external-link="true">Cambria Community Bus</a> is a free service for seniors (aged 60 and up) and disabled people in the Cambria/San Simeon area. 
+Call <a href="tel:+1-805-927-4173" aria-label="Call 805-927-4173">805-927-4173</a> (español <a href="tel:+1-805-975-5724" aria-label="Call 805-975-5724">805-975-5724</a>) M–F 9–11am at least one day in advance to make a reservation for a ride. 
+Rides are door-to-door service and can include multiple stops. 
+The bus only operates on weekdays 8am–4:30pm, and in the local area (except for Tuesdays, when the bus can also do trips to SLO city). </p>
+<p>The <a href="https://cayucosseniors.org/files/Cayucos%20Senior%20Van%20-%20Mission%20Statement.pdf" data-external-link="true">Cayucos Senior Van</a> is a similar program for residents of Cayucos.
+It prioritizes transportation to medical appointments, but can also sometimes handle other needs. 
+It operates M–F 9am–4pm. 
+Call <a href="tel:+1-805-995-3543" aria-label="Call 805-995-3543">805-995-3543</a> to make an appointment at least 48 hours ahead of time. </p>
+<p><a href="#" data-directory-link="Community-Partners-in-Caring" aria-label="View directory entry for Community Partners in Caring"><strong>Community Partners in Caring</strong></a> has volunteers who can give seniors free rides to and from medical appointments, food banks and meal sites, or other services. 
+They operate in Nipomo and the Five-Cities area, as well as Santa Barbara County. </p>
+<h3><span><a id="transportation-to-medical-appointments">Transportation to Medical Appointments</a></span></h3>
+<p>The <a href="https://www.cencalhealth.org/members/transportation/" data-external-link="true">CenCal/Medi-Cal Shuttle</a> offers free, door-to-door transportation to medical appointments for people who are enrolled in Medi-Cal and who cannot use public transportation to get to their appointments. 
+If you expect you will need to stop at a pharmacy after your appointment, say so when you make your shuttle reservation, and they can arrange that also. 
+Make a shuttle reservation at least two days before your medical appointment by calling <a href="tel:+1-855-659-4600" aria-label="Call 855-659-4600">855-659-4600</a> M–F 7am–5pm. </p>
+<p>If you are a <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast (CHC)"><strong>Community Health Centers of the Central Coast (CHC)</strong></a> patient, and you need a ride to your CHC appointment, you can get shuttle service. 
+The CHC Shuttle collects you at your location and takes you to the clinic, then returns you after your appointment. 
+To use the shuttle, you should have a CHC appointment and live in the area of the CHC clinic. 
+CHC may also give you an RTA bus pass to help you get to your appointment. 
+Make a reservation at least 48 hours before your appointment by calling <a href="tel:+1-877-743-3242" aria-label="Call 877-743-3242">877-743-3242</a>. </p>
+<p>Veterans who travel to VA health care facilities for VA-authorized appointments can get free curb-to-curb shuttle service through <a href="#" data-directory-link="Veterans-Transportation-Service" aria-label="View directory entry for Veterans Transportation Service (VTS)"><strong>Veterans Transportation Service (VTS)</strong></a>. 
+Another option is the <a href="https://www.ride-on.org/ride-on-veterans-express-shuttle.php" data-external-link="true">“Veterans Express Shuttle”</a> operated by <a href="#" data-directory-link="Ride-On-Transportation" aria-label="View directory entry for Ride-On Transportation"><strong>Ride-On Transportation</strong></a> (call <a href="tel:+1-805-541-8747" aria-label="Call 805-541-8747">805-541-8747</a> two to three days before your appointment). 
+There is also regularly-scheduled bus service between the SLO Veteran’s Memorial Building (<a href="#" class="map-link" data-lat="35.289321" data-lon="-120.652800" data-zoom="17" data-label="Veterans Memorial Building">801 Grand Ave.</a>) and the West Los Angeles VA Medical Center (WLA). 
+This bus is free to anyone with an appointment at the VA. 
+Schedule a bus reservation through VTS. 
+It leaves SLO at 6am, arrives at WLA at 11:15am, leaves WLA at 3:25pm and returns to SLO at 8:30pm. </p>
+<p>The <a href="#" data-directory-link="American-Cancer-Society" aria-label="View directory entry for American Cancer Society"><strong>American Cancer Society</strong></a>’s <a href="https://www.cancer.org/support-programs-and-services/road-to-recovery.html" data-external-link="true">“Road to Recovery”</a> program offers free rides to and from cancer-related medical appointments.
+Call several days in advance of your appointment to reserve your ride. </p>
+<h3><span><a id="bicycles">Bicycles</a></span></h3>
+<p>The <a href="#" data-directory-link="Bike-Kitchen" aria-label="View directory entry for Bike Kitchen"><strong>Bike Kitchen</strong></a> in SLO city can help you learn how to do maintenance and repairs on your bicycle, and can give you access to the tools and supplies you need. 
+They also sell refurbished bicycles at low prices. 
+Visit their website to see their current schedule. 
+They charge a small fee ($10/hr) to use their repair/maintenance services. </p>
+<p>Here are some tips for keeping your bike safe if you are camping:</p>
+<ul>
+<li>Lock bikes together when you camp with multiple people.</li>
+<li>Position your bike near your tent and thread one of the tent’s guy-lines through the wheel, so your tent will shake if someone moves the bike.</li>
+<li>Use multiple locks (for example, a U-lock and a cable). Avoid using cable locks only, as they are relatively easy to break.</li>
+<li>Consider using a lock that makes an audible alarm when it is tampered with.</li>
+</ul>
+<h3><span><a id="auto-insurance-and-repair">Automobile Insurance and Repair</a></span></h3>
+<p>A car must be insured to be legally driven in California. 
+California has a state-sponsored, low-cost auto insurance program. 
+To qualify, you must have a valid California driver’s license, a low income (for a single person, under $39,125 per year), a vehicle that is worth no more than $25,000, and have:</p>
+
+<ul>
+<li>no more than one at-fault, property-damage-only accident or no more than one point for a moving violation in the past three years,</li>
+<li>no at-fault accidents involving bodily injury or death on a driving record in the previous three years, and</li>
+<li>no felony or misdemeanor convictions for a violation of the Vehicle Code on your motor vehicle driving record.</li>
+</ul>
+<p>You can apply for this insurance on-line at <a href="https://www.mylowcostauto.com" data-external-link="true">mylowcostauto.com</a> or by calling <a href="tel:+1-866-602-8861" aria-label="Call 866-602-8861">866-602-8861</a>. </p>
+<p>The <a href="#" data-directory-link="Family-Care-Network" aria-label="View directory entry for Family Care Network"><strong>Family Care Network</strong></a> can help you pay for car repairs, payments, and gas if you’re broke.
+You may first need to get a referral from a <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> Employment Resource Specialist.</p>
+<p>The <a href="https://www.bar.ca.gov/cap" data-external-link="true">California Bureau of Automotive Repair (CAP)</a>’s “Consumer Assistance Program” can help you fix your car so that it satisfies California emissions standards. 
+This program will pay for up to $1,450 in necessary repairs at a STAR test-and-repair center for model year 1996 or newer vehicles, or up to $1,100 for 1976–1995 vehicles. 
+To qualify, you must verify that you have a household income below 225% of the federally-set poverty level, and your vehicle must fail its biennial smog check. 
+You can apply online at their website or by calling <a href="tel:+1-866-272-9642" aria-label="Call 866-272-9642">866-272-9642</a> (M–F 8:30am–5pm). </p>
+<blockquote>
+<p>See <a href="#emergency-financial-help">Emergency Financial Help</a> for programs that can give you financial assistance to pay for emergency expenses like car repairs.</p>
+</blockquote>
+<h3><span><a id="safe-parking">Safe Parking for People Living in Vehicles</a></span></h3>
+<blockquote>
+<p>See <a href="#camping-parking-rv-parks">Legal Camping, Safe Parking, and RV Parks</a> to learn about options for places to park safely and legally if you live in your vehicle.</p>
+</blockquote>
+<hr>
+<h2><span><a id="clothing">Clothing</a></span></h2>
+<h3><span><a id="free-clothes">Free Clothes</a></span></h3>
+<p>The <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> has some free clothing available, 
+as does the associated <a href="#" data-directory-link="Outreach-and-Engagement-Services" aria-label="View directory entry for Outreach and Engagement Services"><strong>Outreach and Engagement Services</strong></a>. </p>
+<p>The <a href="#" data-directory-link="Los-Osos-Cares" aria-label="View directory entry for Los Osos Cares Resource Center"><strong>Los Osos Cares Resource Center</strong></a> can give eligible people vouchers to purchase clothing with. </p>
+<p><a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> has clothing, shoes, blankets, and sleeping bags for people who come to its shower program (M–F 4–5:30pm at their Atascadero and Paso Robles locations). </p>
+
+
+<p><a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a> gives you new socks, underwear, and a t-shirt. </p>
+
+
+<p><a href="#" data-directory-link="SLO-Grassroots" aria-label="View directory entry for SLO Grassroots"><strong>SLO Grassroots</strong></a> has clothing to give away, but (as of December 2025) they are still looking for an office to operate from.
+You have to make an appointment with them to view their inventory. </p>
+<h4><span><a id="free-clothes-for-kids">Free Clothes for Kids</a></span></h4>
+<p>The <a href="#" data-directory-link="Childrens-Resource-Network-of-the-Central-Coast" aria-label="View directory entry for Children’s Resource Network of the Central Coast"><strong>Children’s Resource Network of the Central Coast</strong></a> has free clothing (and school supplies, books, diapers, and other basic resources) for children from birth to age 18. 
+Call their hotline, use the “Place a Request” form on their website, or visit during walk-in hours. 
+They also operate the “Traveling Children’s Closet,” “The Teen’s Closet,” and “Outreach Apparel” at which schoolchildren can get clothes and other supplies they need. </p>
+<p><a href="#" data-directory-link="Assistance-League-of-SLO-County" aria-label="View directory entry for Assistance League of SLO County"><strong>Assistance League of SLO County</strong></a> operates the “Operation School Bell” program, which gives needy students credits with which they can shop for new retail school clothes. 
+Ask authorities at the child’s school to refer them to the program. </p>
+<p><a href="https://www.coatsforkidsslocounty.org/" data-external-link="true">Coats for Kids of SLO County</a> holds a once-a-year (December) distribution in Paso Robles of cold-weather clothes like coats, jackets, sweaters, and sweatshirts. 
+See their website for details on the next distribution, or use their <a href="https://www.coatsforkidsslocounty.org/contact" data-external-link="true">contact form</a> or call <a href="tel:+1-805-703-1762" aria-label="Call 805-703-1762">805-703-1762</a> with questions. </p>
+<h3><span><a id="thrift-stores">Thrift Stores</a></span></h3>
+<p>Thrift stores sell second-hand (used) clothing at low prices.</p>
+<p><strong>Arroyo Grande:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="Achievement-House-Thrift-Store" aria-label="View directory entry for Achievement House Thrift Store"><strong>Achievement House Thrift Store</strong></a></li>
+</ul>
+<p><strong>Atascadero:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="Brookside-Thrift" aria-label="View directory entry for Brookside Thrift"><strong>Brookside Thrift</strong></a></li>
+<li><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Store"><strong>Goodwill Store</strong></a></li>
+<li><a href="#" data-directory-link="NCI-Affiliates-Thrift" aria-label="View directory entry for NCI Affiliates Thrift"><strong>NCI Affiliates Thrift</strong></a></li>
+</ul>
+<p><strong>Grover Beach:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="California-Cool-Thrift-Store" aria-label="View directory entry for California Cool Thrift Store"><strong>California Cool Thrift Store</strong></a></li>
+<li><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Store"><strong>Goodwill Store</strong></a></li>
+<li><a href="#" data-directory-link="Second-Chances-Thrift-Store" aria-label="View directory entry for Second Chances Thrift Store"><strong>Second Chances Thrift Store</strong></a></li>
+<li><a href="#" data-directory-link="St-Patricks-Shamrock-Thrift" aria-label="View directory entry for St. Patrick’s Shamrock Thrift"><strong>St. Patrick’s Shamrock Thrift</strong></a></li>
+<li><a href="#" data-directory-link="St-Barnabas-Thrift-Shop" aria-label="View directory entry for St. Barnabas Thrift Shop"><strong>St. Barnabas Thrift Shop</strong></a></li>
+</ul>
+<p><strong>Los Osos:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="Abundance-Shop" aria-label="View directory entry for Abundance Shop"><strong>Abundance Shop</strong></a></li>
+</ul>
+<p><strong>Morro Bay:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="Achievement-House-Thrift-Store" aria-label="View directory entry for Achievement House Thrift Store"><strong>Achievement House Thrift Store</strong></a></li>
+<li><a href="#" data-directory-link="Foxys-Thrift-Shop" aria-label="View directory entry for Foxy’s Thrift Shop"><strong>Foxy’s Thrift Shop</strong></a></li>
+</ul>
+<p><strong>Paso Robles:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Store"><strong>Goodwill Store</strong></a></li>
+<li><a href="#" data-directory-link="NCI-Affiliates-Thrift" aria-label="View directory entry for NCI Affiliates Thrift"><strong>NCI Affiliates Thrift</strong></a></li>
+</ul>
+<p><strong>San Luis Obispo:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="Achievement-House-Thrift-Store" aria-label="View directory entry for Achievement House Thrift Store"><strong>Achievement House Thrift Store</strong></a></li>
+<li><a href="#" data-directory-link="Assistance-League-Thrift-Store" aria-label="View directory entry for Assistance League Thrift Store"><strong>Assistance League Thrift Store</strong></a></li>
+<li><a href="#" data-directory-link="Bargain-Boutique" aria-label="View directory entry for Bargain Boutique"><strong>Bargain Boutique</strong></a></li>
+<li><a href="#" data-directory-link="Fred-and-Bettys" aria-label="View directory entry for Fred &amp; Betty’s Thrift Store"><strong>Fred &amp; Betty’s Thrift Store</strong></a></li>
+<li><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Outlet"><strong>Goodwill Outlet</strong></a> and <a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Store"><strong>Goodwill Store</strong></a></li>
+<li><a href="#" data-directory-link="Lumina-Thrift" aria-label="View directory entry for Lumina Thrift"><strong>Lumina Thrift</strong></a></li>
+<li><a href="#" data-directory-link="Mission-Thrift" aria-label="View directory entry for Mission Thrift"><strong>Mission Thrift</strong></a></li>
+<li><a href="#" data-directory-link="SLO-Thrift" aria-label="View directory entry for SLO Thrift"><strong>SLO Thrift</strong></a> (not yet open as of November 2025)</li>
+<li><a href="#" data-directory-link="United-Voluntary-Services-Thrift" aria-label="View directory entry for United Voluntary Services Thrift"><strong>United Voluntary Services Thrift</strong></a></li>
+</ul>
+<hr>
+<h2><span><a id="laundry">Laundry</a></span></h2>
+<p>The <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> offers free laundry facilities every day from 8am to 4pm. 
+You do not have to be staying overnight there to use the laundry facilities, but you do need to complete their intake process first. </p>
+<p>The <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> opens the laundry facility at its Paso Robles location every Wednesday from 10am–6pm, at which outreach clients can do a single load of laundry for free (they provide detergent). </p>
+<p><a href="#" data-directory-link="Laundry-Love" aria-label="View directory entry for Laundry Love"><strong>Laundry Love</strong></a> operates at a Los Osos commercial laundry on the last Wednesday of the month (check their website for the latest schedule). 
+They allow anyone to do two free loads of laundry (five loads for a family), plus bedding. 
+They provide the coins to feed the machines and the laundry detergent and dryer sheets. </p>
+<hr>
+<h2><span><a id="showers-and-hygiene">Showers and Hygiene</a></span></h2>
+<h3><span><a id="free-showers">Free Shower Services</a></span></h3>
+<p><a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a> offers free showers from its mobile shower trailer several times a week in several locations in SLO city and in Grover Beach. 
+They provide towels and soap. 
+Guests also receive free toiletries, and new socks, underwear, and t-shirts. 
+They operate rain-or-shine all year long including holidays. </p>
+<p><a href="#" data-directory-link="805-Street-Outreach" aria-label="View directory entry for 805 Street Outreach"><strong>805 Street Outreach</strong></a> is a similar program that operates every Monday in Morro Bay. 
+They also have clothing and food for guests. </p>
+<p>The <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> in SLO city has shower facilities that it makes available to both its overnight and its day guests. 
+You do not have to be a resident there to use the showers, but you do have to undergo their intake process. </p>
+<p>The <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> offers hot showers five evenings a week (M–F 4–5:30pm) to anyone in need at both their Atascadero and their Paso Robles locations. 
+They give you toiletries, and they also have clothing, shoes, blankets, and sleeping bags. </p>
+<h3><span><a id="pay-showers">Coin-Operated or Gym Membership Options</a></span></h3>
+<p>The <a href="#" data-directory-link="SLO-County-YMCA" aria-label="View directory entry for SLO County YMCA"><strong>SLO County YMCA</strong></a> has shower facilities at their Southwood Ave. gym in SLO city.
+These are available to gym members.
+Membership is not free, but the YMCA policy is that “no one is denied membership because of inability to pay.” 
+Ask them about options for people with low incomes.</p>
+<p>The <a href="https://www.slocity.org/government/department-directory/parks-and-recreation/slo-swim-center" data-external-link="true">SLO Swim Center</a>, which costs $4.75 to enter 
+(but is free to YMCA members during public swim session times), 
+has showers. </p>
+<p>Some SLO County parks have coin-operated shower facilities, including <a href="#" data-directory-link="Coastal-Dunes" aria-label="View directory entry for Coastal Dunes RV Park &amp; Campground"><strong>Coastal Dunes RV Park &amp; Campground</strong></a>, 
+<a href="#" data-directory-link="El-Chorro-Regional-Park-Campground" aria-label="View directory entry for El Chorro Regional Park Campground"><strong>El Chorro Regional Park Campground</strong></a>, 
+<a href="#" data-directory-link="Lopez-Lake-Recreation-Area" aria-label="View directory entry for Lopez Lake Recreation Area"><strong>Lopez Lake Recreation Area</strong></a>, 
+<a href="#" data-directory-link="Oceano-Campground" aria-label="View directory entry for Oceano Campground"><strong>Oceano Campground</strong></a>, 
+and <a href="#" data-directory-link="Santa-Margarita-Lake-Recreation-Area" aria-label="View directory entry for Santa Margarita Lake Recreation Area"><strong>Santa Margarita Lake Recreation Area</strong></a> </p>
+<p>The <a href="#" data-directory-link="Port-San-Luis-Harbor-District" aria-label="View directory entry for Port San Luis Harbor District"><strong>Port San Luis Harbor District</strong></a> “Coastal Gateway Multi-Purpose Room” has coin-operated showers. </p>
+<p>Some commercial gyms have showers.
+For example, a $15 day pass to the <a href="#" data-directory-link="Pismo-Beach-Athletic-Club" aria-label="View directory entry for Pismo Beach Athletic Club"><strong>Pismo Beach Athletic Club</strong></a> provides access to all of their facilities, including showers. 
+Some Medicare supplement plans have a “Silver Sneakers” program with which you can get free gym memberships. </p>
+<hr>
+<h2><span><a id="health-medical-care">Health &amp; Medical Care</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#emergency-care">Emergency Care</a></li>
+<li><a href="#urgent-care">Urgent Care Options</a></li>
+<li><a href="#health-insurance">Health Insurance</a></li>
+<li><a href="#medical-and-assistive-devices">Medical and Assistive Devices</a></li>
+<li><a href="#prescription-medicines">Prescription Medicines</a></li>
+<li><a href="#dental-care">Dental Care</a></li>
+<li><a href="#vision-care">Vision Care and Eyeglasses</a></li>
+<li><a href="#mental-health">Mental Health</a></li>
+<li><a href="#reproductive-health">Reproductive Health</a></li>
+<li><a href="#pregnancy-childbirth-lactation">Pregnancy, Childbirth, Lactation</a></li>
+<li><a href="#chiropractic-treatment">Chiropractic Treatment</a></li>
+<li><a href="#medical-resources-specific-populations">Resources for Specific Populations</a></li>
+<li><a href="#poison-oak">Poison Oak</a></li>
+<li><a href="#sunburn">Sunburn</a></li>
+</ul>
+<blockquote>
+<p>See also the <a href="#fitness">Fitness</a> subsection for information on exercise and fitness options.</p>
+</blockquote>
+<p><a href="#" data-directory-link="Vituity-Cares-Mobile-Clinic" aria-label="View directory entry for Vituity Cares Mobile Clinic"><strong>Vituity Cares Mobile Clinic</strong></a> is a free medical clinic that operates one day per month in SLO city.
+It offers diagnosis, testing, and treatment, can write prescriptions, and usually also has free food and a small free clothing collection.</p>
+<h3><span><a id="emergency-care">Emergency Care</a></span></h3>
+<h4><span>When and How to Call 911</span></h4>
+<p>Call 911 immediately when someone needs emergency medical care that cannot wait.
+This includes when a person:</p>
+<ul>
+<li>Cannot breathe or struggles severely to breathe</li>
+<li>Has no pulse or appears unconscious and unresponsive</li>
+<li>Bleeds heavily and cannot stop the bleeding</li>
+<li>Shows signs of stroke (sudden face drooping, arm weakness, or speech difficulty)</li>
+<li>Experiences chest pain that might indicate a heart attack</li>
+<li>Has a severe allergic reaction with swelling or breathing problems</li>
+<li>Suffers a serious injury</li>
+<li>Takes a dangerous overdose of a drug or poison</li>
+<li>Has a seizure (especially if it lasts longer than five minutes or if the person has never had a seizure before)</li>
+<li>Has a severe mental health crisis in which they are an immediate danger to themselves or others</li>
+</ul>
+<p>Stay calm and speak clearly to the 911 dispatcher.
+The dispatcher will guide you through the process, and may ask you for:</p>
+<ul>
+<li><strong>Your exact location</strong> — Give the full address, including apartment number, floor, or any access instructions. If you’re unsure of the address, describe nearby landmarks or cross streets.</li>
+<li><strong>The nature of the emergency</strong> — Briefly describe what happened and the person’s current condition.</li>
+<li><strong>The patient’s condition</strong> — Report whether the person is conscious, breathing, and responsive. Describe visible injuries or symptoms.</li>
+<li><strong>Your relationship to the patient</strong> — State whether you are family, a friend, or a bystander.</li>
+<li><strong>Your contact information</strong> — Provide a phone number where responders can reach you.</li>
+</ul>
+<p>Do not hang up until the dispatcher tells you to.
+The dispatcher may tell you how to provide care while you wait for help to arrive.
+If the situation changes while you wait, call 911 again immediately to update them.</p>
+<p>Stay with the patient until help arrives, if it is safe for you to do so.
+Choose someone to watch for the ambulance and to guide responders to the location.</p>
+<h4><span>Emergency Rooms</span></h4>
+<p>There are four emergency rooms in SLO County:</p>
+<ol>
+<li><a href="#" data-directory-link="Arroyo-Grande-Community-Hospital" aria-label="View directory entry for Arroyo Grande Community Hospital"><strong>Arroyo Grande Community Hospital</strong></a> (Arroyo Grande)</li>
+<li><a href="#" data-directory-link="Adventist-Health-Sierra-Vista" aria-label="View directory entry for Adventist Health Sierra Vista"><strong>Adventist Health Sierra Vista</strong></a> (SLO)</li>
+<li><a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a> (SLO)</li>
+<li><a href="#" data-directory-link="Adventist-Health-Twin-Cities" aria-label="View directory entry for Adventist Health Twin Cities"><strong>Adventist Health Twin Cities</strong></a> (Templeton)</li>
+</ol>
+<p>These emergency rooms are open all day, every day.</p>
+<p>Do not worry if your Medi-Cal paperwork is not yet in order.
+Under the “Hospital Presumptive Eligibility” program, in an emergency, hospitals will treat you as though you have Medi-Cal for up to two months while they work with you to determine your eligibility, if the following conditions hold:</p>
+<ul>
+<li>You are uninsured and not receiving Medi-Cal.</li>
+<li>You have a low monthly income.</li>
+<li>You live in California.</li>
+<li>You have not used the “Hospital Presumptive Eligibility” program more than once in the past 12 months (more than twice for children).</li>
+</ul>
+<p>U.S. Citizenship is not required. 
+All four emergency rooms participate in the “Hospital Presumptive Eligibility” program. </p>
+<h3><span><a id="urgent-care">Urgent Care Options</a></span></h3>
+<p>Visit an urgent care center when you have a medical problem that needs prompt attention but is not life-threatening.
+Urgent care centers treat conditions that are too serious to wait for a doctor’s appointment but that do not require emergency room services.
+The wait is usually shorter than emergency rooms, and the cost is typically lower for non-emergency conditions.
+Most urgent care centers accept walk-ins, and some also allow appointments.
+Bring your insurance card, identification, and a list of medications you take.</p>
+
+<table>
+<thead>
+<tr>
+<th>Urgent Care Location</th>
+<th>Medicare</th>
+<th>Medi-Cal</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a> (Arroyo Grande)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">Yes</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Dignity-Health-Urgent-Care" aria-label="View directory entry for Dignity Health Urgent Care"><strong>Dignity Health Urgent Care</strong></a> (Atascadero)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">Yes</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Carbon-Health-Urgent-Care-Atascadero" aria-label="View directory entry for Carbon Health Urgent Care"><strong>Carbon Health Urgent Care</strong></a> (Atascadero)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Urgent-Care-of-Atascadero" aria-label="View directory entry for Urgent Care of Atascadero"><strong>Urgent Care of Atascadero</strong></a></td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Urgent-Care-of-Morro-Bay" aria-label="View directory entry for Urgent Care of Morro Bay"><strong>Urgent Care of Morro Bay</strong></a></td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Carbon-Health-Urgent-Care-Paso-Robles" aria-label="View directory entry for Carbon Health Urgent Care"><strong>Carbon Health Urgent Care</strong></a> (Paso Robles)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a> (Paso Robles)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">Yes</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="North-County-Care" aria-label="View directory entry for North County Care Minor Emergency Services"><strong>North County Care Minor Emergency Services</strong></a> (Paso Robles)</td>
+<td data-label="Medicare">?</td>
+<td data-label="Medi-Cal">?</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Dignity-Health-Urgent-Care" aria-label="View directory entry for Dignity Health Urgent Care"><strong>Dignity Health Urgent Care</strong></a> (Pismo Beach)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">Yes</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Urgent-Care-Pismo-Beach" aria-label="View directory entry for Urgent Care Pismo Beach"><strong>Urgent Care Pismo Beach</strong></a></td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Cottage-Urgent-Care" aria-label="View directory entry for Cottage Urgent Care"><strong>Cottage Urgent Care</strong></a> (SLO)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">Yes</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="Family-and-Industrial-Medical-Center" aria-label="View directory entry for Family and Industrial Medical Center"><strong>Family and Industrial Medical Center</strong></a> (SLO)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="MedStop" aria-label="View directory entry for MedStop"><strong>MedStop</strong></a> (SLO)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">No</td>
+</tr>
+<tr>
+<td data-label="Urgent Care Location"><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a> (Templeton — Las Tablas)</td>
+<td data-label="Medicare">Yes</td>
+<td data-label="Medi-Cal">Yes</td>
+</tr>
+</tbody></table>
+<h3><span><a id="health-insurance">Health Insurance</a></span></h3>
+<h4><span>Medi-Cal (Medicaid)</span></h4>
+<p><a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal"><strong>Medi-Cal</strong></a>, California’s Medicaid program, is a health insurance program for low-income people who meet certain eligibility requirements. </p>
+<p><a href="#" data-directory-link="CenCal" aria-label="View directory entry for CenCal"><strong>CenCal</strong></a> administers Medi-Cal in SLO County. </p>
+<p>You can search a list of local CenCal health care providers at <a href="https://www.cencalhealth.org/members/provider-directory-for-members/" data-external-link="true">cencalhealth.org/members/provider-directory-for-members/</a>.</p>
+<p>Homeless SLO County residents who are enrolled in CenCal Health qualify for <a href="#" data-directory-link="Enhanced-Care-Management" aria-label="View directory entry for Enhanced Care Management"><strong>Enhanced Care Management</strong></a>. 
+This helps you coordinate the care you need across multiple healthcare providers. 
+Contact them if you want to apply or you want more details. 
+You can also apply in-person (walk-ins OK) at CAPSLO’s <a href="#" data-directory-link="Outreach-and-Engagement-Services" aria-label="View directory entry for Outreach and Engagement Services"><strong>Outreach and Engagement Services</strong></a> center. </p>
+<h5><span>How to Apply for Medi-Cal</span></h5>
+<p>You can apply for Medi-Cal at <a href="https://www.coveredca.com/" data-external-link="true">www.coveredca.com</a> or <a href="https://benefitscal.com/" data-external-link="true">BenefitsCal.com</a>. </p>
+<p>You can get help applying from the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> 
+or <a href="#" data-directory-link="Catholic-Charities" aria-label="View directory entry for Catholic Charities"><strong>Catholic Charities</strong></a>. 
+To get help in indigenous Mexican languages, call <a href="tel:+1-805-483-1166" aria-label="Call 805-483-1166">805-483-1166</a>, or visit <a href="https://mixteco.org/indigenous-interpreter-services/" data-external-link="true">mixteco.org/indigenous-interpreter-services/</a>. 
+If you are a patient of Adventist Health, you can get help from them by calling <a href="tel:+1-844-827-5047" aria-label="Call 844-827-5047">844-827-5047</a>. </p>
+<p>If you are a farm laborer, you may also be able to get help applying for Medi-Cal from the <a href="https://californiafarmworkers.org/what-we-do/civil-assistance-program/" data-external-link="true">Civil Assistance Program</a> of the California Farmworker Foundation. </p>
+<h5><span>Prescription Medication</span></h5>
+<p>For information about obtaining prescription medicine through Medi-Cal, contact <a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal Rx"><strong>Medi-Cal Rx</strong></a>.
+To find a Medi-Cal Rx pharmacy, visit <a href="https://medi-calrx.dhcs.ca.gov/home/find-a-pharmacy" data-external-link="true">medi-calrx.dhcs.ca.gov/home/find-a-pharmacy</a>.</p>
+<h5><span><a id="medi-cal-dentists">Dentists</a></span></h5>
+<p>Dentists are not provided through CenCal but through <a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal Dental"><strong>Medi-Cal Dental</strong></a>.
+For information about dental benefits, contact Med-Cal Dental.
+To find a Medi-Cal Dental provider, see one of these resources:</p>
+<ul>
+<li><a href="https://www.dental.dhcs.ca.gov/Members/Medi_Cal_Dental/Find_A_Dentist/FindADentist" data-external-link="true">Denti-Cal Dental Care Dentist Referral</a> (<a href="tel:+1-800-322-6384" aria-label="Call 800-322-6384">800-322-6384</a>)</li>
+<li><a href="https://smilecalifornia.org/find-a-dentist/" data-external-link="true">“Find A Dentist” at Smile California</a></li>
+</ul>
+<h4><span>Medicare and HiCAP</span></h4>
+<p>Medicare is a government-provided health insurance program for people over age 65 and for people with long-term disabilities.</p>
+<p>Learn if you qualify for Medicare by asking the <a href="#" data-directory-link="Social-Security-Administration" aria-label="View directory entry for Social Security Administration"><strong>Social Security Administration</strong></a>.
+See <a href="https://www.ssa.gov/prepare/check-eligibility-for-benefits" data-external-link="true">ssa.gov: “Check eligibility for Social Security benefits”</a> or visit in person.</p>
+<p>Medicare’s many options can be confusing.
+<a href="#" data-directory-link="HiCAP" aria-label="View directory entry for Health Insurance Counseling &amp; Advocacy Program (“HiCAP”)"><strong>Health Insurance Counseling &amp; Advocacy Program (“HiCAP”)</strong></a> offers free and unbiased information about Medicare and its options.
+HiCAP can help you:</p>
+<ul>
+<li>find the best prescription drug plan</li>
+<li>find and use prescription drug discount programs</li>
+<li>file Medicare denial appeals</li>
+<li>understand long-term care insurance options</li>
+</ul>
+<p>To use the local HiCAP program you must be eligible for Medicare and you must be a resident of SLO or Santa Barbara counties. 
+The HiCAP program is free. </p>
+<p>You can also submit questions to them via a web form and get answers by email: <a href="https://centralcoastseniors.org/ask-a-medicare-question/" data-external-link="true">“Ask a Medicare Question”</a></p>
+<h4><span>Covered California / Obamacare</span></h4>
+<p>Covered California is a free service that helps you to apply for affordable medical insurance in California.
+This includes Medi-Cal/CenCal but also a variety of other brand-name health insurance plans, which may be available to you for free or at a very low cost depending on your income and circumstances.</p>
+<p>Visit <a href="https://www.coveredca.com/" data-external-link="true">coveredca.com</a> or call <a href="tel:+1-800-300-1506" aria-label="Call 800-300-1506">800-300-1506</a> to learn more.</p>
+<h4><span>VA Health Care</span></h4>
+<p>Military veterans may qualify for VA health care.
+To learn if you qualify, how to apply, and details about your medical benefits package, call <a href="tel:+1-877-222-8387" aria-label="Call 877-222-8387">877-222-8387</a>, or visit <a href="https://va.gov/health-care/about-va-health-benefits/" data-external-link="true">va.gov: “About VA health benefits.”</a></p>
+<p>See also <a href="#" data-directory-link="SLO-Vet-Center" aria-label="View directory entry for SLO Vet Center"><strong>SLO Vet Center</strong></a>, <a href="#" data-directory-link="Veterans-Administration-Outpatient-Clinic" aria-label="View directory entry for Veterans Administration Outpatient Clinic"><strong>Veterans Administration Outpatient Clinic</strong></a>, and <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for Veterans Services (SLO County)"><strong>Veterans Services (SLO County)</strong></a>.</p>
+<h4><span>Crowdfunding Medical Expenses</span></h4>
+<p>If you expect to have high medical expenses that you cannot afford, you might try to raise the money through donations from others.
+The <a href="#" data-directory-link="Help-Hope-Live" aria-label="View directory entry for Help Hope Live"><strong>Help Hope Live</strong></a> program can help you establish a “crowdfunding” campaign to raise money this way.</p>
+<h4><span><a id="emergency-medical-funding">Emergency Funding</a></span></h4>
+<p>If you need immediate funds to pay for a specific medical expense and you are not eligible for Medi-Cal or any other health insurance, consider the <a href="#" data-directory-link="MISP" aria-label="View directory entry for Medically Indigent Services Program"><strong>Medically Indigent Services Program</strong></a>.
+Call them to start the application process. </p>
+<p>If you are a patient of <a href="#" data-directory-link="Adventist-Health-Sierra-Vista" aria-label="View directory entry for Adventist Health"><strong>Adventist Health</strong></a>, you may qualify for their <a href="https://www.adventisthealth.org/patients-and-visitors/help-paying-your-bill/" data-external-link="true">Financial Assistance</a> program.
+Ask them in person for an application or contact them at <a href="tel:+1-844-827-5047" aria-label="Call 844-827-5047">844-827-5047</a>  or <a href="mailto:AHFinAsst@AH.org" aria-label="Email AHFinAsst@AH.org">AHFinAsst@AH.org</a>.</p>
+<blockquote>
+<p>See also the <a href="#emergency-financial-help">Emergency Financial Needs</a> section of this guide.</p>
+</blockquote>
+<h3><span>Transportation to Medical Appointments</span></h3>
+<blockquote>
+<p>See <a href="#transportation-to-medical-appointments">Transportation to Medical Appointments</a> in the <a href="#transportation">Transportation</a> section</p>
+</blockquote>
+<h3><span><a id="medical-and-assistive-devices">Medical and Assistive Devices</a></span></h3>
+<p><a href="#" data-directory-link="Access-Central-Coast" aria-label="View directory entry for Access Central Coast"><strong>Access Central Coast</strong></a> helps you find and afford assistive devices like wheelchairs, canes, walkers, scooters, modified telephones, and speech-generating devices. </p>
+<p><a href="#" data-directory-link="APA" aria-label="View directory entry for Alliance for Pharmaceutical Access"><strong>Alliance for Pharmaceutical Access</strong></a> helps you get low-cost diabetic supplies (glucose test strips and meters, insulin syringes, etc.). </p>
+<p><a href="#" data-directory-link="Atascadero-Senior-Center" aria-label="View directory entry for Atascadero Senior Center"><strong>Atascadero Senior Center</strong></a>, 
+<a href="#" data-directory-link="Morro-Bay-Senior-Center" aria-label="View directory entry for Morro Bay Senior Center"><strong>Morro Bay Senior Center</strong></a>, 
+and <a href="#" data-directory-link="Nipomo-Senior-Center" aria-label="View directory entry for Nipomo Senior Center"><strong>Nipomo Senior Center</strong></a> 
+have free lending libraries of mobility aids and some other medical equipment.</p>
+<p>The <a href="#" data-directory-link="Boyd-Bristol-Medical-Equipment-Program" aria-label="View directory entry for Boyd Bristol Medical Equipment Program"><strong>Boyd Bristol Medical Equipment Program</strong></a> helps veterans and their family members get free loans of medical equipment like walkers, canes, scooters, and crutches. 
+They can also deliver these devices to you. </p>
+<p><a href="#" data-directory-link="Cambrias-Anonymous-Neighbors" aria-label="View directory entry for Cambria’s Anonymous Neighbors (CAN)"><strong>Cambria’s Anonymous Neighbors (CAN)</strong></a> provides loans of medical equipment including wheelchairs, walkers, canes, grab bars, and Life Alert devices to people on the North Coast. </p>
+<p><a href="#" data-directory-link="California-Connect" aria-label="View directory entry for California Connect"><strong>California Connect</strong></a> can loan you, for free, assistive telecommunications equipment that helps if you have functional limitations of hearing, vision, mobility, speech, and/or interpretation of information. </p>
+<p>The <a href="#" data-directory-link="California-Department-of-Rehabilitation" aria-label="View directory entry for California Department of Rehabilitation"><strong>California Department of Rehabilitation</strong></a> can give you a free speech-generating device if you have difficulty speaking. </p>
+
+
+<p>The <a href="#" data-directory-link="CCATC" aria-label="View directory entry for Central Coast Assistive Technology Center"><strong>Central Coast Assistive Technology Center</strong></a> allows you to try, and helps you learn to use, assistive technologies including vision/hearing technologies and ergonomics. 
+They also help you access a no-cost lending library of assistive technology devices (<a href="https://myatprogram.org/" data-external-link="true">myatprogram.org</a>).</p>
+
+
+<p><a href="#" data-directory-link="PathPoint" aria-label="View directory entry for PathPoint"><strong>PathPoint</strong></a> has a lending library of assistive technology devices for people with developmental disabilities. </p>
+<p><a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> helps uninsured people get low-cost diabetes monitoring and treatment supplies. </p>
+<p><a href="#" data-directory-link="South-Bay-Seniors-People-Helping-People" aria-label="View directory entry for South Bay Seniors People Helping People"><strong>South Bay Seniors People Helping People</strong></a> can loan you assistive technology like walkers and wheelchairs. 
+Call them or visit their office for details. </p>
+<h3><span><a id="prescription-medicines">Prescription Medicines</a></span></h3>
+<p>Drug discount plans allow you to get prescriptions at reduced prices.
+You can get help finding the best discount plans for you from <a href="#" data-directory-link="APA" aria-label="View directory entry for Alliance for Pharmaceutical Access"><strong>Alliance for Pharmaceutical Access</strong></a>, 
+<a href="#" data-directory-link="HiCAP" aria-label="View directory entry for Health Insurance Counseling &amp; Advocacy Program (“HiCAP”)"><strong>Health Insurance Counseling &amp; Advocacy Program (“HiCAP”)</strong></a>, 
+<a href="#" data-directory-link="NeedyMeds" aria-label="View directory entry for NeedyMeds"><strong>NeedyMeds</strong></a>, 
+or <a href="#" data-directory-link="United-Way" aria-label="View directory entry for United Way"><strong>United Way</strong></a>. </p>
+<p>For answers about Medi-Cal/CenCal prescription benefits, contact <a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal Rx"><strong>Medi-Cal Rx</strong></a>.
+To find a Medi-Cal Rx pharmacy, visit <a href="https://medi-calrx.dhcs.ca.gov/home/find-a-pharmacy" data-external-link="true">medi-calrx.dhcs.ca.gov: “Find a Pharmacy”</a>.</p>
+<p>The <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> dispenses some medications directly, without you having to visit a pharmacy. </p>
+<p><a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> helps people who are uninsured (or whose insurance does not cover prescriptions) get free or low-cost prescription medications. </p>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> students can get over-the-counter and some prescription medicines (many free of charge) from <a href="https://www.cuesta.edu/student-support/student-health-services/index.html" data-external-link="true">Student Health Services</a>. </p>
+<h3><span><a id="dental-care">Dental Care</a></span></h3>
+<p><a href="#" data-directory-link="CCDS" aria-label="View directory entry for Central Coast Dental Society"><strong>Central Coast Dental Society</strong></a> maintains <a href="https://centralcoastdentalsociety.org/public-resources/reduced-fee-dental" data-external-link="true">a list of dentists who offer reduced rates for people in financial hardship</a>.</p>
+<p><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers"><strong>Community Health Centers</strong></a> offers dental care at its offices in Nipomo, Oceano, Templeton (Las Tablas), and at 40 Prado in SLO. </p>
+<p><a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> has a dental clinic. </p>
+<blockquote>
+<p>See <a href="#medi-cal-dentists">Medi-Cal: Dentists</a> above to learn how to find a Medi-Cal dental provider.</p>
+</blockquote>
+<h3><span><a id="vision-care">Vision Care</a></span></h3>
+<p>The <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers"><strong>Community Health Centers</strong></a> offices in Nipomo, Paso Robles, and at 260 Station Way in Arroyo Grande specialize in optometry. </p>
+<p><a href="#" data-directory-link="EyeCare-America" aria-label="View directory entry for EyeCare America"><strong>EyeCare America</strong></a> offers a free eye exam and follow-up ophthalmology treatment to uninsured and underinsured adults. </p>
+<p><a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> has a vision care clinic. </p>
+<h4><span>Eyeglasses</span></h4>
+<p>The American Academy of Ophthalmology maintains <a href="https://aao.org/eyecare-america/resources/eye-glasses" data-external-link="true">a list of sources of free and low-cost eyeglasses</a>.</p>
+<p>You can find a list of Medi-Cal opticians at <a href="https://provdir.cencalhealth.org/" data-external-link="true">provdir.cencalhealth.org</a>.</p>
+<h3><span><a id="mental-health">Mental Health</a></span></h3>
+<p>You can get 24-hour mental health support from SLO Hotline (<a href="tel:+1-805-783-0607" aria-label="Call 805-783-0607">805-783-0607</a>, or text <a href="sms:741741">741741</a>).</p>
+<blockquote>
+<p>For mental health emergencies, see <a href="#emergency-care">Emergency Care</a> and <a href="#emergency-contacts">Emergency Contacts</a>.</p>
+</blockquote>
+<p>The <a href="#" data-directory-link="MHET" aria-label="View directory entry for Mental Health Evaluation Team / Mobile Crisis Team"><strong>Mental Health Evaluation Team / Mobile Crisis Team</strong></a> and <a href="#" data-directory-link="Mobile-Crisis-Unit" aria-label="View directory entry for Mobile Crisis Unit"><strong>Mobile Crisis Unit</strong></a> respond to acute mental health needs.</p>
+<p><a href="#" data-directory-link="Cal-Poly-Community-Counseling-Service" aria-label="View directory entry for San Luis Obispo Counseling Service at Cal Poly"><strong>San Luis Obispo Counseling Service at Cal Poly</strong></a> and <a href="#" data-directory-link="Community-Counseling-Center" aria-label="View directory entry for Community Counseling Center"><strong>Community Counseling Center</strong></a> offer low- or no-cost mental health counseling.</p>
+<p>A <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers"><strong>Community Health Centers</strong></a> primary care physician can refer you to CHC-provided mental health counseling or psychiatry, which happens over the phone or through internet videoconferencing. </p>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> students can get mental health therapy through <a href="https://www.cuesta.edu/student-support/student-health-services/index.html" data-external-link="true">Student Health Services</a>. </p>
+<p>Adult Mental Health Outpatient Treatment (via <a href="#" data-directory-link="SLO-County-Mental-Health-Services" aria-label="View directory entry for SLO County Mental Health Services"><strong>SLO County Mental Health Services</strong></a>) 
+and <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association"><strong>Transitions Mental Health Association</strong></a> 
+and its <a href="#" data-directory-link="Homeless-Outreach-Full-Service-Partnership" aria-label="View directory entry for Homeless Outreach Full Service Partnership"><strong>Homeless Outreach Full Service Partnership</strong></a> 
+offer mental health evaluation &amp; treatment, including programs specifically for homeless people.</p>
+<p>The <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> at <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for CAPSLO"><strong>CAPSLO</strong></a>’s <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> includes mental health counseling and treatment. 
+<a href="#" data-directory-link="SLO-Hub" aria-label="View directory entry for SLO Hub"><strong>SLO Hub</strong></a> offers weekly mental health therapy sessions to its clients. </p>
+<p><a href="#" data-directory-link="Life-Steps-Foundation" aria-label="View directory entry for Life Steps Foundation"><strong>Life Steps Foundation</strong></a> 
+and <a href="#" data-directory-link="PathPoint" aria-label="View directory entry for PathPoint"><strong>PathPoint</strong></a> 
+have some services for people with mental health disorders and/or developmental disabilities.</p>
+<p><a href="#" data-directory-link="Tri-County-GLAD" aria-label="View directory entry for Tri-County GLAD"><strong>Tri-County GLAD</strong></a> offers some mental health services to people who are deaf or hard of hearing. </p>
+<p>The <a href="#" data-directory-link="Veterans-Administration-Outpatient-Clinic" aria-label="View directory entry for Veterans Administration Outpatient Clinic"><strong>Veterans Administration Outpatient Clinic</strong></a> offers mental health care to qualifying U.S. military veterans.
+They say: “All VA health care facilities offer same-day help. You may qualify even without enrolling in VA health care.” 
+And <a href="#" data-directory-link="SLO-Vet-Center" aria-label="View directory entry for SLO Vet Center"><strong>SLO Vet Center</strong></a> offers confidential counseling and other mental health care to combat veterans (and certain other veterans) and to victims of military sexual trauma. </p>
+<h3><span><a id="reproductive-health">Reproductive Health</a></span></h3>
+<p><a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health and Prevention"><strong>The Center for Health and Prevention</strong></a> offers contraception, STD testing and treatment, UTI/yeast infection testing and treatment, genital exams, Pap smears, and menopausal services. </p>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> students can get reproductive/sexual healthcare and referrals (for example for birth control, emergency contraception, and STI testing) from <a href="https://www.cuesta.edu/student-support/student-health-services/index.html" data-external-link="true">Student Health Services</a>. </p>
+<p>The <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> offers contraceptives, HIV screening and education, OB/GYN services, and STD testing. </p>
+<p><a href="#" data-directory-link="Planned-Parenthood" aria-label="View directory entry for Planned Parenthood"><strong>Planned Parenthood</strong></a> offers abortion, birth control, emergency contraception, HIV/STD testing and treatment, help with various sexual and reproductive concerns, and no-cost family planning services. </p>
+<p>The <a href="#" data-directory-link="SLO-County-Public-Health-Department" aria-label="View directory entry for SLO County Public Health Department"><strong>SLO County Public Health Department</strong></a> offers STD testing and birth control. </p>
+<h3><span><a id="pregnancy-childbirth-lactation">Pregnancy, Childbirth, Lactation</a></span></h3>
+<p><a href="#" data-directory-link="Adventist-Health-Sierra-Vista" aria-label="View directory entry for Adventist Health"><strong>Adventist Health</strong></a> (<a href="tel:+1-805-434-4644" aria-label="Call 805-434-4644">805-434-4644</a>) 
+and <a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital"><strong>French Hospital</strong></a> (<a href="tel:+1-805-541-2229" aria-label="Call 805-541-2229">805-541-2229</a>) 
+each offer free breastfeeding support by phone.</p>
+<p><a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health and Prevention"><strong>The Center for Health and Prevention</strong></a> offers pregnancy testing and counseling. </p>
+<p><a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a>’s 1057 E. Grand Ave. (Arroyo Grande), 1551 Bishop St. (SLO), and 292 Posada Ln. (Templeton) locations offer the Wellness Pregnancy Program / Comprehensive Perinatal Services Program. </p>
+
+
+<p><a href="#" data-directory-link="Planned-Parenthood" aria-label="View directory entry for Planned Parenthood"><strong>Planned Parenthood</strong></a> offers pregnancy testing and planning, and prenatal and postpartum services. </p>
+<p><a href="#" data-directory-link="Pregnancy-Parenting-Support" aria-label="View directory entry for Pregnancy &amp; Parenting Support"><strong>Pregnancy &amp; Parenting Support</strong></a> offers maternity clothes, nursing supplies, diapers, formula, and referrals. </p>
+<p>The <a href="#" data-directory-link="WIC" aria-label="View directory entry for Women, Infants, and Children (WIC)"><strong>Women, Infants, and Children (WIC)</strong></a> program offers breastfeeding support. </p>
+<h3><span><a id="chiropractic-treatment">Chiropractic Treatment</a></span></h3>
+<p>The <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers of the Central Coast"><strong>Community Health Centers of the Central Coast</strong></a> offices in Arroyo Grande (260 Station Way and 1205 E. Grand Ave.), Atascadero, Cambria, Nipomo, Oceano, Paso Robles, San Miguel, Templeton (Las Tablas), and SLO (77 Casa St. and 1551 Bishop St.) offer chiropractic treatment. </p>
+<h3><span><a id="surgery">Surgery</a></span></h3>
+<p>The <a href="#" data-directory-link="CSF-Medical-Non-Profit-Foundation" aria-label="View directory entry for CSF Medical Non Profit Foundation"><strong>CSF Medical Non Profit Foundation</strong></a> helps medically uninsured people obtain life-saving surgical procedures. </p>
+<p>The <a href="#" data-directory-link="Recuperative-Care-Program" aria-label="View directory entry for Recuperative Care Program"><strong>Recuperative Care Program</strong></a> gives you a place to recover from surgery if your health would be compromised by an unstable living situation. 
+Ask your doctor to refer you to that program. </p>
+<h3><span><a id="medical-resources-specific-populations">Medical Resources for Specific Populations</a></span></h3>
+<h4><span>Children</span></h4>
+<p><a href="#" data-directory-link="California-Childrens-Services" aria-label="View directory entry for California Children’s Services"><strong>California Children’s Services</strong></a> pays for and helps arrange doctor visits, hospital stays, surgery, physical therapy, tests, medical equipment, etc. for children and youths whose parents otherwise could not afford it. </p>
+<p>The <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers"><strong>Community Health Centers</strong></a> offices at 260 Station Way in Arroyo Grande, in Nipomo, Oceano, Paso Robles, Templeton (Las Tablas), and at 77 Casa St. in SLO offer pediatric services. </p>
+<p>The <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> offers pediatric care and well child check-ups. </p>
+<p><a href="https://www.infantsee.org/" data-external-link="true">InfantSEE</a> helps you get a free eye/vision test for infants. </p>
+<p><a href="https://tolosachildrensdental.org/" data-external-link="true">Tolosa Children’s Dental Center</a> (<a href="tel:+1-805-592-2445" aria-label="Call 805-592-2445">805-592-2445</a>) accepts Medi-Cal 
+or sliding-scale cash payments. </p>
+<p><a href="#" data-directory-link="UnitedHealthcare-Childrens-Foundation" aria-label="View directory entry for UnitedHealthcare Children’s Foundation"><strong>UnitedHealthcare Children’s Foundation</strong></a> helps pay for medical expenses that are not covered by a child’s family’s commercial health insurance. 
+The child must be 16 or younger, with a U.S. social security number. 
+The need must be documented by a physician, and the child must be covered by commercial health insurance. </p>
+<p>The <a href="#" data-directory-link="WIC" aria-label="View directory entry for Women, Infants, and Children (WIC)"><strong>Women, Infants, and Children (WIC)</strong></a> program gives food benefits to low-income women who have recently given birth. </p>
+<h4><span>People with Diabetes</span></h4>
+<p><a href="#" data-directory-link="APA" aria-label="View directory entry for Alliance for Pharmaceutical Access"><strong>Alliance for Pharmaceutical Access</strong></a>
+and <a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> 
+can help you get low-cost diabetes supplies.</p>
+<p><a href="#" data-directory-link="Dignity-Health" aria-label="View directory entry for Dignity Health"><strong>Dignity Health</strong></a> leads a free diabetes support group on Zoom (internet video conferencing) and in-person every three months. 
+Call <a href="tel:+1-805-597-6780" aria-label="Call 805-597-6780">805-597-6780</a> or email <a href="mailto:Angela.Fissell@commonspirit.org" aria-label="Email Angela.Fissell@commonspirit.org">Angela.Fissell@commonspirit.org</a> for details. </p>
+<p>The <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> offers diabetes testing and care. </p>
+<p><a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> offers nutrition education &amp; lifestyle coaching for uninsured people with diabetes or prediabetes. </p>
+<h4><span>People with Disabilities</span></h4>
+<p><a href="#" data-directory-link="California-Connect" aria-label="View directory entry for California Connect"><strong>California Connect</strong></a> can loan you, for free, assistive telecommunications equipment that helps if you have functional limitations of hearing, vision, mobility, speech, and/or interpretation of information. </p>
+<p>The <a href="#" data-directory-link="California-Department-of-Rehabilitation" aria-label="View directory entry for California Department of Rehabilitation"><strong>California Department of Rehabilitation</strong></a> helps people with disabilities find or keep employment and live independently. 
+They can help you navigate disability and benefits programs, obtain assistive technologies, and get help with childcare and transportation.</p>
+<p><a href="#" data-directory-link="Disability-Rights-California" aria-label="View directory entry for Disability Rights California"><strong>Disability Rights California</strong></a> helps you understand and defend your legal rights as a disabled person. </p>
+<p>The <a href="#" data-directory-link="Life-Steps-Foundation" aria-label="View directory entry for Life Steps Foundation"><strong>Life Steps Foundation</strong></a> has resources for people with cerebral palsy, mild intellectual disability, mental health disorders, traumatic brain injury, Down syndrome, and spectrum disorders. 
+<a href="#" data-directory-link="PathPoint" aria-label="View directory entry for PathPoint"><strong>PathPoint</strong></a> also has services for people with developmental disabilities. </p>
+<p>If you use American Sign Language, <a href="#" data-directory-link="Lifesigns" aria-label="View directory entry for Lifesigns"><strong>Lifesigns</strong></a> can provide an interpreter to accompany you at your medical appointments. 
+<a href="#" data-directory-link="Tri-County-GLAD" aria-label="View directory entry for Tri-County GLAD"><strong>Tri-County GLAD</strong></a> can help with telephone call interpreting. </p>
+<h4><span>People with HIV or Hepatitis-C</span></h4>
+<p>The <a href="#" data-directory-link="ASN" aria-label="View directory entry for Access Support Network"><strong>Access Support Network</strong></a> has a variety of services for people impacted by HIV and Hep-C. 
+These include testing, treatment, benefits counseling, help with insurance, harm reduction (including Narcan and suboxone), infection prevention, and wound care. </p>
+<p><a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health &amp; Prevention"><strong>The Center for Health &amp; Prevention</strong></a> offers HIV/Hep-C testing. </p>
+<h4><span>Seniors</span></h4>
+
+
+<p>The <a href="#" data-directory-link="Central-Coast-Commission-for-Senior-Citizens" aria-label="View directory entry for Central Coast Commission for Senior Citizens"><strong>Central Coast Commission for Senior Citizens</strong></a> offers a variety of services for seniors, including <a href="#" data-directory-link="Senior-Connection" aria-label="View directory entry for Senior Connection"><strong>Senior Connection</strong></a> (an information and referral service), the <a href="#" data-directory-link="CCADRC" aria-label="View directory entry for Central Coast Aging &amp; Disability Resource Center"><strong>Central Coast Aging &amp; Disability Resource Center</strong></a>, and the <a href="#" data-directory-link="HiCAP" aria-label="View directory entry for Health Insurance Counseling &amp; Advocacy Program"><strong>Health Insurance Counseling &amp; Advocacy Program</strong></a>.
+They can help you with nutrition and meal services, transportation, and care management.</p>
+<h4><span>Teens and Youth</span></h4>
+<p><a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a>’s <a href="#" data-directory-link="Teen-Wellness" aria-label="View directory entry for Teen Wellness"><strong>Teen Wellness</strong></a> program includes health coaching, strength classes, mindfulness workshops, and reproductive health education. </p>
+<h4><span>Women</span></h4>
+<p><a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health &amp; Prevention"><strong>The Center for Health &amp; Prevention</strong></a> offers breast exams, referrals for free mammograms, Pap smears, and menopausal services. </p>
+<p>The <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers"><strong>Community Health Centers</strong></a> offices at 1057 E. Grand Ave. in Arroyo Grande, in Nipomo, at 1551 Bishop St. in SLO, and at 292 Posada Ln. in Templeton specialize in women’s health. </p>
+
+
+<p><a href="#" data-directory-link="SLO-Noor-Foundation" aria-label="View directory entry for SLO Noor Foundation"><strong>SLO Noor Foundation</strong></a> has a women’s mobile health unit. </p>
+<h3><span><a id="poison-oak">Poison Oak</a></span></h3>
+<p>Poison oak is a common plant in SLO County and grows everywhere from shaded wet creek beds to dry sunny hillsides. 
+It is a shrub or vine and sometimes also climbs trees and so can appear to be tree branches. 
+Its leaves appear in groups of three, but they can have a variety of shapes and colors (dark to pale green, pale orange, bright red). 
+The plants sometimes also display clusters of tiny green, pale, or brown fruits. </p>
+<div class="poison-oak-images">
+
+<p><img src="/poison-oak-1.png" alt="poison oak: flat green leaves with simple borders">
+<img src="/poison-oak-2.png" alt="poison oak: flat red leaves with undulating borders">
+<img src="/poison-oak-3.png" alt="poison oak: glossy red and green leaves"></p>
+</div>
+
+<p>The plant exudes an oil that causes a skin rash in people who touch it. 
+You do not have to touch the plant to be affected: you just need to touch the oil, which can rub off onto clothing, pet fur, or other items and may remain poisonous for years. 
+If you have been near a fire in which poison oak plants were burned, you may be exposed to the oil through the smoke. 
+You can prevent the rash by washing your skin thoroughly as soon as possible after exposure and by washing any clothing or other items that may be carrying the oil. 
+Rubbing alcohol or detergent soaps can be helpful in removing oils. </p>
+<p>The rash typically appears 12–48 hours, or even several days after exposure. 
+It is typically very itchy, and sometimes blisters.
+You can treat the rash with over-the-counter steroid (such as hydrocortisone) creams, calamine lotion, or antihistamines. </p>
+<p>If you have trouble breathing or swallowing, you may have inhaled some oils (for example from smoke) and you may be experiencing severe respiratory irritation. 
+In such a case you should seek medical attention.</p>
+<h3><span><a id="sunburn">Sunburn</a></span></h3>
+<p>Sunburn is painful. 
+It also can make you fatigued and more susceptible to infection. 
+In the long run it can put you at higher risk of developing skin cancer. </p>
+<p>Homeless people are more prone to sunburn because they have fewer options to escape the mid-day sun.
+You can reduce your risk of sunburn by finding shady places to rest during the day, by wearing more thoroughly-covering clothing like long-sleeved shirts and broad-brimmed hats, and by applying sunscreen. 
+Ask homeless service providers if they have any sunscreen they can give you. Sometimes they do.</p>
+<blockquote>
+<p>See the <a href="#clothing">Clothing</a> section of this guide for some tips on where to find free or low-cost clothing.</p>
+</blockquote>
+<p>If you develop a sunburn, you can get some relief with over-the-counter salves and creams, or just by keeping the area moist (perhaps with a dampened cloth). 
+If you have blisters that break, keep the area clean and covered with a bandage. 
+If you notice increasing redness that spreads beyond the area of the burn, or pus, or if you develop a fever, seek medical care as this may indicate an infection. </p>
+
+
+<hr>
+<h2><span><a id="drug-use-and-recovery">Drug Use, Recovery, and Harm Reduction</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#naloxone-narcan">Naloxone / Narcan</a></li>
+<li><a href="#tobacco-nicotine">Tobacco / Nicotine</a></li>
+<li><a href="#twelve-step">12-Step and Similar Recovery Programs</a></li>
+</ul>
+<blockquote>
+<p>Note: The somewhat confusing term “behavioral health” often describes programs for people who use addictive or harmful drugs and want help.</p>
+</blockquote>
+<p><a href="#" data-directory-link="ASN" aria-label="View directory entry for Access Support Network"><strong>Access Support Network</strong></a> offers suboxone (buprenorphine) treatment and opioid overdose prevention training. </p>
+<p><a href="#" data-directory-link="Aegis-Treatment-Centers" aria-label="View directory entry for Aegis Treatment Centers"><strong>Aegis Treatment Centers</strong></a> is an Opioid Treatment Program (OTP) offering Medication-Assisted Treatment that uses methadone, Suboxone, and similar medicines. 
+They provide specialized services for pregnant women, for veterans, for people with low incomes and for people with mental health disorders. </p>
+
+<p>They accept Medi-Cal, Medicare, and most commercial insurance. </p>
+<p><a href="#" data-directory-link="Aspire-Counseling-Service" aria-label="View directory entry for Aspire Counseling Services"><strong>Aspire Counseling Services</strong></a> runs inpatient (partial hospitalization) and intensive outpatient treatment programs for people trying to beat addiction. 
+They accept Medicare and most private insurance plans. </p>
+<p>The <a href="#" data-directory-link="CHC" aria-label="View directory entry for Community Health Centers"><strong>Community Health Centers</strong></a> offices at 260 Station Way in Arroyo Grande, in Atascadero, Cambria, Nipomo, Oceano, Paso Robles,
+at 77 Casa St. in SLO, and in Templeton (Las Tablas), specialize in behavioral health. 
+Their <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> at the <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> offers substance abuse treatment and needle exchange.</p>
+<p><a href="#" data-directory-link="Good-Samaritan-Shelter" aria-label="View directory entry for Good Samaritan Shelter"><strong>Good Samaritan Shelter</strong></a> in Santa Maria has a detox program and apparently accepts referrals from <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5 Cities Homeless Coalition"><strong>5 Cities Homeless Coalition</strong></a> in SLO County.</p>
+<p><a href="#" data-directory-link="SLO-Bangers" aria-label="View directory entry for SLO Bangers"><strong>SLO Bangers</strong></a> runs a needle exchange program, can give you overdose prevention training, and distributes Narcan.</p>
+<p><a href="#" data-directory-link="SLO-County-Mental-Health-Services" aria-label="View directory entry for SLO County Mental Health Services"><strong>SLO County Mental Health Services</strong></a> include drug &amp; alcohol walk-in clinics, detox (medically-assisted treatment), and referral to residential treatment options.</p>
+<p><a href="#" data-directory-link="SLO-County-Drug-and-Alcohol-Services" aria-label="View directory entry for SLO County Drug and Alcohol Services"><strong>SLO County Drug and Alcohol Services</strong></a> offers medically-assisted treatment, recovery services, and outpatient care.
+Some of their services are available on a walk-in basis.
+They charge a sliding fee depending on ability to pay.
+They operate the <a href="#" data-directory-link="SLO-Sobering-Center" aria-label="View directory entry for SLO Sobering Center"><strong>SLO Sobering Center</strong></a> for sobering up, detox, and medically-assisted drug withdrawal.</p>
+<p><a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a> and <a href="#" data-directory-link="Arroyo-Grande-Community-Hospital" aria-label="View directory entry for Arroyo Grande Community Hospital"><strong>Arroyo Grande Community Hospital</strong></a> offer walk-in suboxone treatment at their emergency rooms.</p>
+<p><a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association"><strong>Transitions Mental Health Association</strong></a> has substance use support groups for people who also have other mental health needs.</p>
+<p>The <a href="#" data-directory-link="Veterans-Administration-Outpatient-Clinic" aria-label="View directory entry for Veterans Administration Outpatient Clinic"><strong>Veterans Administration Outpatient Clinic</strong></a> offers substance abuse treatment to qualifying U.S. military veterans.
+The <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for County Veterans Services Offices"><strong>County Veterans Services Offices</strong></a> can also refer veterans to alcohol and drug dependency treatment programs.</p>
+<p>You can search for other rehab / addiction / detox programs in SLO County at websites like <a href="https://www.addictions.com/rehabs/california/san-luis-obispo/" data-external-link="true">addictions.com</a>, <a href="https://recovery.com/san-luis-obispo/" data-external-link="true">recovery.com</a>, or <a href="https://rehabs.org/centers/california/san-luis-obispo/" data-external-link="true">rehabs.org</a>.</p>
+<p><a href="https://www.samhsa.gov/" data-external-link="true">Substance Abuse and Mental Health Services Administration (SAMHSA)</a> is a U.S. government agency.
+It has a free phone service (<a href="tel:+1-800-662-4357" aria-label="Call 800-662-HELP">800-662-HELP</a>; TTY: <a href="tel:+1-800-487-4889" aria-label="Call 800-487-4889">800-487-4889</a>; text: <a href="sms:435748?&amp;body=HELP4U">435748</a>) that can help you find substance abuse treatment options near you that match your needs. </p>
+<h3><span><a id="naloxone-narcan">Naloxone / Narcan</a></span></h3>
+<p>Naloxone is an easy-to-administer medication that can save the life of someone who is experiencing an overdose of an opiate such as fentanyl or heroin.</p>
+<p>You can get naloxone from <a href="#" data-directory-link="ASN" aria-label="View directory entry for Access Support Network"><strong>Access Support Network</strong></a>, <a href="#" data-directory-link="SLO-Bangers" aria-label="View directory entry for SLO Bangers"><strong>SLO Bangers</strong></a>, <a href="#" data-directory-link="SLO-County-Drug-and-Alcohol-Services" aria-label="View directory entry for SLO County Drug and Alcohol Services"><strong>SLO County Drug and Alcohol Services</strong></a>, and <a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a> and <a href="#" data-directory-link="Arroyo-Grande-Community-Hospital" aria-label="View directory entry for Arroyo Grande Community Hospital"><strong>Arroyo Grande Community Hospital</strong></a> emergency rooms.
+You can also get free naloxone any time from these “NaloxBoxes”:</p>
+
+
+<p>🗺️ <strong><a href="naloxone-locations-map.html" rel="noopener">View all locations on an interactive map</a></strong></p>
+<p><strong>North Coast:</strong></p>
+<ul>
+<li>Baywood-Los Osos: Community Park, <a href="#" class="map-link" data-lat="35.312984" data-lon="-120.836284" data-zoom="17" data-label="Community Park">2180 Palisades Ave.</a></li>
+<li>Cambria: Shamel Park, <a href="#" class="map-link" data-lat="35.565991" data-lon="-121.108126" data-zoom="16" data-label="Shamel Park">5455 Windsor Blvd.</a></li>
+<li>Cambria: <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> (Cambria branch), <a href="#" class="map-link" data-lat="35.564950" data-lon="-121.096263" data-zoom="17" data-label="Cambria Library">1043 Main St.</a></li>
+<li>Cayucos: Paul Andrew Park, <a href="#" class="map-link" data-lat="35.445481" data-lon="-120.898994" data-zoom="16" data-label="Paul Andrew Park">N. 3rd St.</a></li>
+<li>Morro Bay: Public Health facility, <a href="#" class="map-link" data-lat="35.365706" data-lon="-120.844141" data-zoom="17" data-label="Public Health">760 Morro Bay Blvd.</a></li>
+</ul>
+<p><strong>North County:</strong></p>
+<ul>
+<li>Atascadero: <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>, <a href="#" class="map-link" data-lat="35.465791" data-lon="-120.648782" data-zoom="17" data-label="Department of Social Services">9630 El Camino Real</a></li>
+<li>Atascadero: <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> (Atascadero branch), <a href="#" class="map-link" data-lat="35.489118" data-lon="-120.663909" data-zoom="17" data-label="Public Library">6555 Capistrano Ave.</a></li>
+<li>Paso Robles: <a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a>, <a href="#" class="map-link" data-lat="35.618617" data-lon="-120.689353" data-zoom="17" data-label="Behavioral Health">805 4th St.</a></li>
+<li>Paso Robles: City Library, <a href="#" class="map-link" data-lat="35.625383" data-lon="-120.690684" data-zoom="17" data-label="City Library">1000 Spring St.</a></li>
+<li>Paso Robles: <a href="#" data-directory-link="ECHO" aria-label="View directory entry for ECHO"><strong>ECHO</strong></a> (Paso Home Key), <a href="#" class="map-link" data-lat="35.645387" data-lon="-120.687569" data-zoom="17" data-label="ECHO Shelter">1134 Black Oak Dr.</a></li>
+<li>Paso Robles: <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> Student Health Center <a href="#" class="map-link" data-lat="35.650584" data-lon="-120.670395" data-zoom="17" data-label="Cuesta College Student Health Center">Map</a></li>
+<li>San Miguel: Community Park, <a href="#" class="map-link" data-lat="35.751293" data-lon="-120.699068" data-zoom="17" data-label="Community Park">1325 K St.</a></li>
+<li>Santa Margarita: Community Park, <a href="#" class="map-link" data-lat="35.392470" data-lon="-120.604482" data-zoom="17" data-label="Community Park">2210 H St.</a></li>
+<li>Shandon: <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> (Shandon branch), <a href="#" class="map-link" data-lat="35.656573" data-lon="-120.376358" data-zoom="17" data-label="Public Library">195 N. 2nd St.</a></li>
+</ul>
+<p><strong>SLO city:</strong></p>
+<ul>
+<li><a href="#" data-directory-link="SLO-County-Animal-Services" aria-label="View directory entry for SLO County Animal Services"><strong>SLO County Animal Services</strong></a>, <a href="#" class="map-link" data-lat="35.318844" data-lon="-120.715762" data-zoom="17" data-label="SLO County Animal Services">885 Oklahoma Ave.</a></li>
+<li><a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a> Prevention &amp; Outreach, <a href="#" class="map-link" data-lat="35.268354" data-lon="-120.666490" data-zoom="17" data-label="Prevention and Outreach">277 South St. #T</a></li>
+<li><a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health &amp; Prevention"><strong>The Center for Health &amp; Prevention</strong></a> (CAPSLO Clinic), <a href="#" class="map-link" data-lat="35.290116" data-lon="-120.653550" data-zoom="17" data-label="The Center">705 Grand Ave.</a></li>
+<li>Cuesta Canyon Park, <a href="#" class="map-link" data-lat="35.294471" data-lon="-120.642822" data-zoom="16" data-label="Cuesta Park">2400 Loomis St.</a></li>
+<li><a href="#" data-directory-link="El-Chorro-Regional-Park-Campground" aria-label="View directory entry for El Chorro Regional Park Campground"><strong>El Chorro Regional Park Campground</strong></a>, <a href="#" class="map-link" data-lat="35.331302" data-lon="-120.728846" data-zoom="15" data-label="El Chorro Regional Park">State Hwy 1 @ Dairy Creek Rd.</a></li>
+<li>Maxine Lewis Grove, <a href="#" class="map-link" data-lat="35.261503" data-lon="-120.648658" data-zoom="17" data-label="Maxine Lewis Grove">732 Orcutt Rd.</a></li>
+<li><a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>, <a href="#" class="map-link" data-lat="35.253655" data-lon="-120.668725" data-zoom="17" data-label="Department of Social Services">3433 S. Higuera St.</a></li>
+<li><a href="#" data-directory-link="SLO-County-Public-Health-Department" aria-label="View directory entry for SLO County Public Health Department"><strong>SLO County Public Health Department</strong></a> (Health Campus), <a href="#" class="map-link" data-lat="35.274827" data-lon="-120.646298" data-zoom="16" data-label="Health Campus">2180 Johnson Ave.</a></li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> (SLO branch), <a href="#" class="map-link" data-lat="35.282385" data-lon="-120.662284" data-zoom="17" data-label="Public Library">995 Palm St.</a></li>
+<li><a href="#" data-directory-link="Sun-Street-Centers" aria-label="View directory entry for Sun Street Centers"><strong>Sun Street Centers</strong></a>, <a href="#" class="map-link" data-lat="35.256680" data-lon="-120.671937" data-zoom="17" data-label="Sun Street Centers">34 Prado Rd.</a></li>
+<li>The Anderson, <a href="#" class="map-link" data-lat="35.281304" data-lon="-120.661857" data-zoom="17" data-label="Anderson Hotel">965 Monterey St.</a></li>
+<li><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> Student Health Center <a href="#" class="map-link" data-lat="35.329871" data-lon="-120.740733" data-zoom="17" data-label="Cuesta College Student Health Center">Map</a></li>
+</ul>
+<p><strong>South County:</strong></p>
+<ul>
+<li>Arroyo Grande: <a href="#" data-directory-link="Lopez-Lake-Recreation-Area" aria-label="View directory entry for Lopez Lake Recreation Area"><strong>Lopez Lake Recreation Area</strong></a>, <a href="#" class="map-link" data-lat="35.192994" data-lon="-120.457449" data-zoom="15" data-label="Lopez Lake Recreation Area">6800 Lopez Dr.</a></li>
+<li>Arroyo Grande: <a href="#" data-directory-link="The-Center" aria-label="View directory entry for The Center for Health &amp; Prevention"><strong>The Center for Health &amp; Prevention</strong></a> (CAPSLO Clinic), <a href="#" class="map-link" data-lat="35.120654" data-lon="-120.597809" data-zoom="18" data-label="The Center">1152 E. Grand Ave.</a></li>
+<li>Grover Beach: Public Health, <a href="#" class="map-link" data-lat="35.119294" data-lon="-120.611992" data-zoom="17" data-label="Public Health">286 S. 16th St. Bldg A</a></li>
+<li>Nipomo: <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> (Nipomo branch), <a href="#" class="map-link" data-lat="35.028904" data-lon="-120.497031" data-zoom="17" data-label="Nipomo Library">918 W. Tefft St.</a></li>
+<li>Oceano: <a href="#" data-directory-link="Coastal-Dunes" aria-label="View directory entry for Coastal Dunes RV Park &amp; Campground"><strong>Coastal Dunes RV Park &amp; Campground</strong></a>, <a href="#" class="map-link" data-lat="35.113119" data-lon="-120.625704" data-zoom="16" data-label="Coastal Dunes">1001 Pacific Blvd.</a></li>
+<li>Oceano: <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> (Oceano branch), <a href="#" class="map-link" data-lat="35.102919" data-lon="-120.610154" data-zoom="17" data-label="Oceano Library">1511 19th St.</a></li>
+<li>Oceano: <a href="#" data-directory-link="Coastal-Dunes" aria-label="View directory entry for Oceano Campground"><strong>Oceano Campground</strong></a> (County Campground), <a href="#" class="map-link" data-lat="35.104656" data-lon="-120.625624" data-zoom="17" data-label="Oceano Campground">494 Air Park Dr.</a></li>
+</ul>
+<h3><span><a id="tobacco-nicotine">Tobacco / Nicotine</a></span></h3>
+<p>The “Kick It California” program can help you stop smoking (<a href="https://kickitca.org/" data-external-link="true">kickitca.org</a> at <a href="tel:+1-800-300-8086" aria-label="Call 800-300-8086">800-300-8086</a> or <a href="https://smokefree.gov/" data-external-link="true">smokefree.gov</a> at <a href="tel:+1-800-784-8669" aria-label="Call 800-784-8669">800-784-8669</a>).</p>
+<p>The <a href="#" data-directory-link="HCHP" aria-label="View directory entry for Healthcare for the Homeless Program"><strong>Healthcare for the Homeless Program</strong></a> and the <a href="#" data-directory-link="SLO-County-Public-Health-Department" aria-label="View directory entry for SLO County Public Health Department"><strong>SLO County Public Health Department</strong></a> also offer tobacco cessation help.</p>
+<h3><span><a id="twelve-step">12-Step and Similar Recovery Programs</a></span></h3>
+<p><a href="#" data-directory-link="AA" aria-label="View directory entry for Alcoholics Anonymous"><strong>Alcoholics Anonymous</strong></a> is a peer-led sobriety and recovery program.
+<a href="#" data-directory-link="Recovery-Dharma" aria-label="View directory entry for Recovery Dharma"><strong>Recovery Dharma</strong></a>, hosted by <a href="#" data-directory-link="Aspire-Counseling-Service" aria-label="View directory entry for Aspire Counseling Services"><strong>Aspire Counseling Services</strong></a>, is a similar, Buddhist-oriented program.</p>
+<p><a href="#" data-directory-link="Narcotics-Anonymous" aria-label="View directory entry for Narcotics Anonymous"><strong>Narcotics Anonymous</strong></a> is similar and helps you stop using other addictive drugs.
+<a href="#" data-directory-link="Marijuana-Anonymous" aria-label="View directory entry for Marijuana Anonymous"><strong>Marijuana Anonymous</strong></a> is for marijuana specifically.</p>
+<p>AA &amp; NA meet in many locations throughout the county, every day of the week.
+The <a href="#" data-directory-link="Alano-Club" aria-label="View directory entry for Alano Club"><strong>Alano Club</strong></a> and <a href="https://thecambriaconnection.org/meetings-and-events/" data-external-link="true">The Cambria Connection</a>, for example, host AA or NA meetings several times a day.</p>
+<h3><span>Sober Living Homes and Residential Treatment Options</span></h3>
+<blockquote>
+<p>See <a href="#sober-living-homes">Shelter &amp; Housing: Sober Living Homes</a></p>
+</blockquote>
+<hr>
+<h2><span><a id="tattoo-removal">Tattoo Removal</a></span></h2>
+<p>There are programs available that will erase your tattoos.
+This can help you if you have tattoos that interfere with your ability to get a job or that are suggestive of gang or hate group affiliation.
+Tattoo removal can help you get a fresh start, unburdened by regretful decisions from your past.</p>
+<p>The process of laser tattoo removal takes time.
+Typically you undergo between five and twelve visits, each one lasting about five minutes, over several months.
+In each visit a laser breaks ink particles in your tattoo so that your immune system can remove them.
+The tattooed area will become red and swollen soon after treatment, but this eventually settles down.
+Sometimes there is some blistering and scabbing.
+You will need to take some care to keep the area of the tattoo clean, and to apply some ointments that assist healing.</p>
+<p>The <a href="#" data-directory-link="Liberty-Tattoo-Removal-Program" aria-label="View directory entry for Liberty Tattoo Removal Program"><strong>Liberty Tattoo Removal Program</strong></a> offers laser tattoo removal of gang-related, anti-social, or economically limiting tattoos.
+You are required to do some hours of community service (or an equivalent financial donation) before each treatment, but there is otherwise no cost.
+You must agree to remain clean and sober, and to get no more tattoos, during the treatment.
+This service is offered to people in SLO County and the treatments happen in SLO city.</p>
+<p><a href="#" data-directory-link="Catholic-Charities" aria-label="View directory entry for Catholic Charities"><strong>Catholic Charities</strong></a> has a low-cost tattoo removal program ($20–90 per session, on a sliding scale based on ability to pay).
+You must also complete 20 hours of community service before beginning treatment.
+They prioritize the removal of offensive or gang-related tattoos, and will remove both visible-and-obvious tattoos (e.g. the face, the back of the hands) and more discreet ones.
+Call them to begin the process.</p>
+<p>The <a href="https://removery.com/services/ink-nitiative" data-external-link="true">Removery INK-nitiative Program</a> offers free removal of tattoos, if those tattoos are in visible areas (face, hands, arms) or suggest gang or hate group affiliation, to people who have been incarcerated, are former gang members, or are survivors of domestic abuse or human trafficking.
+Apply on their website.</p>
+<p>The <a href="https://jailstojobs.org/resources/tattoo-removal-programs" data-external-link="true">Jails to Jobs</a> website lists hundreds of other free or low-cost tattoo removal programs throughout the country.</p>
+<hr>
+<h2><span><a id="end-of-life-help">End-of-Life Care, Advance Directives, Hospice</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#hospice-and-palliative-care">Hospice and Palliative Care Services</a></li>
+<li><a href="#advance-directives">Advance Directives</a></li>
+</ul>
+<h3><span><a id="hospice-and-palliative-care">Hospice and Palliative Care Services</a></span></h3>
+<p>Palliative care is medical treatment that aims to relieve pain and suffering, perhaps alongside medical treatment that hopes to cure or treat some health problem.</p>
+<p>Hospice care is meant to make the process of dying less uncomfortable, and is meant for people who do not have realistic hopes of being cured and living long.
+Typically this means they are in their last six months of life.</p>
+<p><a href="#" data-directory-link="Hospice-SLO" aria-label="View directory entry for Hospice SLO"><strong>Hospice SLO</strong></a> includes non-medical volunteer support, grief counseling, support groups, in-home respite care, care management, and end-of-life companion support.
+All services are provided at no charge (they rely entirely on community donations).
+These services are open to San Luis Obispo County residents grieving a death, coping with life-limiting illness, or facing end of life.</p>
+<p>The <a href="#" data-directory-link="Medically-Fragile-Homeless-Program" aria-label="View directory entry for Medically Fragile Homeless Program"><strong>Medically Fragile Homeless Program</strong></a> provides shelter to terminally ill people who need housing so that they can die in the dignity and stability of housing with the care of hospice.</p>
+<p><a href="#" data-directory-link="Aevum" aria-label="View directory entry for Aevum Home Health"><strong>Aevum Home Health</strong></a> offers palliative care, and accepts Medicare and Medi-Cal. They also have a hospice program.</p>
+<p><a href="#" data-directory-link="Central-Coast-Home-Health" aria-label="View directory entry for Central Coast Home Health and Hospice"><strong>Central Coast Home Health and Hospice</strong></a> includes hospice nurse availability, nursing services, spiritual care, dietitian services, social work services, bereavement services, home health aides, trained volunteers, support groups, and musicians.
+They accept Medicare; contact them directly to ask about whether Medi-Cal will cover their services.</p>
+<p><a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for Dignity Health French Hospital Medical Center Home Health and Hospice"><strong>Dignity Health French Hospital Medical Center Home Health and Hospice</strong></a> includes team-oriented medical care, symptom and pain management, and emotional and spiritual support tailored to patient needs.
+They accept Medicare and Medi-Cal.
+They also have financial assistance programs that make hospice treatment free for people below 250% of the federal poverty level, and discounted for people below 400% of the federal poverty level (call <a href="tel:+1-888-488-7667" aria-label="Call 888-488-7667">888-488-7667</a> or <a href="tel:+1-805-542-6321" aria-label="Call 805-542-6321">805-542-6321</a> for details).</p>
+<p><a href="#" data-directory-link="Dignity-Health" aria-label="View directory entry for Dignity Health"><strong>Dignity Health</strong></a> also has a Home Health and Hospice program in Atascadero that includes skilled nursing, hospice care, and palliative care.
+They accept Medicare and Medi-Cal.
+They also have financial assistance programs that make hospice treatment free for people below 250% of the federal poverty level, and discounted for people below 400% of the federal poverty level (call <a href="tel:+1-888-488-7667" aria-label="Call 888-488-7667">888-488-7667</a> or <a href="tel:+1-805-542-6321" aria-label="Call 805-542-6321">805-542-6321</a> for details).
+They are located at <a href="#" class="map-link" data-lat="35.497588" data-lon="-120.680838" data-zoom="17" data-label="Home Health and Hospice">4555 El Camino Real #A</a>, are open M–F 8am–5pm, and can be reached by phone at <a href="tel:+1-805-434-1427" aria-label="Call 805-434-1427">805-434-1427</a> or <a href="tel:+1-800-549-9609" aria-label="Call 800-549-9609">800-549-9609</a>.</p>
+<p><a href="#" data-directory-link="Medi-Cal" aria-label="View directory entry for Medi-Cal"><strong>Medi-Cal</strong></a> (<a href="#" data-directory-link="CenCal" aria-label="View directory entry for CenCal"><strong>CenCal</strong></a>) recipients who have a life expectancy of six months or less can choose to receive Medi-Cal covered hospice care in lieu of ordinary medical coverage.
+Medi-Cal (CenCal) also covers palliative care as part of its ordinary medical coverage.</p>
+<p>Hospice care is part of the Veterans Health Administration (VHA)’s standard medical benefits package.
+If you are a veteran who is enrolled with the VHA, and you have a clinical need for end-of-life hospice care, you can get this without a copay through the VHA.
+Contact the local <a href="#" data-directory-link="Veterans-Administration-Outpatient-Clinic" aria-label="View directory entry for Veterans Administration Outpatient Clinic"><strong>Veterans Administration Outpatient Clinic</strong></a> or call the national department of Veterans Affairs at <a href="tel:+1-800-827-1000" aria-label="Call 800-827-1000">800-827-1000</a>.</p>
+<h3><span><a id="advance-directives">Advance Directives</a></span></h3>
+<p>Advance Health Care Directives are legal documents that let you communicate your health care wishes in advance, in case you become unable to speak for yourself.
+Sometimes people call these “Living Wills.”
+These documents include:</p>
+<ul>
+<li><strong>Advance Health Care Directives:</strong> Specifies which medical treatments you would or would not want if you become terminally ill or are in a persistent vegetative state</li>
+<li><strong>Healthcare Power of Attorney:</strong> Designates a trusted person to make medical decisions for you when you cannot</li>
+<li><strong>Physician Orders for Life-Sustaining Treatment:</strong> You can use this to tell physicians how much they should intervene to try to extend your life</li>
+<li><strong>Do Not Resuscitate (DNR) Orders:</strong> Expresses your desire to refuse resuscitation efforts in particular</li>
+<li><strong>Organ Donation Authorization:</strong> You give or withhold permission for your organs, tissues, or body parts to be donated when you die, or put conditions on how they can be used</li>
+</ul>
+<p>These documents help to ensure that your healthcare wishes are respected even if you are incapacitated and cannot express them yourself.
+They usually must be signed by you <em>and</em> by certain witnesses to be effective.
+It is a good idea to create such documents <em>before</em> you need them, as when you need them you will be preoccupied or unable.
+Give these documents to your healthcare providers so they know to respect your specific preferences.</p>
+<p>The free websites <a href="https://prepareforyourcare.org/" data-external-link="true">PREPARE for Your Care</a> and <a href="https://theconversationproject.org/" data-external-link="true">The Conversation Project</a> can help you create advance directive documents that match your needs and your preferences.
+The <a href="https://eforms.com/power-of-attorney/ca/california-advanced-health-care-directive/" data-external-link="true">California Advance Directive Form</a> website has several varieties of advance directive forms in PDF format that you can review or print.</p>
+<p><a href="#" data-directory-link="Senior-Legal-Services-Project" aria-label="View directory entry for Senior Legal Services Project"><strong>Senior Legal Services Project</strong></a>, <a href="#" data-directory-link="California-Rural-Legal-Assistance" aria-label="View directory entry for California Rural Legal Assistance (CRLA)"><strong>California Rural Legal Assistance (CRLA)</strong></a>, and <a href="#" data-directory-link="SLO-Legal-Assistance-Foundation" aria-label="View directory entry for SLO Legal Assistance Foundation (SLOLAF)"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a> can give you free help to make your advance directive documents clear and legally binding.</p>
+<p><a href="#" data-directory-link="Hospice-SLO" aria-label="View directory entry for Hospice SLO"><strong>Hospice SLO</strong></a> offers advanced directive assistance either in-person at its offices, or by phone or internet conferencing.</p>
+<p>Your healthcare provider or hospice can help you complete a Physician Orders for Life-Sustaining Treatment (POLST) form.
+It instructs medical care providers whether they should try to extend your life however they can, or whether they should avoid certain types of burdensome treatments like CPR, feeding tubes, or a mechanical breathing apparatus.
+A POLST form only works if you or your legally-recognized decision-maker signs it <em>and</em> your physician, nurse practitioner, or physician assistant also signs it.
+You can change your mind after you submit such a form and can change it or discontinue it.
+You can learn more about the form and review one online, in several languages, at <a href="https://capolst.org/" data-external-link="true">capolst.org</a>.</p>
+<hr>
+<h2><span><a id="personal-safety">Personal Safety, Deescalation, Self-Defense</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#self-defense-classes">Self-Defense Classes and Martial Arts</a></li>
+<li><a href="#personal-safety-tips">Personal Safety Tips</a></li>
+</ul>
+<h3><span><a id="self-defense-classes">Self-Defense Classes and Martial Arts</a></span></h3>
+<p>Sometimes relatively inexpensive self-defense or martial arts classes are offered through the “Community Programs” at <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> (see the <a href="https://www.cuesta.edu/communityprograms/community-recreation/martial-arts/index.html" data-external-link="true">“Martial Arts”</a> section of their website) or <a href="#" data-directory-link="San-Luis-Coastal-Adult-School" aria-label="View directory entry for San Luis Coastal Adult School"><strong>San Luis Coastal Adult School</strong></a> (see the <a href="https://ae.slcusd.org/community-programs" data-external-link="true">“Community Programs”</a> section of their website).</p>
+
+
+
+<h3><span><a id="personal-safety-tips">Personal Safety Tips</a></span></h3>
+<p>To stay safe on the streets, stay aware of your surroundings.
+Be alert when you walk alone, and avoid distractions like phones or headphones.
+Trust your instincts—if a situation feels unsafe, go somewhere safer.
+Walk with confidence: keep your eyes forward, and maintain a steady pace.
+These simple behaviors can make you less vulnerable to potential threats.</p>
+<p>Learning to identify trustworthy people is one of the most important street skills you can develop, though it takes time and experience.
+Be cautious when forming new relationships—sometimes people experiencing homelessness are victimized by people who say they want to help.
+Watch for “red flags” like people who try to exploit your vulnerabilities, who offer deals that seem too good to be true, or who pressure you into uncomfortable or vulnerable situations.
+Connect with peers who understand your situation, as these relationships often provide both safety and emotional support.
+Remember that developing good judgment about people is a gradual process, not something you can master immediately.</p>
+<p>Whenever possible, travel with trusted companions rather than going places alone.
+Having someone you trust with you provides both practical safety and moral support.
+Build a network of friends who protect each other.
+Such connections improve your physical safety and also your overall well-being and security.</p>
+<p>If you use emergency shelters, address your security concerns with the staff before you settle in.
+(For example, if you see someone at the shelter who has been threatening to you in the past, or if you are not sure your possessions will be secure where you have been told to leave them.)
+Some people choose to sleep on the streets rather than in shelters because of safety concerns.
+If you do stay outside, you need to balance the risks of harassment in public places against the risk of assault in more secluded areas.
+Stay vigilant even in places that are supposed to be safe.</p>
+<p>If you find yourself in a dangerous situation, your primary goal should be to escape and get help rather than to fight.
+The best approach to self-defense is to avoid physical violence through awareness and de-escalation.
+If you do need to defend yourself, learn a few simple techniques that can make an attacker reconsider and give you time to get away.
+When possible, take formal self-defense classes to learn proper techniques from trained instructors.</p>
+<p><strong>Sources:</strong></p>
+<ul>
+<li><a href="https://www.instructables.com/Basic-Street-Safety-for-Women/" data-external-link="true">“Basic Street Safety for Women”</a></li>
+<li><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC2776751/" data-external-link="true">“Capacity for Survival: Exploring Strengths of Homeless Street Youth”</a></li>
+<li><a href="https://www.thebautistaprojectinc.org/post/personal-security-homeless-shelter" data-external-link="true">“Personal Security &amp; Safety When Living In A Homeless Shelter”</a></li>
+</ul>
+<hr>
+<h2><span><a id="legal-help">Legal Help &amp; Crime Victim Protection</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#defendants-and-convicts">Help for Defendants, Convicts, Parolees, Probationers</a></li>
+<li><a href="#housing-legal">Legal Help Regarding Housing (Discrimination, Landlord Disputes, etc.)</a></li>
+<li><a href="#benefits-legal">Help with Benefits, Wrangling with Health Insurers, et Cetera</a></li>
+<li><a href="#consumer-protection">Consumer Protection</a></li>
+<li><a href="#crime-victims">Victims of Crime, Abuse</a></li>
+<li><a href="#legal-self-help">Legal Self-Help / Law Libraries</a></li>
+<li><a href="#legal-consultation">Legal Consultation</a></li>
+<li><a href="#family-law">Family Law / Child Support</a></li>
+<li><a href="#immigration-law">Immigration Law</a></li>
+<li><a href="#senior-legal-services">Senior Legal Services</a></li>
+<li><a href="#tax-disputes">Tax Disputes</a></li>
+<li><a href="#legal-miscellany">Miscellany</a></li>
+</ul>
+<h3><span><a id="defendants-and-convicts">Help for Defendants, Convicts, Parolees, Probationers</a></span></h3>
+<p>If you are being taken to court and accused of a serious crime by the government, you have the right to have a lawyer who is trained in the law to help defend you against the charges.
+You have a right to a lawyer even if you do not have enough money to pay one.
+If you cannot afford to hire a lawyer, tell the judge so when you first appear in court, and the judge will assign a public defender to you.
+<a href="#" data-directory-link="SLO-Public-Defenders" aria-label="View directory entry for SLO Public Defenders"><strong>SLO Public Defenders</strong></a> is the primary public defenders’ office in SLO County.
+You must wait until the judge assigns a particular public defender to you before you can discuss your case with them.</p>
+<p>If you have been in jail or prison and are reentering the community after doing your time or being released on parole, <a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a> can help make your reentry successful.
+They can give you housing assistance including clean &amp; sober living homes, and help returning to the workforce.
+Call or email them to learn more.</p>
+<p>If you have a criminal record that makes it difficult for you to find employment or housing, you may be able to clean that record.
+The “Clean Slate Clinic” is a joint project of <a href="#" data-directory-link="Peoples-Justice-Project" aria-label="View directory entry for People’s Justice Project"><strong>People’s Justice Project</strong></a>, <a href="#" data-directory-link="California-Rural-Legal-Assistance" aria-label="View directory entry for California Rural Legal Assistance"><strong>California Rural Legal Assistance</strong></a>, and <a href="#" data-directory-link="SLO-College-of-Law-Legal-Clinic" aria-label="View directory entry for SLO College of Law Legal Clinic"><strong>SLO College of Law Legal Clinic</strong></a>.
+Contact them at <a href="tel:+1-805-902-2752" aria-label="Call 805-902-2752">805-902-2752</a> or <a href="tel:+1-805-242-6691" aria-label="Call 805-242-6691">805-242-6691</a> to schedule an appointment.</p>
+<p>U.S. military veterans who enter the criminal justice system may be able to get services from <a href="https://www.slocounty.ca.gov/departments/district-attorney/adult-prosecutions/veterans-treatment-court" data-external-link="true">“Veterans Treatment Court”</a> if the activity they were arrested or prosecuted for is attributed to conditions like post-traumatic stress disorder, traumatic brain injury, sexual trauma, or other causes related to military service.
+Veterans Treatment Court is a rigorous 12–18 month program of supervised probation customized for the needs of traumatized veterans which includes treatment, counseling, and regular court appearances.
+Contact <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for County Veterans Services"><strong>County Veterans Services</strong></a> for help getting into this program.</p>
+<h3><span><a id="housing-legal">Legal Help Regarding Housing (Discrimination, Landlord Disputes, etc.)</a></span></h3>
+<p><a href="#" data-directory-link="California-Rural-Legal-Assistance" aria-label="View directory entry for California Rural Legal Assistance"><strong>California Rural Legal Assistance</strong></a> provides free civil legal assistance to low-income people.
+This includes cases concerning foreclosures, evictions &amp; lockouts, Section 8 and public housing, and housing discrimination.</p>
+<p><a href="#" data-directory-link="SLO-Legal-Assistance-Foundation" aria-label="View directory entry for SLO Legal Assistance Foundation (SLOLAF)"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a> helps low-income people in SLO County with legal support.
+Among the issues they help with are eviction defense for tenants, landlord/tenant conflicts, habitability/repair issues, accessibility for people with disabilities, Fair housing and discrimination, Section 8 housing, unlawful rent increases, and mobile home law.</p>
+<p>The <a href="#" data-directory-link="California-Civil-Rights-Department" aria-label="View directory entry for California Civil Rights Department"><strong>California Civil Rights Department</strong></a> can help you understand your rights to be protected from illegal <a href="https://calcivilrights.ca.gov/housing/" data-external-link="true">housing discrimination</a> and can also help you investigate and file formal discrimination complaints.</p>
+<p>The California advocacy organization <a href="https://tenantstogether.org/" data-external-link="true">Tenants Together</a> (<a href="mailto:info@tenantstogether.org" aria-label="Email info@tenantstogether.org">info@tenantstogether.org</a>) has a tenants’ rights hotline at <a href="tel:+1-888-495-8020" aria-label="Call 888-495-8020">888-495-8020</a> (text <a href="sms:+1-650-600-7821?&amp;body=HELPLINE">650-600-7821</a>).
+They also have an on-line self-help <a href="https://www.tenantstogether.org/covid-19-tenant-defense" data-external-link="true">Tenant Defense Toolkit</a> to help you understand your rights as a renter and how to enforce those rights.</p>
+<p>The California Department of Real Estate published a <a href="https://www4.courts.ca.gov/documents/California-Tenants-Guide.pdf" data-external-link="true"><em>California Tenants’ Guide</em></a> (<a href="https://www4.courts.ca.gov/documents/California-Tenants-Guide-Spanish.pdf" data-external-link="true">Español</a>) which gives a detailed explanation of California law concerning tenants of rental properties.</p>
+<p>SLO city has a <a href="https://linktr.ee/slorentcoalition" data-external-link="true">Tenants Union</a> (<a href="tel:+1-805-779-1639" aria-label="Call 805-779-1639">805-779-1639</a>).</p>
+<p>The SLO branch of Democratic Socialists of America have a <a href="https://slocialism.org/housing-justice/" data-external-link="true">Housing Justice</a> guide for tenants in San Luis Obispo.
+It tries to explain how you can best assert and defend your legal rights as a renter.</p>
+<p>The <a href="#" data-directory-link="Long-Term-Care-Ombudsman" aria-label="View directory entry for Long Term Care Ombudsman"><strong>Long Term Care Ombudsman</strong></a> can help you fight for your rights if you are being improperly evicted from a long term care facility.</p>
+<p>U.S. military veterans who have low incomes and who are homeless or at risk of homelessness can get help from <a href="#" data-directory-link="Supportive-Services-for-Veteran-Families" aria-label="View directory entry for Supportive Services for Veteran Families"><strong>Supportive Services for Veteran Families</strong></a>.
+This help includes temporary financial assistance for rent, deposits, and utilities, legal assistance, rental agreement education, and landlord-tenant mediation.
+You must have a DD214 with discharge other than dishonorable.</p>
+<h3><span><a id="benefits-legal">Help with Benefits, Wrangling with Health Insurers, etc.</a></span></h3>
+<blockquote>
+<p>See the <a href="#navigating-social-security">Navigating Social Security / SSDI / SSI / Survivors Benefits</a> section for advice specific to those programs.</p>
+</blockquote>
+<p><a href="#" data-directory-link="HiCAP" aria-label="View directory entry for Health Insurance Counseling &amp; Advocacy Program (“HiCAP”)"><strong>Health Insurance Counseling &amp; Advocacy Program (“HiCAP”)</strong></a> offers free and unbiased information about Medicare and its options.
+HiCAP can also help you file Medicare denial appeals or make Medicare fraud referrals.
+To use the local HiCAP program you must be eligible for Medicare and you must be a resident of SLO or Santa Barbara counties.
+HiCAP is free.</p>
+<p>Central California Legal Services’ <a href="https://centralcallegal.org/health/" data-external-link="true">Health Consumer Center</a> program (<a href="tel:+1-800-464-3111" aria-label="Call 800-464-3111">800-464-3111</a>) helps people enroll and stay enrolled in health insurance programs, helps make sure those programs cover the medical care you need, and helps people who are improperly billed or subject to improper collections actions because of medical treatment.</p>
+<p>If you are a U.S. military veteran, you can get help learning about, applying for, and receiving government benefits you are entitled to from the <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for County Veterans Services Offices"><strong>County Veterans Services Offices</strong></a>.</p>
+
+
+<h3><span><a id="consumer-protection">Consumer Protection</a></span></h3>
+<p>To report a consumer complaint directly to the SLO District Attorney, you can use <a href="https://www.slocounty.ca.gov/departments/district-attorney/special-prosecutions/consumer-protection" data-external-link="true">the consumer complaint form</a> on their website.</p>
+<p>Identity theft is when someone else pretends to be you—for example by using your name, identification, or credit card number—to commit fraud or to put the blame on you for something they have done.
+You can report identity theft with the Federal Trade Commission at <a href="https://www.identitytheft.gov/" data-external-link="true">IdentityTheft.gov</a> or <a href="tel:+1-877-438-4338" aria-label="Call 877-438-4338">877-438-4338</a> and they can help you take steps to protect yourself.</p>
+<p>If you believe you have been defrauded by an automotive repair shop, you can get help from the <a href="https://bar.ca.gov/" data-external-link="true">Bureau of Automotive Repairs</a> (<a href="tel:+1-800-952-5210" aria-label="Call 800-952-5210">800-952-5210</a> or <a href="mailto:BARenforcement@dca.ca.gov" aria-label="Email BARenforcement@dca.ca.gov">BARenforcement@dca.ca.gov</a>).</p>
+<p>The <a href="#" data-directory-link="California-DMV" aria-label="View directory entry for California Department of Motor Vehicles"><strong>California Department of Motor Vehicles</strong></a> has an investigations division that enforces laws relating to new and used vehicle dealers.
+If you are the victim of fraud or other illegal action by a vehicle dealer, you can <a href="https://dmvinvestigations.my.site.com/INVCMS/s/" data-external-link="true">file a complaint online</a>.</p>
+<p>If you are the victim of fraud or other illegal action concerning a bank account, credit card, debt collector, money transfer, payday loan, or something like that, you may be able to get help from the <a href="https://www.consumerfinance.gov/complaint/" data-external-link="true">Consumer Financial Protection Bureau</a> (<a href="tel:+1-855-411-2372" aria-label="Call 855-411-2372">855-411-2372</a>).</p>
+<p>The <a href="#" data-directory-link="Long-Term-Care-Ombudsman" aria-label="View directory entry for Long Term Care Ombudsman"><strong>Long Term Care Ombudsman</strong></a> can help you fight for your rights if you are being mistreated by or improperly evicted from a long term care facility.</p>
+<p>Many service providers are licensed by the State of California (for example, health care providers, accountants, security guards, social workers, etc.).
+If you believe you have been treated unfairly or improperly by a licensed service provider, you can file a complaint with the <a href="https://www.dca.ca.gov/" data-external-link="true">California Department of Consumer Affairs</a> (<a href="tel:+1-800-952-5210" aria-label="Call 800-952-5210">800-952-5210</a>/TTY:<a href="tel:+1-800-735-2929" aria-label="Call 800-735-2929">800-735-2929</a>, <a href="mailto:dca@dca.ca.gov" aria-label="Email dca@dca.ca.gov">dca@dca.ca.gov</a>).</p>
+<h3><span><a id="crime-victims">Victims of Crime, Abuse</a></span></h3>
+<p>Victims of crime have certain legal rights, and they may be asked to participate in crime investigations or to testify in criminal cases.
+The <a href="#" data-directory-link="Victim-Witness-Assistance-Program" aria-label="View directory entry for Victim Witness Assistance Program"><strong>Victim Witness Assistance Program</strong></a> helps crime victims who are navigating this process.
+It can help you understand your rights, obtain support services, get help with court appearances, apply for restitution, and get notifications about important updates concerning the criminal case against your victimizer(s).</p>
+<p>If you have been the victim of a violent crime, the <a href="https://victims.ca.gov/" data-external-link="true">California Victim Compensation Board</a> (<a href="tel:+1-800-777-9229" aria-label="Call 800-777-9229">800-777-9229</a>) can help you get financial restitution, medical treatment, mental health counseling, and other help.</p>
+<p>If you are the victim of sexual assault or intimate partner violence, <a href="#" data-directory-link="Lumina-Alliance" aria-label="View directory entry for Lumina Alliance"><strong>Lumina Alliance</strong></a> can help you advocate for your rights and can accompany you through the legal process.</p>
+<p><a href="#" data-directory-link="CASA" aria-label="View directory entry for CASA (Court Appointed Special Advocates)"><strong>CASA (Court Appointed Special Advocates)</strong></a> helps to advocate on behalf of abused or neglected children in the court system.
+CASA advocates are court-appointed; you cannot request their services directly.</p>
+
+
+<h3><span><a id="legal-self-help">Legal Self-Help / Law Libraries</a></span></h3>
+
+
+<p>If you need to research the law, legal precedents, and legal processes, you can visit the <a href="#" data-directory-link="SLO-County-Law-Library" aria-label="View directory entry for SLO County Law Library"><strong>SLO County Law Library</strong></a>, a free research library.
+The library has thousands of print volumes and also has publicly-accessible computers at which you can access WestLaw, CEB OnLaw, NOLO Guides, Bell’s Compendium, and other electronic legal databases.
+It also has tools with which you can create documents that conform to the standards of local courts.</p>
+<p>If you are filing a small claims case (a civil dispute involving less than $10,000, in which the parties are not represented in court by lawyers), a family law case (for example divorce, child support, child custody), a request for a restraining order, or certain other matters you can get free help from <a href="#" data-directory-link="SLO-Court-Self-Help-Services" aria-label="View directory entry for SLO Court Self-Help Services"><strong>SLO Court Self-Help Services</strong></a>.</p>
+<p><a href="#" data-directory-link="SLO-Superior-Court" aria-label="View directory entry for SLO Superior Court"><strong>SLO Superior Court</strong></a> also has some guides on:</p>
+<ul>
+<li><a href="https://selfhelp.courts.ca.gov/immigration" data-external-link="true">immigration resources</a></li>
+<li>how to obtain <a href="https://www.slo.courts.ca.gov/self-help/gun-violence-restraining-orders" data-external-link="true">gun violence</a>, <a href="https://www.slo.courts.ca.gov/self-help/civil-harassment-restraining-order" data-external-link="true">civil harassment</a>, and <a href="https://www.slo.courts.ca.gov/self-help/family-law/domestic-violence" data-external-link="true">domestic violence</a> restraining orders</li>
+<li>the process of going to court for child custody and support, <a href="https://www.slo.courts.ca.gov/self-help/family-law/divorce" data-external-link="true">divorce, legal separation, and annulment</a>, and other <a href="https://www.slo.courts.ca.gov/self-help/family-law" data-external-link="true">family law</a> matters</li>
+<li>the processes of <a href="https://www.slo.courts.ca.gov/self-help/name-change" data-external-link="true">legal name changes</a> and <a href="https://www.slo.courts.ca.gov/self-help/gender-change" data-external-link="true">gender changes</a></li>
+</ul>
+<p>The state of California’s <a href="https://selfhelp.courts.ca.gov/small-claims-california" data-external-link="true">Small claims in California</a> web page is also a good introduction to the small claims process.</p>
+<p>The SLO Law Line (<a href="tel:+1-805-548-8884" aria-label="Call 805-548-8884">805-548-8884</a>) gives free basic legal advice to people who cannot afford an attorney, and can help you find additional legal assistance.
+Call to make an appointment for a telephone consultation.</p>
+<p>U.S. military veterans can get help from the <a href="https://www.statesidelegal.org/" data-external-link="true">StateSideLegal</a> website, which has information about how to file benefits claims and denial appeals, how to defend civil rights claims, and other legal matters.</p>
+<h3><span><a id="legal-consultation">Legal Consultation in General</a></span></h3>
+<p>If you need to confer with a lawyer or other legal consultant, you have several options.</p>
+<p>The <a href="#" data-directory-link="SLO-County-Bar-Association" aria-label="View directory entry for SLO County Bar Association"><strong>SLO County Bar Association</strong></a>’s <a href="https://slobar.org/Information-and-referral-service/" data-external-link="true">Attorney Referral Service</a> can help you find a lawyer who is most appropriate to your case.
+This service is free for personal injury, worker’s compensation, and criminal law cases, but costs $50 otherwise.</p>
+<p>The <a href="#" data-directory-link="SLO-Legal-Assistance-Foundation" aria-label="View directory entry for SLO Legal Assistance Foundation (SLOLAF)"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a> provides free legal assistance on civil law and family law (not criminal law) matters to low-income people in SLO County.</p>
+<p><a href="#" data-directory-link="California-Rural-Legal-Assistance" aria-label="View directory entry for California Rural Legal Assistance (CRLA)"><strong>California Rural Legal Assistance (CRLA)</strong></a> provides free civil law (not criminal law) services to low-income people in SLO County.</p>
+<p><a href="#" data-directory-link="Peoples-Justice-Project" aria-label="View directory entry for People’s Justice Project"><strong>People’s Justice Project</strong></a> is a non-profit law firm that can provide affordable legal representation to people with low- or moderate-income in criminal law or civil rights cases.</p>
+<p>U.S. military veterans can use the <a href="https://www.statesidelegal.org/" data-external-link="true">StateSideLegal</a> website’s <a href="https://www.statesidelegal.org/helpnavigate?clear=true" data-external-link="true">Veterans Legal Help Navigator</a> to find legal representatives that best match the needs of your case.</p>
+<p><a href="#" data-directory-link="ACLU" aria-label="View directory entry for ACLU of Southern California"><strong>ACLU of Southern California</strong></a> can provide limited legal advice in civil liberties and civil rights cases.
+It has limited resources and typically focuses on specific cases which it hopes to use to force systemic changes.
+It does not accept walk-ins.
+It offers several free <a href="https://www.aclusocal.org/en/know-your-rights" data-external-link="true">Know Your Rights</a> guides, but note that these can be more reflective of what the ACLU believes your legal rights are on paper than what the law enforcement system actually respects.</p>
+<h3><span><a id="family-law">Family Law / Child Support</a></span></h3>
+<p><a href="#" data-directory-link="Child-Support-Services" aria-label="View directory entry for Child Support Services"><strong>Child Support Services</strong></a> can help you locate parents who may owe child support, establish parentage, obtain and enforce support orders, and collect payments.</p>
+<p>If you are filing a family law case, you can get free help from <a href="#" data-directory-link="SLO-Court-Self-Help-Services" aria-label="View directory entry for SLO Court Self-Help Services"><strong>SLO Court Self-Help Services</strong></a>.</p>
+<p><a href="#" data-directory-link="SLO-Superior-Court" aria-label="View directory entry for SLO Superior Court"><strong>SLO Superior Court</strong></a> has some guides on the process of going to court for child custody and support, <a href="https://www.slo.courts.ca.gov/self-help/family-law/divorce" data-external-link="true">divorce, legal separation, and annulment</a>, and other <a href="https://www.slo.courts.ca.gov/self-help/family-law" data-external-link="true">family law</a> matters.</p>
+<h3><span><a id="immigration-law">Immigration Law</a></span></h3>
+
+
+<p><a href="#" data-directory-link="SLO-County-UndocuSupport" aria-label="View directory entry for SLO County UndocuSupport"><strong>SLO County UndocuSupport</strong></a> has <a href="https://www.sloundocusupport.org/immigrantservicesguide" data-external-link="true">a list of legal assistance services</a> that includes <a href="https://docs.google.com/spreadsheets/d/1FRaVSHBETqYvk1-aDJ-ULYsHvpfXaLFuAhS7tjwPBKA/edit?usp=sharing" data-external-link="true">a chart of which local legal aid groups provide which specific immigration-related legal services</a>.</p>
+<p><a href="#" data-directory-link="Catholic-Charities" aria-label="View directory entry for Catholic Charities"><strong>Catholic Charities</strong></a> has an <a href="https://catholiccharitiesdom.org/immigration-citizenship/" data-external-link="true">Immigration and Citizenship Program</a> to help people with issues such as U.S citizenship applications, immigration status changes, DACA, U-Visas, VAWA-Visas, and consular visa processes.</p>
+<p><a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a> hosts the <a href="https://uuslo.org/Immigration-Legal-Services" data-external-link="true">Unitarian Universalist Refugee and Immigrant Services Education (UURISE)</a> program, which offers free or low-cost immigration legal services.</p>
+<p><a href="#" data-directory-link="Immigrant-Hope-Arroyo-Grande" aria-label="View directory entry for Immigrant Hope Arroyo Grande"><strong>Immigrant Hope Arroyo Grande</strong></a> is an immigration legal services center that can help you with naturalization, consular processing, immigration status changes, temporary protective status, DACA, green card renewals, and visas.</p>
+<p><a href="#" data-directory-link="SLO-College-of-Law-Legal-Clinic" aria-label="View directory entry for SLO College of Law"><strong>SLO College of Law</strong></a> holds <a href="https://montereylaw.edu/clinics/immigrationclinic.html" data-external-link="true">immigration clinics</a> by telephone or Zoom on Mondays between 4pm and 6pm.
+They can help you with DACA renewal, visas, naturalization/citizenship, and green cards.
+This costs $15.
+Schedule an appointment at their website or by calling <a href="tel:+1-831-582-3600" aria-label="Call 831-582-3600">831-582-3600</a>.</p>
+<p><a href="#" data-directory-link="SLO-Superior-Court" aria-label="View directory entry for SLO Superior Court"><strong>SLO Superior Court</strong></a> also has some free <a href="https://selfhelp.courts.ca.gov/immigration" data-external-link="true">immigration resources</a>.</p>
+<p><a href="#" data-directory-link="Central-Coast-Coalition-for-Undocumented-Student-Success" aria-label="View directory entry for Central Coast Coalition for Undocumented Student Success"><strong>Central Coast Coalition for Undocumented Student Success</strong></a> operates Dream (or Monarch) Centers at local colleges (Cal Poly, Cuesta, and Allan Hancock).
+These centers help students with (among other things) DACA application assistance and other legal help:</p>
+<ul>
+<li><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> provides free immigration legal services to students, faculty, and staff.
+Make an appointment to talk to an advisor <a href="https://findyourally.com/" data-external-link="true">here</a> or call <a href="tel:+1-805-246-3867" aria-label="Call 805-246-3867">805-246-3867</a> or <a href="tel:+1-805-546-3109" aria-label="Call 805-546-3109">805-546-3109</a></li>
+<li>Cal Poly’s Dream Center provides free and confidential <a href="#" data-directory-link="Immigrant-Legal-Defense" aria-label="View directory entry for Immigrant Legal Defense"><strong>Immigrant Legal Defense</strong></a> to Cal Poly students, recent graduates, employees, and immediate family members.
+This includes deportation defense (detained and non-detained), DACA applications and renewals, family-based immigration petitions, U &amp; T visa applications, VAWA cases, asylum claims, lawful permanent resident status, and citizenship applications</li>
+<li>The Allan Hancock College <a href="https://www.hancockcollege.edu/aimtodream/index.php" data-external-link="true">AIM to Dream Center</a> offers free immigration legal services to all students, faculty, and staff.
+This includes DACA, citizenship, family petitions, adjustments of status, among other things.</li>
+</ul>
+<p>If you call the Rapid Response Hotline at <a href="tel:+1-805-870-8855" aria-label="Call 805-870-8855">805-870-8855</a>, you can get know-your-rights information and referrals to trusted attorneys (nonprofit, private, or public) from the “805 Immigrant Rapid Response Network.”</p>
+<p>The <a href="https://www.ilrc.org/community-resources" data-external-link="true">Immigrant Legal Resource Center</a> and the <a href="https://www.immigrantdefenseproject.org/" data-external-link="true">Immigrant Defense Project</a> can also help you with know-your-rights information and with finding legal help.</p>
+<h3><span><a id="senior-legal-services">Senior Legal Services</a></span></h3>
+<p>The <a href="#" data-directory-link="Senior-Legal-Services-Project" aria-label="View directory entry for Senior Legal Services Project"><strong>Senior Legal Services Project</strong></a> offers free legal help for people in SLO County who are age 60 and up.
+They can help you navigate the legal issues around benefits rights assistance, consumer protection, housing discrimination and eviction prevention, advance medical directives and durable power of attorney, will preparation, and protective/restraining orders.
+They often hold by-appointment clinics at local Senior Centers, or you can contact their office directly via the <a href="#" data-directory-link="SLO-Legal-Assistance-Foundation" aria-label="View directory entry for SLO Legal Assistance Foundation (SLOLAF)"><strong>SLO Legal Assistance Foundation (SLOLAF)</strong></a>.</p>
+<h3><span><a id="tax-disputes">Tax Disputes</a></span></h3>
+<p>The Orfalea College of Business at Cal Poly operates a <a href="https://orfalea.calpoly.edu/low-income-taxpayer-clinic" data-external-link="true">Low Income Taxpayer Clinic</a> at <a href="#" class="map-link" data-lat="35.299891" data-lon="-120.664977" data-zoom="17" data-label="Business Building">Cal Poly’s SLO campus, building 3, room 107</a>, M–Th 9am–5pm and F 9am–1pm.</p>
+<p>They represent low-income clients for free in tax controversies before the I.R.S. and the U.S. Tax Court.
+Their help is available in English and Spanish.
+This service is only available to you if the amount the IRS says you owe is $50,000 per tax year or less, and your household’s total income does not exceed 250 percent of the federal poverty guidelines.</p>
+<p>To use this service, complete <a href="https://orfalea.calpoly.edu/low-income-taxpayer-clinic/prospective-clients" data-external-link="true">an intake form</a> which is available on their website, or call them at <a href="tel:+1-877-318-6772" aria-label="Call 877-318-6772">877-318-6772</a> (Español: <a href="tel:+1-805-756-5725" aria-label="Call 805-756-5725">805-756-5725</a>)
+You can also ask for more information by email at <a href="mailto:litc@calpoly.edu" aria-label="Email litc@calpoly.edu">litc@calpoly.edu</a>.</p>
+<h3><span><a id="legal-miscellany">Miscellany</a></span></h3>
+<blockquote>
+<p>See the <a href="#advance-directives">Advance Directives</a> section of this guide for help on how to make legally-binding advance directives such as Advance Care Directives, Healthcare Power of Attorney, Physician Orders for Life-Sustaining Treatment (POLST), Do Not Resuscitate (DNR) orders, and organ donation authorizations.</p>
+</blockquote>
+<p>The <a href="#" data-directory-link="California-Civil-Rights-Department" aria-label="View directory entry for California Civil Rights Department"><strong>California Civil Rights Department</strong></a> enforces California’s laws against certain forms of discrimination in employment, housing, business, and services, and against hate crimes and human trafficking.
+If you believe you have been treated illegally in ways like these, you can <a href="https://calcivilrights.ca.gov/complaintprocess/" data-external-link="true">file a discrimination complaint</a>, <a href="https://stophate.calcivilrights.ca.gov/s/" data-external-link="true">report a hate crime</a> with them and request that they investigate.</p>
+<p>The Americans with Disabilities Act protects people who have disabilities from discrimination.
+The <a href="https://www.ada.gov/" data-external-link="true">ada.gov</a> website explains this Act and how you can enforce your rights under it.
+That site also shows you how to <a href="https://www.ada.gov/file-a-complaint/" data-external-link="true">file an official complaint</a>.
+You can also reach the U.S. Department of Justice’s Americans with Disabilities Act section at <a href="tel:+1-800-514-0301" aria-label="Call 800-514-0301">800-514-0301</a> (TTY: <a href="tel:+1-833-610-1264" aria-label="Call 833-610-1264">833-610-1264</a>) or <a href="mailto:Disability.Outreach@usdoj.gov" aria-label="Email Disability.Outreach@usdoj.gov">Disability.Outreach@usdoj.gov</a>.</p>
+<hr>
+<h2><span><a id="ids-and-other-documents">IDs and Other Documents</a> (How to Obtain, Replace, Secure)</span></h2>
+<p>Often, agencies and programs will ask you to produce certain documents, like a government identification card (such as a driver’s license), a social security card, a birth certificate, and so forth.
+If you have lost such documents, or have never obtained them, this can be an obstacle to working with those agencies and programs.</p>
+<p>This section of the guide shows you how to obtain or replace documents like these.</p>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#social-security-numbers-or-cards">Social Security Numbers or Cards</a></li>
+<li><a href="#id-cards-drivers-licenses">ID Cards and Driver’s Licenses</a></li>
+<li><a href="#birth-death-marriage-certificates">Birth, Death, and Marriage Certificates</a></li>
+<li><a href="#civil-case-documents">Civil Case Documents</a></li>
+<li><a href="#passports">Passports</a></li>
+<li><a href="#document-tips">Tips</a></li>
+</ul>
+<h3><span><a id="social-security-numbers-or-cards">Social Security Numbers or Cards</a></span></h3>
+<p>You do not often need your social security card, but you do often need your social security number.
+The <a href="#" data-directory-link="Social-Security-Administration" aria-label="View directory entry for Social Security Administration"><strong>Social Security Administration</strong></a> can help you get a new Social Security card.</p>
+<p>If you have an account or can create an on-line account at <a href="https://www.ssa.gov/myaccount" data-external-link="true">ssa.gov/myaccount</a>, you can request a Social Security card on-line and it will be mailed to you.
+You can get help with this process by calling <a href="tel:+1-800-772-1213" aria-label="Call 800-772-1213">800-772-1213</a> (TTY: <a href="tel:+1-800-325-0778" aria-label="Call 800-325-0778">800-325-0778</a>).</p>
+<blockquote>
+<p>See <a href="#mail-drops-post-office-boxes">Mail Drops, Post Office Boxes, Etc.</a> for ways to get mail if you do not have a stable mailing address.</p>
+</blockquote>
+<p>If you are unable to complete this on-line process, you can visit the local Social Security Administration office to get a new card.
+It will go more smoothly if you can bring some alternative form of identification like a driver’s license or passport.
+In the absence of those, a military ID, employee ID, school ID, or health insurance card might be helpful.</p>
+<h3><span><a id="id-cards-drivers-licenses">ID Cards and Driver’s Licenses</a></span></h3>
+<p>A state-issued “Real ID,” or a California driver’s license which is also a Real ID, is a useful form of government-issued photo identification card that is widely accepted by a variety of programs, businesses, and service providers.
+You get such an identification card from the <a href="#" data-directory-link="California-DMV" aria-label="View directory entry for California DMV"><strong>California DMV</strong></a>.
+You must visit the California DMV office to have your photo taken and to submit your paperwork.</p>
+<p>You typically first need to already have another identification document (such as a certified birth certificate, a passport, a permanent resident card, a certificate of naturalization or citizenship, or a permanent resident card) as well as documents that demonstrate your California residency (such as a utility bill, tax return, bank statement, or rental agreement that contains your name and address).
+There are also fees you typically must pay to obtain either a Real ID or a driver’s license that operates as a Real ID.</p>
+<p>However, if you are homeless, you may be able to get a waiver for fees (a “no-fee ID card”), and you may be able to use the address of a homeless shelter or other homeless services agency as your California residency address.
+This is true even if you are only temporarily homeless because you are fleeing domestic violence or a similar dangerous situation.
+You can only get a simple Real ID (“California Identification Card”) with the no-fee method, not a driver’s license.
+Homeless services providers like <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a>, the <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition (5CHC)"><strong>5Cities Homeless Coalition (5CHC)</strong></a>, or the <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> can help you with this process.</p>
+<p>If you have previously received a Real ID or California driver’s license, but you have lost the card and need to replace it, you can begin this process by visiting <a href="https://www.dmv.ca.gov/wasapp/oddl/oddlApplication.do" data-external-link="true">www.edl.dmv.ca.gov/apply</a> or the California DMV office.</p>
+<h3><span><a id="birth-death-marriage-certificates">Birth, Death, and Marriage Certificates</a></span></h3>
+<p>If you were born in SLO County, you can obtain a copy of your birth certificate from the <a href="#" data-directory-link="SLO-County-Clerk-Recorder" aria-label="View directory entry for SLO County Clerk-Recorder"><strong>SLO County Clerk-Recorder</strong></a>.
+You will need to show valid identification (typically, a government-issued photo ID like a driver’s license or passport).</p>
+<p>There is also a $32 fee.
+However, if you are homeless, you can request an “Affidavit of Homeless Status for Fee Exempt Certified Copy of Birth Certificate.”
+You need to sign this and you also need to get a signature from a “homeless services provider.”
+This exempts you from having to pay the $32 fee.
+Homeless services providers like <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a>, the <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition (5CHC)"><strong>5Cities Homeless Coalition (5CHC)</strong></a>, or the <a href="#" data-directory-link="ECHO" aria-label="View directory entry for El Camino Homeless Organization (ECHO)"><strong>El Camino Homeless Organization (ECHO)</strong></a> can help you with this process.</p>
+<p>You can obtain a “certified copy” of a birth certificate for yourself or your child or other close relative.
+A certified copy allows you to establish your identity.
+Otherwise you can obtain an “informational” copy, which is not valid for establishing identity.
+You should understand ahead of time whether or not you need a certified copy, and, if so, you should be sure to ask for one specifically when you order your copy.</p>
+<p>You can also use the <a href="https://www.vitalchek.com/v/vital-records/california/san-luis-obispo-county-recorder" data-external-link="true">VitalChek</a> website to order an <em>informational</em> copy of your birth certificate on-line without visiting the SLO County Clerk-Recorder office.
+(You may need to provide a notarized, sworn statement if you want to order a “certified copy” this way, in which case it is probably just as easy to visit the SLO County Clerk-Recorder office.)
+That may cost a bit more.</p>
+<p>Death records for deaths that occurred in SLO County can also be obtained from the SLO County Clerk-Recorder ($24) or from VitalChek.
+Again, there is a difference between “certified” and “informational” copies of death certificates, and you should check which one you need before you order it.
+You can typically only get a “certified” copy for a close relative, and you may have to provide additional documentation.</p>
+<p>You can also get a copy of a marriage certificate that was issued in SLO County from the SLO County Clerk-Recorder office ($17) or from VitalChek.
+Again, there is a difference between “certified” and “informational” copies, and you should check which one you need before you order it.
+You can typically only get a “certified” copy for yourself or a close relative, and you may have to provide additional documentation.</p>
+<p>There is no homeless fee exemption program for death and marriage certificates the way there is for birth certificates.</p>
+<p>If you need a birth, death, or marriage certificate from another county in California, try the <a href="https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records.aspx" data-external-link="true">California Department of Public Health’s “Vital Records”</a> web page.
+If you need such records from elsewhere in the U.S. outside California, visit the <a href="https://www.cdc.gov/nchs/w2w/index.htm" data-external-link="true">National Center for Health Statistics</a> web page.
+The VitalChek website can often also get you these records from other areas.</p>
+<h3><span><a id="civil-case-documents">Civil Case Documents</a></span></h3>
+<p>To get copies of <a href="#" data-directory-link="SLO-Superior-Court" aria-label="View directory entry for SLO Superior Court">SLO Superior Court</a> documents in civil cases to which you are a party, first go to the court offices in San Luis Obispo or in Paso Robles.
+Those offices have a publicly-accessible computer at which you can find your case number.
+Court staff can help you with this process.
+Then review the documents associated with that case, choose which documents you want, and request them.
+You must pay 50¢ per page to get printouts of these documents.</p>
+<p>If you cannot go to the court offices, you can follow the procedure described on <a href="https://www.slo.courts.ca.gov/self-help/civil-appeals/getting-copies-court-files" data-external-link="true">this web page</a> to order documents by mail.</p>
+<p>If you have a lawyer, that lawyer may be able to search for these documents on-line themselves.</p>
+<blockquote>
+<p>See the <a href="#legal-help">Legal Help &amp; Crime Victim Protection</a> section for some tips on getting help from a lawyer.</p>
+</blockquote>
+<h3><span><a id="passports">Passports</a></span></h3>
+<p>A U.S. passport is required for international travel to most countries outside the United States.
+You need a passport to travel by air, land, or sea to most international destinations.</p>
+<h4><span><a id="first-time-passport">Getting a Passport for the First Time</a></span></h4>
+<p>To apply for your first U.S. passport, you must apply in person at an authorized passport acceptance facility.
+You cannot apply by mail for a first-time passport.
+It costs $165 total ($130 application fee + $35 execution fee) to apply for an adult passport.
+You must bring the following documents:</p>
+<ol>
+<li>Proof of U.S. citizenship (Certified U.S. birth certificate with official seal, or Certificate of Naturalization, or Certificate of Citizenship, or Consular Report of Birth Abroad, or a previous U.S. passport)<ul>
+<li>Note: Digital or mobile birth certificates are not accepted; you must bring a physical birth certificate</li>
+</ul>
+</li>
+<li>A photo identification with your picture (driver’s license, government employee ID, U.S. military ID, or Certificate of Naturalization or Citizenship)<ul>
+<li>Note: Digital or photocopied documents are not accepted; you must bring the original document</li>
+<li>You must also submit photocopies of the front and back of your ID</li>
+</ul>
+</li>
+<li>A recent passport photo that meets official requirements</li>
+<li>A completed Form DS-11 (do not it sign until you are instructed to do so by the passport agent)</li>
+</ol>
+<p>You also must provide an address where you can receive your passport by mail.
+If you do not have a stable address, consider using a mail drop service (see the <a href="#mail-drops-post-office-boxes">Mail drops section</a> of this guide).</p>
+<p>You can apply for a passport at the post office.
+Call them to make an appointment:</p>
+<table>
+<thead>
+<tr>
+<th>City</th>
+<th>Post Office Address</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="City">Atascadero</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="35.464331" data-lon="-120.648234" data-zoom="17" data-label="Post Office">9800 El Camino Real</a></td>
+<td data-label="Phone"><a href="tel:+1-805-461-6161" aria-label="Call 805-461-6161">805-461-6161</a></td>
+</tr>
+<tr>
+<td data-label="City">Cayucos</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="35.449964" data-lon="-120.903495" data-zoom="17" data-label="Post Office">97 Ash St.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-995-3479" aria-label="Call 805-995-3479">805-995-3479</a></td>
+</tr>
+<tr>
+<td data-label="City">Grover Beach</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="35.121670" data-lon="-120.619893" data-zoom="17" data-label="Post Office">917 W. Grand Ave.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-489-5138" aria-label="Call 805-489-5138">805-489-5138</a></td>
+</tr>
+<tr>
+<td data-label="City">Guadalupe</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="34.971861" data-lon="-120.571864" data-zoom="17" data-label="Post Office">1030 Guadalupe St.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-353-4061" aria-label="Call 805-353-4061">805-353-4061</a></td>
+</tr>
+<tr>
+<td data-label="City">Oceano</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="35.098991" data-lon="-120.611433" data-zoom="17" data-label="Post Office">1800 Beach St.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-489-6515" aria-label="Call 805-489-6515">805-489-6515</a></td>
+</tr>
+<tr>
+<td data-label="City">Pismo Beach</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="35.135025" data-lon="-120.606878" data-zoom="17" data-label="Post Office">100 Crest Dr.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-481-5971" aria-label="Call 805-481-5971">805-481-5971</a></td>
+</tr>
+<tr>
+<td data-label="City">San Luis Obispo</td>
+<td data-label="Post Office Address"><a href="#" class="map-link" data-lat="35.260524" data-lon="-120.680128" data-zoom="17" data-label="Post Office">1655 Dalidio Dr.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-543-2605" aria-label="Call 805-543-2605">805-543-2605</a></td>
+</tr>
+</tbody></table>
+<p>If you are applying for a new passport, if your passport expired more than five years ago and you need a new one, or if your passport was lost or damaged and you need a new one, you can also apply for a passport at certain <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> branches. 
+Call them to make an appointment:</p>
+<ul>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for Atascadero Library"><strong>Atascadero Library</strong></a></li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for Nipomo Library"><strong>Nipomo Library</strong></a></li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO City Library"><strong>SLO City Library</strong></a></li>
+</ul>
+<h4><span>Renewing Your Passport</span></h4>
+<p>You can renew your passport by mail if all of the following are true:</p>
+<ul>
+<li>You have your most recent passport with you</li>
+<li>Your passport is not damaged or mutilated</li>
+<li>Your passport was issued when you were age 16 or older</li>
+<li>Your passport was issued in the last 15 years</li>
+<li>Your passport is in your current name (or you can document a legal name change)</li>
+</ul>
+<p>If you meet these requirements, you can renew by mail using Form DS-82.
+This costs $130 for adults.
+You can also renew online at <a href="https://travel.state.gov/content/travel/en/passports/have-passport/renew-online.html" data-external-link="true">travel.state.gov</a> if you meet additional eligibility requirements.</p>
+<p>If you cannot renew by mail (for example, if your passport is lost, stolen, damaged, or expired more than five years), you must apply in person using the same process as for a first-time passport.</p>
+<h4><span>Replacing a Lost or Stolen Passport</span></h4>
+<p>If your passport is lost or stolen, follow these steps to get a new one:</p>
+<ol>
+<li><p><strong>Report it immediately:</strong>
+  Report your passport lost or stolen as soon as possible.
+  This protects you from identity theft.
+  You can report <a href="https://pptform.state.gov/" data-external-link="true">online using Form DS-64</a>, by calling <a href="tel:+1-877-487-2778" aria-label="Call 877-487-2778">877-487-2778</a> (TTY <a href="tel:+1-888-874-7793" aria-label="Call 888-874-7793">888-874-7793</a>), or in person when you apply for a replacement.
+  Note that if you report your passport lost or stolen, you can no longer use it for travel even if you find it later.</p>
+</li>
+<li><p><strong>Apply for a replacement:</strong>
+  To replace a lost or stolen passport, apply in person at an authorized passport acceptance facility.
+  The process and requirements are the same as for a first-time passport application (<a href="#first-time-passport">see above</a>).
+  Reporting your passport lost or stolen does not replace it; to get a replacement you must also apply for a new passport.
+  This costs $165.</p>
+</li>
+</ol>
+<h4><span>Passports from Other Countries</span></h4>
+<p>If you are a citizen of another country and you need to obtain or renew a passport from your home country, contact your country’s embassy or consulate.
+The nearest consulates for many countries are located in Los Angeles or San Francisco.
+You can find contact information for embassies and consulates at <a href="https://embassy.goabroad.com/" data-external-link="true">embassy.goabroad.com</a> or by searching online for your country’s embassy or consulate in the United States.</p>
+<h3><span><a id="document-tips">Tips</a></span></h3>
+<h4><span>Document Storage and Security</span></h4>
+<p>Here are some tips for handling important documents:</p>
+<ul>
+<li>Use your phone camera to take photos of important documents, and save those photos “in the cloud” (iCloud for iPhone, Google Photos for Android) so still have access to your photos if your phone is lost or stolen.</li>
+<li>Make copies of important documents, and store the copies separately from the originals.
+That way if you lose one set, you are less likely to lose all of them.</li>
+<li>Some homeless services centers offer document storage for their clients.
+Ask your case worker if they can store your important documents in your file at those agencies.</li>
+<li>If you have enough money, consider storing especially important or difficult-to-replace documents in a safety deposit box at a bank.
+These can be rented for $30–50 per year.</li>
+</ul>
+<h4><span>If You Have No Identification Documents</span></h4>
+<p>If you are completely without identifying documentation, you may need help establishing your identity so that you can access programs and services that require identifying documentation.</p>
+<p>You may want to begin by contacting the <a href="#" data-directory-link="Social-Security-Administration" aria-label="View directory entry for Social Security Administration"><strong>Social Security Administration</strong></a> who can assist you in verifying your identity through their records.</p>
+<p><a href="#" data-directory-link="SLO-Court-Self-Help-Services" aria-label="View directory entry for SLO Court Self-Help Services"><strong>SLO Court Self-Help Services</strong></a> can help you through California’s affidavit processes, with which you can establish your identity when you lack identity documentation.
+This way you can get a California photo ID card, which helps you get access to many programs and services.
+There is an expensive filing fee for this process, but ask about a fee waiver that is available to people with low incomes.</p>
+<p>If you have a case manager, ask them if they can help you with this process.</p>
+<hr>
+<h2><span><a id="mail-drops-post-office-boxes">Mail Drops, Post Office Boxes, Etc.</a></span></h2>
+<p>If you are homeless, you may be at a loss when asked for your mailing address.
+There are various ways to establish a reliable mailing address even if you do not have a stable living address.</p>
+<p>The <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> and <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> offices permit clients of their services to use these offices as mailing addresses, and will hold your incoming mail there for you. 
+Ask them for details.</p>
+<p>You can rent mail boxes from UPS Stores and from the U.S. Postal Service.
+The Postal Service option is the most affordable of the two.
+But sometimes, a “P.O. Box” address (which is what you get from the Postal Service) is not adequate for your needs, and one advantage of the UPS Store option is that it appears as a regular street address (e.g. “1241 Johnson Avenue #1234, San Luis Obispo”).
+UPS Store locations with mailbox rental services are available throughout SLO County including:</p>
+<table>
+<thead>
+<tr>
+<th>City</th>
+<th>UPS Store Location</th>
+<th>Phone</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="City">Arroyo Grande</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.119852" data-lon="-120.605397" data-zoom="17" data-label="UPS Store">1375 E. Grand Ave. #103</a></td>
+<td data-label="Phone"><a href="tel:+1-805-904-6480" aria-label="Call 805-904-6480">805-904-6480</a></td>
+</tr>
+<tr>
+<td data-label="City">Atascadero</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.483837" data-lon="-120.660562" data-zoom="17" data-label="UPS Store">7343 El Camino Real</a></td>
+<td data-label="Phone"><a href="tel:+1-805-466-9015" aria-label="Call 805-466-9015">805-466-9015</a></td>
+</tr>
+<tr>
+<td data-label="City">Morro Bay</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.368768" data-lon="-120.844887" data-zoom="17" data-label="UPS Store">630 Quintana Rd.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-772-9284" aria-label="Call 805-772-9284">805-772-9284</a></td>
+</tr>
+<tr>
+<td data-label="City">Nipomo</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.038131" data-lon="-120.489689" data-zoom="17" data-label="UPS Store">110 South Mary Ave. #2</a></td>
+<td data-label="Phone"><a href="tel:+1-805-929-0055" aria-label="Call 805-929-0055">805-929-0055</a></td>
+</tr>
+<tr>
+<td data-label="City">Paso Robles</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.616733" data-lon="-120.682645" data-zoom="17" data-label="UPS Store">179 Niblick Rd.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-237-8727" aria-label="Call 805-237-8727">805-237-8727</a></td>
+</tr>
+<tr>
+<td data-label="City">Pismo Beach</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.136200" data-lon="-120.624797" data-zoom="17" data-label="UPS Store">567 Five Cities Dr.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-295-6581" aria-label="Call 805-295-6581">805-295-6581</a></td>
+</tr>
+<tr>
+<td data-label="City">SLO</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.249339" data-lon="-120.642032" data-zoom="17" data-label="UPS Store">3940 Broad St.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-549-0200" aria-label="Call 805-549-0200">805-549-0200</a></td>
+</tr>
+<tr>
+<td data-label="City">SLO</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.293776" data-lon="-120.671971" data-zoom="17" data-label="UPS Store">793 Foothill Blvd.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-541-9333" aria-label="Call 805-541-9333">805-541-9333</a></td>
+</tr>
+<tr>
+<td data-label="City">SLO</td>
+<td data-label="UPS Store Location"><a href="#" class="map-link" data-lat="35.282248" data-lon="-120.656089" data-zoom="17" data-label="UPS Store">1241 Johnson Ave.</a></td>
+<td data-label="Phone"><a href="tel:+1-805-541-1334" aria-label="Call 805-541-1334">805-541-1334</a></td>
+</tr>
+</tbody></table>
+<p>Another option is to ask people to send you mail addressed to <a href="https://faq.usps.com/s/article/What-is-General-Delivery" data-external-link="true">“General Delivery”</a>:</p>
+<blockquote>
+<p><em>Your Name</em><br>
+General Delivery<br>
+<em>City Name</em>, CA <em>ZIP-Code</em>‒9999</p>
+</blockquote>
+<p>You can collect mail that is sent to you via General Delivery from the post office.
+Here are some General Delivery zip codes for SLO County:</p>
+<table>
+<thead>
+<tr>
+<th>Post Office</th>
+<th>Pick-up Address</th>
+<th>ZIP Code</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Post Office">Arroyo Grande</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.121805" data-lon="-120.580037" data-zoom="17" data-label="Post Office">160 Station Way</a></td>
+<td data-label="ZIP Code">93420‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Atascadero</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.464331" data-lon="-120.648234" data-zoom="17" data-label="Post Office">9800 El Camino Real</a></td>
+<td data-label="ZIP Code">93422‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Cambria</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.563988" data-lon="-121.081246" data-zoom="17" data-label="Post Office">4100 Bridge St.</a></td>
+<td data-label="ZIP Code">93428‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Cayucos</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.449483" data-lon="-120.903533" data-zoom="17" data-label="Post Office">97 Ash Ave.</a></td>
+<td data-label="ZIP Code">93430‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Grover Beach</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.121670" data-lon="-120.619893" data-zoom="17" data-label="Post Office">917 W. Grand Ave.</a></td>
+<td data-label="ZIP Code">93433‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Los Osos</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.310118" data-lon="-120.828820" data-zoom="17" data-label="Post Office">1189 Los Osos Valley Rd.</a></td>
+<td data-label="ZIP Code">93402‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Morro Bay</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.366647" data-lon="-120.847324" data-zoom="17" data-label="Post Office">898 Napa Ave.</a></td>
+<td data-label="ZIP Code">93442‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Nipomo</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.035132" data-lon="-120.488569" data-zoom="17" data-label="Post Office">630 W. Tefft St.</a></td>
+<td data-label="ZIP Code">93444‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Oceano</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.098991" data-lon="-120.611433" data-zoom="17" data-label="Post Office">1800 Beach St.</a></td>
+<td data-label="ZIP Code">93445‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Paso Robles</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.619901" data-lon="-120.689465" data-zoom="17" data-label="Post Office">800 6th St.</a></td>
+<td data-label="ZIP Code">93446‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Pismo Beach</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.135025" data-lon="-120.606878" data-zoom="17" data-label="Post Office">100 Crest Dr.</a></td>
+<td data-label="ZIP Code">93449‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">San Luis Obispo</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.260524" data-lon="-120.680128" data-zoom="17" data-label="Post Office">1655 Dalidio Dr.</a> (main)</td>
+<td data-label="ZIP Code">93401‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">San Simeon</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.612276" data-lon="-121.145205" data-zoom="17" data-label="Post Office">250 San Simeon Ave. Ste 7</a></td>
+<td data-label="ZIP Code">93452‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Santa Margarita</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.391744" data-lon="-120.608109" data-zoom="17" data-label="Post Office">22360 El Camino Real</a></td>
+<td data-label="ZIP Code">93453‒9999</td>
+</tr>
+<tr>
+<td data-label="Post Office">Templeton</td>
+<td data-label="Pick-up Address"><a href="#" class="map-link" data-lat="35.557484" data-lon="-120.700688" data-zoom="17" data-label="Post Office">101 N. Main St.</a></td>
+<td data-label="ZIP Code">93465‒9999</td>
+</tr>
+</tbody></table>
+<p><strong>Note</strong>: In cities with multiple post office locations, General Delivery is typically handled at only one facility (usually the main post office). For example, San Luis Obispo has two post offices, but General Delivery is handled at the main location on Dalidio Dr.
+To confirm which location handles General Delivery in your area, call <a href="tel:+1-800-275-8777" aria-label="Call 800-275-8777">800-275-8777</a> and request “Customer Service,” or use the <a href="https://tools.usps.com/zip-code-lookup.htm" data-external-link="true">USPS ZIP Code lookup tool</a> by entering “General Delivery” as the address line.</p>
+
+
+<p>You should speak with the postmaster at the post office where you want to receive general delivery mail beforehand.
+The post office will hold general delivery mail for you for 30 days.
+You must have a valid photo ID to collect your mail at the post office.
+This service is free.
+However, this is not a long-term solution; it is meant for temporary use (for instance by travelers passing through town).
+The post office may stop accepting general delivery mail for you if you try to use this method for a long time or if you get too much mail.</p>
+
+
+<hr>
+<h2><span><a id="banking-and-money-management">Banking and Money Management</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#banks-and-credit-unions">Banks and Credit Unions</a></li>
+<li><a href="#financial-literacy">Financial Literacy Classes and 1-on-1 Assistance</a></li>
+<li><a href="#debt-consolidation">Debt Consolidation</a></li>
+</ul>
+<h3><span><a id="banks-and-credit-unions">Banks and Credit Unions</a></span></h3>
+<p>Credit unions are like banks, but are nonprofit organizations that tend to be locally-focused.
+They can often be more accommodating than banks to people with low incomes and to homeless people.</p>
+<p>Credit unions in SLO County include:</p>
+<ul>
+<li><a href="#" data-directory-link="CoastHills-Credit-Union" aria-label="View directory entry for CoastHills Credit Union"><strong>CoastHills Credit Union</strong></a></li>
+<li><a href="#" data-directory-link="Golden-1-Credit-Union" aria-label="View directory entry for Golden 1 Credit Union"><strong>Golden 1 Credit Union</strong></a></li>
+<li><a href="#" data-directory-link="SESLOC-Credit-Union" aria-label="View directory entry for SESLOC Credit Union"><strong>SESLOC Credit Union</strong></a></li>
+<li><a href="#" data-directory-link="SLO-Credit-Union" aria-label="View directory entry for SLO Credit Union"><strong>SLO Credit Union</strong></a></li>
+</ul>
+<p>Some ordinary banks offer “Bank On Certified Accounts” which are savings or checking accounts that are more affordable, have small minimum balances, and have no overdraft fees.
+You can search for banks that offer such accounts at <a href="https://joinbankon.org/accounts/" data-external-link="true">joinbankon.org</a>.</p>
+<blockquote>
+<p>See the <a href="#mail-drops-post-office-boxes">Mail Drops, Post Office Boxes, Etc.</a> section of this guide if you do not have a stable address and you need an address you can use while establishing a bank account.</p>
+</blockquote>
+<blockquote>
+<p>See the <a href="#ids-and-other-documents">IDs and other documents</a> section of this guide for information on how to obtain required identification and other documentation.</p>
+</blockquote>
+<p><strong>Tips for how to succeed in establishing a bank account:</strong></p>
+<ul>
+<li>Call ahead: Contact banks before you visit and ask about their specific requirements</li>
+<li>Bring multiple documents: Have as much identification and address verification as possible</li>
+<li>Ask about special programs: Specifically inquire about programs for people without permanent addresses</li>
+<li>Consider credit unions first: They are often more flexible and community-focused than large banks</li>
+<li>Use service organization support: Have case workers or service providers help advocate and provide verification if needed</li>
+</ul>
+<h3><span><a id="financial-literacy">Financial Literacy Classes and 1-on-1 Assistance</a></span></h3>
+<p><a href="#" data-directory-link="SESLOC-Credit-Union" aria-label="View directory entry for SESLOC Credit Union"><strong>SESLOC Credit Union</strong></a> offers <a href="https://www.sesloc.org/why-sesloc/financial-education/seminars-and-webinars/" data-external-link="true">online webinars</a> on topics like debt management and the psychology of spending.
+These webinars are free to the public.
+They also offer free <a href="https://www.sesloc.org/why-sesloc/financial-education/greenpath-financial-counseling/" data-external-link="true">one-on-one, professional financial counseling</a> to SESLOC members.</p>
+<p><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Central Coast"><strong>Goodwill Central Coast</strong></a> has a free “Opportunity Platform” that includes one-on-one financial coaching services to help you achieve your personal money goals.</p>
+<h3><span><a id="debt-consolidation">Debt Consolidation</a></span></h3>
+<p><a href="https://www.moneymanagement.org/" data-external-link="true">Money Management International</a> (<a href="tel:+1-866-889-9347" aria-label="Call 866-889-9347">866-889-9347</a>) and <a href="https://www.nfcc.org/" data-external-link="true">National Foundation for Credit Counseling</a> (<a href="tel:+1-800-388-2227" aria-label="Call 800-388-2227">800-388-2227</a>) are nonprofit groups that can help you manage credit card or other debt.</p>
+<hr>
+<h2><span><a id="tax-preparation">Tax Preparation</a></span></h2>
+<p>There are several programs that can give you free assistance in completing and filing your annual tax returns.
+Free tax assistance programs are usually available in the February-through-April period.</p>
+<p>Even if you do not think you owe any taxes because your income is very low, it can be to your advantage to file a tax return.
+This is for a few reasons:</p>
+<ol>
+<li>You may qualify for certain refundable tax credits that can put money in your pocket, even if you did not pay taxes all year.</li>
+<li>Some programs for low-income people require those people to show their most recent tax return to prove that they qualify.</li>
+<li>Filing a tax return, even if it is of no practical effect, can be a gesture of compliance with the law that can be helpful, for example if you are engaged in the U.S. immigration process.</li>
+</ol>
+<p>Avoid using commercial tax preparers that charge high fees, or that offer “refund anticipation loans.”
+Some of these give poor-quality tax advice, and most of them are bad bargains compared to the free services.</p>
+<p>If you are due a tax refund, you will get that refund more quickly if you have a bank account that accepts direct deposit.
+The U.S. Internal Revenue Service stopped issuing paper tax refund checks in 2025.</p>
+<blockquote>
+<p>See the <a href="#banking-and-money-management">Banking and Money Management</a> section of this guide for help in establishing a bank account.</p>
+</blockquote>
+<p>The national Volunteer Income Tax Assistance (VITA) program allows low- and moderate-income people to get free help in preparing and filing their federal and state tax returns.
+<a href="#" data-directory-link="United-Way" aria-label="View directory entry for United Way of SLO County"><strong>United Way of SLO County</strong></a> coordinates the local VITA program through various partner organizations, including Cal Poly and <a href="#" data-directory-link="AARP-Tax-Aide" aria-label="View directory entry for AARP"><strong>AARP</strong></a>.
+The AARP Tax-Aide Program is especially for people over age 50.
+Use United Way’s <a href="tel:+1-211" aria-label="Call 211">211</a> service to find a VITA location near you and make an appointment.
+The United Way also has <a href="https://www.myfreetaxes.org/file-with-virtual-help/" data-external-link="true">an on-line program</a> with which you can upload your tax documents and get free help from tax preparation volunteers over the internet.</p>
+<p>There are also free options that allow you to file your federal income taxes yourself by using guided tax preparation software or by filling in on-line forms and filing them electronically.
+See <a href="https://www.irs.gov/freefile" data-external-link="true">irs.gov/freefile</a> for details.</p>
+
+
+<blockquote>
+<p>See the <a href="#internet-and-email">Internet Access / Email / Digital Access Assistance</a> section of this guide for ways to get access to a computer and the internet.</p>
+</blockquote>
+<p>Homeless people can use the address of a friend, relative, or trusted service provider as their filing address.</p>
+<blockquote>
+<p>See the <a href="#mail-drops-post-office-boxes">Mail Drops, Post Office Boxes, Etc.</a> section of this guide for more options for establishing a mailing address.</p>
+</blockquote>
+<hr>
+<h2><span><a id="emergency-financial-help">Emergency Financial Help</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#financial-aid-apply-yourself">You Can Apply Yourself</a></li>
+<li><a href="#financial-aid-get-referral">You Must Apply through Some Referring Agency</a></li>
+<li><a href="#government-assistance-programs">Government Assistance Programs</a></li>
+<li><a href="#utility-assistance-programs">Utility Assistance Programs</a></li>
+</ul>
+<p>If you need to pay a bill or make a purchase and you have no money, there are some programs available that may be able to help you.
+For some of these, you can apply directly to the agency running the program to ask for their help.
+For others, you can only apply through some other agency (your case manager, doctor, or social worker may be able to do this for you if you ask).</p>
+<p>Some of these programs are specific to certain regions or to certain sorts of financial needs.</p>
+<p>Many do not give you money directly, but help you purchase goods or pay bills.</p>
+<blockquote>
+<p>See the <a href="#financial-literacy">Banking and money management</a> section of this guide for financial literacy and credit counseling resources that can help you reduce your debt or save money for when you need it.</p>
+</blockquote>
+<h3><span><a id="financial-aid-apply-yourself">You Can Apply Yourself</a></span></h3>
+<p><a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> has an <a href="https://5chc.org/programs/immediate-needs" data-external-link="true">Immediate Needs</a> program that can help low-income families and individuals in need in the Five Cities area with limited funds to pay for bills, or for goods or services to address their immediate needs such as utilities, transportation, auto repairs, clothing, and employment readiness.
+No funds are given directly to the individual applicant; rather bills are paid or goods are purchased on their behalf.</p>
+<p><a href="#" data-directory-link="UUSLO" aria-label="View directory entry for Unitarian Universalists San Luis Obispo"><strong>Unitarian Universalists San Luis Obispo</strong></a> has a “Minister’s Discretionary Fund” with which it can pay for emergency needs like vehicle registration, repair, payments, or impound fees; property storage fees; travel for healthcare; phones and phone service; or supplies for living outdoors.
+Email <a href="mailto:minister.uuslo@gmail.com" aria-label="Email minister.uuslo@gmail.com">minister.uuslo@gmail.com</a> if you need such help.</p>
+<p><a href="#" data-directory-link="Green-Pastures" aria-label="View directory entry for Green Pastures"><strong>Green Pastures</strong></a>, operated by the First Presbyterian Church in SLO city, offers micro-grants for financial needs such as utility bills and medical bills, with a focus on helping people stay in their homes.
+See <a href="https://fpcslo.org/greenpastures" data-external-link="true">their website</a> for details on how and when to apply for these grants.</p>
+<p><a href="#" data-directory-link="St-Patricks-Church" aria-label="View directory entry for St. Patrick’s Church"><strong>St. Patrick’s Church</strong></a> in Arroyo Grande has limited discretionary funds for specific emergency needs such as utility payments or partial rent.</p>
+<p>The <a href="#" data-directory-link="Auntie-Isabell-Foundation" aria-label="View directory entry for Auntie Isabell Foundation"><strong>Auntie Isabell Foundation</strong></a> gives financial assistance (grants and business development microloans) to “underrepresented individuals” in Paso Robles.
+Grants can be for needs like education, housing, transportation, job preparation, addressing life challenges, and child care. 
+You must be aged 18–30 to qualify for a grant. 
+You can apply for grants or loans by completing a form on their website. </p>
+<p>The <a href="#" data-directory-link="Society-of-St-Vincent-de-Paul" aria-label="View directory entry for Society of St. Vincent de Paul"><strong>Society of St. Vincent de Paul</strong></a> can help with an emergency such as a threatened utility cut-off or a housing eviction notice, or a job-threatening transportation issue.
+They may also be able to help you with a rental deposit.</p>
+<p><a href="#" data-directory-link="Salvation-Army" aria-label="View directory entry for Salvation Army"><strong>Salvation Army</strong></a> provides some rent and utility assistance, when funds are available, from its SLO city and Arroyo Grande service centers.
+Call to make an appointment.</p>
+<p><a href="#" data-directory-link="Loaves-and-Fishes-Paso-Robles" aria-label="View directory entry for Loaves &amp; Fishes (Paso Robles)"><strong>Loaves &amp; Fishes (Paso Robles)</strong></a> can help people of limited means with groceries and other services.
+Use the <a href="https://loavesandfishespaso.org/contact/" data-external-link="true">contact form</a> on their website to request an appointment.</p>
+<p>The <a href="#" data-directory-link="Los-Osos-Cares" aria-label="View directory entry for Los Osos Cares"><strong>Los Osos Cares</strong></a> Resource Center can give immediate needs assistance to people in Los Osos, Baywood Park, Morro Bay, Cayucos, Cambria, and that general region.</p>
+<p><a href="#" data-directory-link="Jewish-Family-Services" aria-label="View directory entry for Jewish Family Services"><strong>Jewish Family Services</strong></a> offers once-per-year pre-paid gas card assistance for people in SLO County who need help with transportation costs.
+<a href="https://www.jccslo.com/gas.html" data-external-link="true">Submit an application on their website</a>.</p>
+<p><a href="#" data-directory-link="Catholic-Charities" aria-label="View directory entry for Catholic Charities"><strong>Catholic Charities</strong></a> operates a one-time “Emergency Rental Assistance” program.
+It is only available sometimes.
+Check <a href="https://catholiccharitiesdom.org/family-supportive-services/hope-in-home/" data-external-link="true">this web page</a> to see if the program is currently in effect and if so, how to apply for it.
+They also operate a <a href="https://catholiccharitiesdom.org/family-supportive-services/" data-external-link="true">“Financial Stability Services”</a> program which can provide financial resources to low-income people in financial crisis.
+To apply for these programs, first call their main or Paso Robles number to make an appointment.
+When applying for help, bring your identification, proof of income, and proof of need.
+If you are applying for help to pay the rent, also bring your rental agreement.
+If you are applying for help to pay utility bills, bring those bills.</p>
+<p>The local Facebook group <a href="https://www.facebook.com/groups/helpslo/" data-external-link="true">HelpSLO</a> invites people to post requests for needs they have, such as for new tires for their car, or school clothing for their children, or other things like that.
+However, you cannot ask for cash.
+The group is informal, and your need will be met (if it is) by the individual generosity of another group member.</p>
+<p>The national group <a href="https://www.modestneeds.org/" data-external-link="true">Modest Needs</a> crowdfunds requests for financial assistance for low-income workers who are living paycheck-to-paycheck and who encounter an unexpected or emergency expense they cannot afford, or who become unable to pay their bills.
+They do not give money to applicants directly, but can help them to pay bills.
+See <a href="https://www.modestneeds.org/mn/for-applicants" data-external-link="true">their website</a> for instructions on how to apply for a grant.</p>
+<p>If you are a <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> student, you can get help with food, housing, health and well-being, transportation, textbooks, parking passes, technology, and other basic needs from the <a href="https://www.cuesta.edu/student-support/support-programs/basic-needs-center/index.html" data-external-link="true">Basic Needs Office</a>.</p>
+<h3><span><a id="financial-aid-get-referral">You Must Apply through Some Referring Agency</a></span></h3>
+<p><a href="#" data-directory-link="North-County-NeighborAid" aria-label="View directory entry for North County NeighborAid"><strong>North County NeighborAid</strong></a> (managed by <a href="#" data-directory-link="CFS" aria-label="View directory entry for Center for Family Strengthening"><strong>Center for Family Strengthening</strong></a>) gives cash assistance and gifts of goods to needy people in northern SLO County. 
+Examples include gas cards for parents traveling to distant children’s hospitals, groceries following crises, rental assistance, baby supplies, summer camp fees, and utility payments. 
+Availability depends on the financial health of the organization (funding fluctuates). 
+You typically cannot apply directly to this program but must be referred to it by a service provider.</p>
+<p><a href="#" data-directory-link="Womenade" aria-label="View directory entry for Womenade"><strong>Womenade</strong></a> buys goods and pays bills for people in need.
+Womenade SLO helps people in the city of SLO; Womenade South County helps people in the Five Cities area and nearby; Womenade Estero Bay helps people in the Los Osos area.
+You cannot apply directly for help from Womenade, but you must apply through another service provider.</p>
+<p><a href="#" data-directory-link="Jewish-Family-Services" aria-label="View directory entry for Jewish Family Services"><strong>Jewish Family Services</strong></a> has a micro-grant program for people who need one-time emergency financial assistance for needs like rent assistance, vehicle needs, transportation, or food.
+You cannot apply for this yourself, but must have a case worker apply on your behalf.</p>
+<p><a href="https://joniandfriends.org/support/christian-fund-for-the-disabled/" data-external-link="true">Christian Fund for the Disabled</a> will match with its own money the grant given by a church or other Christian organization to a disabled person who has particular financial needs associated with their disability (such as the need for assistive equipment or rehabilitative therapy).
+Your application to this fund must include documentation from that church or Christian organization, among other things.</p>
+
+
+<h3><span><a id="government-assistance-programs">Government Assistance Programs</a></span></h3>
+<p><a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> (DSS) operates the General Assistance cash aid program which provides money and vouchers to people.
+It is for needy people without dependent children who live in SLO County who are not eligible for any other cash aid program.
+Apply for this program at a DSS office.
+If you qualify for this program, you must also do an in-person interview at the SLO city DSS office.</p>
+<p>You can also apply for <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs"><strong>CalWORKs</strong></a> cash aid at any DSS office, or online at <a href="https://benefitscal.com/" data-external-link="true">BenefitsCal</a>.
+CalWORKs is California’s version of the Temporary Assistance to Needy Families (TANF) federal program.
+To qualify, you must have a “qualifying child” at least one parent of whom is “deceased, absent from the home, disabled, or unemployed” and you must be below a certain maximum income/assets limit.
+You must participate in an in-person interview, and you may need to provide some documentation to verify your eligibility.
+To receive benefits, you may be required to participate in the Welfare-to-Work Program, which helps you prepare for, find, and maintain employment.</p>
+<p>If you are a refugee or an immigrant from Cuba or Haiti who is not eligible for CalWORKs, you may be able to get benefits from the <a href="https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/refugee-cash-assistance-%28rca%29-entrant-cash-assista" data-external-link="true">Refugee Cash Assistance (RCA) or Entrant Cash Assistance (ECA)</a> programs.
+If you are also a victim of human trafficking, domestic violence, or other serious crime, you may also qualify for <a href="https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/trafficking-crime-victims-assistance-program-%28cw%29" data-external-link="true">Trafficking &amp; Crime Victims Assistance Program (TCVAP)</a>.
+For any of these programs, you can apply in person at a <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> office.
+Bring proof of income and assets and documentation about your refugee or entry status, including your sponsor’s information if you have a sponsor.
+For TCVAP, you can also apply online at <a href="https://benefitscal.com/" data-external-link="true">BenefitsCal</a>.
+Refugees can also get help applying for these programs from <a href="#" data-directory-link="SLO4Home" aria-label="View directory entry for SLO for HOME"><strong>SLO for HOME</strong></a>.</p>
+<p>If you become unemployed, you may be able to apply for unemployment insurance benefits.
+This temporarily pays you part of the salary you earned while you were working.
+To qualify, you must have a Social Security number, be authorized to work in the United States, and earn some minimum amount of reported wages or salary during the previous 18 months.
+You must have become totally or partially unemployed, and through no fault of your own.
+You must also be able to work, looking for paid work, and able to accept paid work.
+You can apply for unemployment benefits from California’s <a href="#" data-directory-link="Employment-Development-Department" aria-label="View directory entry for Employment Development Department (EDD)"><strong>Employment Development Department (EDD)</strong></a> through <a href="https://edd.ca.gov/Unemployment/UI_Online.htm" data-external-link="true">the myEDD website</a> or by phone (<a href="tel:+1-800-300-5616" aria-label="Call 800-300-5616">800-300-5616</a>, TTY: <a href="tel:+1-800-815-9387" aria-label="Call 800-815-9387">800-815-9387</a>).
+If you have questions, you can also email <a href="mailto:WSBSanLuisObispoInfo@edd.ca.gov" aria-label="Email WSBSanLuisObispoInfo@edd.ca.gov">WSBSanLuisObispoInfo@edd.ca.gov</a>.</p>
+<p>If you are a U.S. military veteran, you can get help learning about, applying for, and receiving government benefits you are entitled to from the <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for County Veterans Services Offices"><strong>County Veterans Services Offices</strong></a>.</p>
+<p>If you are a farm laborer, you may be able to get some help applying for benefits from the <a href="https://californiafarmworkers.org/what-we-do/civil-assistance-program/" data-external-link="true">Civil Assistance Program</a> of the California Farmworker Foundation.</p>
+<h3><span><a id="utility-assistance-programs">Utility Assistance Programs</a></span></h3>
+
+
+<p>Some local utilities have or participate in programs to make it easier for people with limited means to pay their utility bills.</p>
+<p>The <a href="https://www.pge.com/en/account/billing-and-assistance/financial-assistance/california-alternate-rates-for-energy-program.html" data-external-link="true">PG&amp;E CARE Program</a> gives a discount of at least 20% on gas and electric bills to people with low incomes or who are enrolled in public assistance programs such as Medi-Cal, CalFresh, or SSI.
+If you do not qualify for that program, you may still qualify for <a href="https://www.pge.com/en/account/billing-and-assistance/financial-assistance/family-electric-rate-assistance-program-fera.html" data-external-link="true">Family Electric Rate Assistance</a> which can give you a 18% discount on your electric bill.
+Apply for either program online at <a href="https://energyinsight.pge.com/carefera" data-external-link="true">energyinsight.pge.com/carefera</a>
+If you have questions, contact them at <a href="mailto:CAREandFERA@pge.com" aria-label="Email CAREandFERA@pge.com">CAREandFERA@pge.com</a> or <a href="tel:+1-877-660-6789" aria-label="Call 877-660-6789">877-660-6789</a>.</p>
+<p>PG&amp;E also has a <a href="https://www.pge.com/en/account/billing-and-assistance/financial-assistance/relief-for-energy-assistance-through-community-help.html" data-external-link="true">Relief for Energy Assistance through Community Help (REACH)</a> program.
+It can help people who are threatened with energy bill shutoff during times of crisis by giving them a credit for the amount due on their bill.
+To apply, complete the <a href="https://www.hardshiptools.org/MyApp/Apply.aspx" data-external-link="true">Dollar Energy Fund</a> application form on-line, or call <a href="tel:+1-888-282-6816" aria-label="Call 888-282-6816">888-282-6816</a>.</p>
+<p><a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for CAPSLO"><strong>CAPSLO</strong></a> operates the <a href="https://capslo.org/utility-assistance/" data-external-link="true">Low Income Home Energy Assistance Program</a> (also known as HEAP or LIHEAP).
+This program helps low-income households in SLO County with one-time assistance to pay their gas, propane, or electric bill.
+It has limited funding, so is only able to offer help while funding is available.</p>
+<p>The City of SLO has <a href="https://www.slocity.org/government/department-directory/utilities-department/utility-billing/customer-assistance-programs" data-external-link="true">Customer Assistance Programs</a> that can reduce your water, sewer, trash, and recycling bills.
+For details on how to apply, contact the Utility Billing department at <a href="tel:+1-805-781-7133" aria-label="Call 805-781-7133">805-781-7133</a> or <a href="mailto:ub@slocity.org" aria-label="Email ub@slocity.org">ub@slocity.org</a>.</p>
+<p>Low-income households in Los Osos who qualify for in PG&amp;E’s CARE program (see above) can also get up to 50% off of their sewer bill by applying for <a href="https://www.slocounty.ca.gov/departments/public-works/services/programs-outreach/los-osos-low-income-financial-assistance-program" data-external-link="true">Los Osos Low Income Financial Assistance Program</a>.
+Contact the County Department of Public Works at <a href="mailto:PublicWorks@co.slo.ca.us" aria-label="Email PublicWorks@co.slo.ca.us">PublicWorks@co.slo.ca.us</a> or <a href="tel:+1-805-781-5252" aria-label="Call 805-781-5252">805-781-5252</a> for details.</p>
+<hr>
+<h2><span><a id="navigating-social-security">Navigating Social Security / SSDI / SSI / Survivors Benefits / CAPI</a></span></h2>
+<blockquote>
+<p>See the <a href="#social-security-numbers-or-cards">Social Security Numbers or Cards</a> section of this guide to learn how to get a Social Security number or to get or replace a Social Security card.</p>
+</blockquote>
+<p>Note: in 2025, Social Security stopped issuing paper checks.
+Now they use direct deposit to bank accounts or issue a “Direct Express” prepaid debit card.</p>
+<blockquote>
+<p>See the <a href="#banks-and-credit-unions">Banks and Credit Unions</a> section of this guide for information on how to establish a bank account.</p>
+</blockquote>
+<p>There are a number of programs operated by the Social Security Administration, including:</p>
+<ul>
+<li><strong>Social Security</strong> — monthly payments from the government to people who reach retirement age, and who paid into the social security system while they were working</li>
+<li><strong>Social Security Disability Insurance</strong> (SSDI) — monthly payments from the government to people who cannot work because they are disabled, and who paid into the social security system while they were working</li>
+<li><strong>Supplemental Security Income</strong> (SSI) — monthly payments from the government to disabled people and to seniors with limited means</li>
+</ul>
+<p>Homeless people have the same rights as anyone else to apply for these payments.
+You do not have to have a permanent address to receive benefits.</p>
+<p>You may be entitled to certain benefits even if you did not pay into the social security system, if your spouse or ex-spouse did.
+You may need to appear at the Social Security Administration office in person to apply for such spousal or survivors benefits.</p>
+<blockquote>
+<p>See the <a href="#mail-drops-post-office-boxes">Mail drops</a> section of this guide for information on establishing a mailing address.</p>
+</blockquote>
+<p>You can apply for these benefits through the local <a href="#" data-directory-link="Social-Security-Administration" aria-label="View directory entry for Social Security Administration"><strong>Social Security Administration</strong></a> office either in person or by phone.
+You can also <a href="https://www.ssa.gov/apply" data-external-link="true">apply on-line</a> at the Social Security Administration’s website.
+If you have a case worker, ask them if they can help you through the process or refer you to someone who can.</p>
+<p>To make the application process go smoothly, learn what documentation you need and have that documentation with you when you apply.
+If you do not have a stable mailing address, establish one ahead of time.
+If you are applying for disability, bring your relevant medical records, treatment history, and medical provider contact information.
+Pay stubs and tax records can help to establish your work history, especially if you were paid under-the-table or as a contractor rather than an employee.</p>
+<p>Be patient, as the process of applying for benefits can be time-consuming and the bureaucracy can move slowly.
+If you are denied benefits, learn about the appeals process and consider appealing the decision.</p>
+<p>If you are denied SSI benefits solely because of your immigration status, you may be able to get benefits instead from the <a href="https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/california-assistance-program-for-immigrants-%28capi%29" data-external-link="true">California Assistance Program for Immigrants (CAPI)</a>.
+Apply from the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>.</p>
+<p>If you have a disability and are applying for Social Security Disability Insurance, you may be able to get some immediate financial help from the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>’ “General Assistance Disabled Program” while you wait for your application to be processed.
+They may also be able to assign you a “Benefits Arch Advocate” who can help you apply for SSI and SSDI.</p>
+
+
+<p>The government encourages you to seek work and to return to work without losing disability benefits.
+The <a href="https://choosework.ssa.gov/" data-external-link="true">Ticket to Work Program</a> is a free, voluntary program for people aged 18–64 who are receiving SSDI or SSI benefits.
+It can give you free career counseling, vocational rehabilitation, and job placement and training.
+Call <a href="tel:+1-866-968-7842" aria-label="Call 866-968-7842">866-968-7842</a> (TTY: <a href="tel:+1-866-833-2967" aria-label="Call 866-833-2967">866-833-2967</a>) to learn how to apply.</p>
+<p>If you are a U.S. military veteran, you may also qualify for a variety of other benefits.
+You can get help learning about, applying for, and receiving government benefits you are entitled to from the <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for County Veterans Services Offices"><strong>County Veterans Services Offices</strong></a>.</p>
+<hr>
+<h2><span><a id="employment-job-boards">Employment, Job Boards, Etc.</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ol>
+<li><a href="#finding-steady-work">Finding Steady Work</a></li>
+<li><a href="#recycling">Making Ends Meet: Recycling</a></li>
+<li><a href="#gig-jobs">Making Ends Meet: Gig Jobs</a></li>
+</ol>
+<h3><span><a id="finding-steady-work">Finding Steady Work</a></span></h3>
+<p>The <a href="#" data-directory-link="SLO-Cal-Careers-Center" aria-label="View directory entry for SLO Cal Careers Center"><strong>SLO Cal Careers Center</strong></a> offers free employment and training, can help you improve your résumé and your interviewing skills, and can help you find job openings.
+They offer specialized services for young people, for veterans, and for people with disabilities.</p>
+<p><a href="#" data-directory-link="Eckerd-Connects-Workforce-Development" aria-label="View directory entry for Eckerd Connects Workforce Development"><strong>Eckerd Connects Workforce Development</strong></a> can help you explore career possibilities, get training and credentialing to help you qualify for more jobs, and find employment.
+<a href="https://eckerd.org/jobs-training/online-application/" data-external-link="true">Apply on-line at their website.</a></p>
+<p><a href="#" data-directory-link="CalJOBS" aria-label="View directory entry for CalJOBS"><strong>CalJOBS</strong></a> is a job listing and resume listing web site.
+You can search for open employment positions on the site, and you can add your resume so that employers can search for you.</p>
+<p>The state <a href="#" data-directory-link="Employment-Development-Department" aria-label="View directory entry for Employment Development Department (EDD)"><strong>Employment Development Department (EDD)</strong></a> offers many <a href="https://edd.ca.gov/en/jobs_and_training/Job_Seeker_Information/" data-external-link="true">job seeker services</a> such as free job training programs and job fairs.</p>
+<p>The <a href="#" data-directory-link="Employment-Development-Department" aria-label="View directory entry for Employment Development Department (EDD)"><strong>Employment Development Department (EDD)</strong></a> has a Migrant Seasonal Farmworker program that includes no-cost job search assistance, labor market info, vocational training, and information about your legal rights and labor law protections.</p>
+<p><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Central Coast"><strong>Goodwill Central Coast</strong></a> has a free “Opportunity Platform” that includes job search, resume building, digital literacy, and job readiness programs.</p>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> <a href="https://landing.brainfuse.com/authenticate.asp?u=main.sloh.ca.brainfuse.com" data-external-link="true">Brainfuse HelpNow eLearning</a> program can help you prepare for a variety of standardized tests, learn professional skills, and polish your resume.
+Its <a href="https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/center/jobandcareeraccelerator5/home?AuthToken=4DE278CD-C0CB-4ED5-84D4-2DFC47FF903D" data-external-link="true">EBSCOlearning</a> platform can help you prepare a good resume and cover letter, can improve your job search technique, and can better prepare you for a job interview.</p>
+<p>Recent refugees from other countries can also get help finding employment from <a href="#" data-directory-link="SLO4Home" aria-label="View directory entry for SLO for HOME"><strong>SLO for HOME</strong></a>.</p>
+
+
+<h4><span>For College Students</span></h4>
+<p>Cuesta College students, graduates, and staff can get help finding a job or an internship from <a href="https://www.cuesta.edu/student-support/career-work/career-services/index.html" data-external-link="true">Cuesta College Career Services</a> (<a href="mailto:CareerServices@cuesta.edu" aria-label="Email CareerServices@cuesta.edu">CareerServices@cuesta.edu</a>, <a href="tel:+1-805-546-3252" aria-label="Call 805-546-3252">805-546-3252</a> SLO, <a href="tel:+1-805-546-3232" aria-label="Call 805-546-3232">805-546-3232</a> Paso Robles).
+Call to make an appointment.</p>
+<p>Cal Poly (SLO) students, graduates, and staff can get help from <a href="https://careerservices.calpoly.edu/" data-external-link="true">Cal Poly Career Services</a> (<a href="mailto:careerservices@calpoly.edu" aria-label="Email careerservices@calpoly.edu">careerservices@calpoly.edu</a>, <a href="tel:+1-805-756-1111" aria-label="Call 805-756-1111">805-756-1111</a>, <a href="#" class="map-link" data-lat="35.298472" data-lon="-120.664092" data-zoom="17" data-label="Cal Poly Career Services">Student Services Building, room 114</a>).
+This includes career counseling, career and professional development certificates, interview clothes, and career fairs.
+They also conduct workshops on topics like job searching, building your resume, interview skills, and how to use LinkedIn.</p>
+<h4><span>For People with Disabilities</span></h4>
+<p>If you are currently receiving SSDI or SSI benefits and you are between the ages of 18 and 64, the <a href="https://choosework.ssa.gov/" data-external-link="true">Ticket to Work Program</a> can give you free career counseling, vocational rehabilitation, and job placement and training, and can help you return to work without losing your benefits.
+Call <a href="tel:+1-866-968-7842" aria-label="Call 866-968-7842">866-968-7842</a> (TTY: <a href="tel:+1-866-833-2967" aria-label="Call 866-833-2967">866-833-2967</a>) to learn how to apply.</p>
+<p><a href="#" data-directory-link="PathPoint" aria-label="View directory entry for PathPoint"><strong>PathPoint</strong></a> helps people with intellectual or developmental disabilities to find jobs that are good matches for them, trains them in job skills, and helps them to maintain employment.</p>
+<p><a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a> has <a href="https://www.t-mha.org/work-programs.php" data-external-link="true">work programs</a> to help people with mental illnesses find and maintain meaningful employment.
+They operate the Growing Grounds farm, nursery, and downtown SLO retail store, which employ TMHA clients and give them vocational training.</p>
+<p>TMHA also operates a <a href="https://www.t-mha.org/program-details.php?id=16" data-external-link="true">“Supported Employment Program”</a> which helps people with mental illnesses find and keep jobs.
+To use that program, you first must get a referral from <a href="#" data-directory-link="California-Department-of-Rehabilitation" aria-label="View directory entry for California Department of Rehabilitation"><strong>California Department of Rehabilitation</strong></a>, <a href="#" data-directory-link="SLO-County-Behavioral-Health" aria-label="View directory entry for SLO County Behavioral Health"><strong>SLO County Behavioral Health</strong></a>, or <a href="#" data-directory-link="SLO-County-Mental-Health-Services" aria-label="View directory entry for SLO County Mental Health Services"><strong>SLO County Mental Health Services</strong></a>.</p>
+<p><a href="#" data-directory-link="California-Department-of-Rehabilitation" aria-label="View directory entry for California Department of Rehabilitation"><strong>California Department of Rehabilitation</strong></a> offers vocational rehabilitation services for people with disabilities, including job training, placement assistance, assistive technology, and education support.</p>
+<h4><span>For People Released from Jail or Prison</span></h4>
+<p><a href="#" data-directory-link="Restorative-Partners" aria-label="View directory entry for Restorative Partners"><strong>Restorative Partners</strong></a> can help you build job experience after you are released from jail or prison.
+They operate <a href="https://www.thebridgecafe.org/" data-external-link="true">“The Bridge Cafe”</a> which can give you paid employment while training you for certification by <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a>’s Culinary Arts program.
+After you complete that program, they will also help you find a job in that field.
+Contact Restorative Partners to inquire about participating in this program.</p>
+<h4><span>For U.S. Military Veterans</span></h4>
+<p>If you were not dishonorably discharged and if you have a service-connected disability rating of at least 10% from the Department of Veterans Affairs, you may be eligible for the Veteran Readiness &amp; Employment (VR&amp;E) program.
+VR&amp;E can help you with with job training, education, employment accommodations, resume development, and job seeking skills coaching.
+You can apply for this program by submitting a <a href="https://www.va.gov/find-forms/about-form-28-1900/" data-external-link="true">Form 28-1900</a>.
+You can also get help from <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for Veterans Services"><strong>Veterans Services</strong></a>.</p>
+<p>The <a href="#" data-directory-link="Employment-Development-Department" aria-label="View directory entry for Employment Development Department (EDD)"><strong>Employment Development Department (EDD)</strong></a> has a Veterans Services program.
+To apply, register &amp; post a resume in <a href="#" data-directory-link="CalJOBS" aria-label="View directory entry for CalJOBS"><strong>CalJOBS</strong></a>, then meet with a Veterans Service Navigator at the EDD for an initial assessment.</p>
+<h3><span><a id="recycling">Making Ends Meet: Recycling</a></span></h3>
+<p>There are a few places in SLO County that specialize in purchasing aluminum and glass for recycling:</p>
+<ul>
+<li><a href="#" data-directory-link="AGS-Recycling" aria-label="View directory entry for AGS Recycling"><strong>AGS Recycling</strong></a> (Arroyo Grande and Morro Bay)</li>
+<li><a href="#" data-directory-link="Cambria-Recycling-Center" aria-label="View directory entry for Cambria Recycling Center"><strong>Cambria Recycling Center</strong></a> (Cambria)</li>
+<li><a href="#" data-directory-link="Steves-Recycling" aria-label="View directory entry for Steve’s Recycling"><strong>Steve’s Recycling</strong></a> (Los Osos)</li>
+<li><a href="#" data-directory-link="Recycle-101" aria-label="View directory entry for Recycle 101"><strong>Recycle 101</strong></a> (Oceano)</li>
+</ul>
+<p>Many stores also will pay CRV (California Redemption Value) refunds for up to fifty returned beverage containers at a time.
+To find such a store near you, use the search form at the <a href="https://www2.calrecycle.ca.gov/BevContainer/InStoreRedemption" data-external-link="true">CalRecycle</a> website.</p>
+<h3><span><a id="gig-jobs">Making Ends Meet: Gig Jobs</a></span></h3>
+<p>There are some ways to earn small amounts of money by doing various tasks on the internet, such as taking surveys, watching videos, or testing apps.
+Some of these are scams, and most do not pay very much, but they can be ways to make a few bucks here and there if you are unable to find or commit to steady work.</p>
+<p>The <a href="https://www.reddit.com/r/beermoney/" data-external-link="true">“beermoney” subreddit</a> maintains <a href="https://www.reddit.com/r/beermoney/comments/ab0dyv/most_common_beer_money_sites_do_not_create/" data-external-link="true">a curated list of such opportunities</a>.
+That site also includes feedback from participants on their experiences.</p>
+<p>The site <a href="https://www.flexjobs.com/" data-external-link="true">FlexJobs</a> is another way to find remote jobs with flexible hours.</p>
+<hr>
+<h2><span><a id="education-job-skills-training">Education, Job Skills Training, Certification, Tutoring, Literacy</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#adult-education">Adult Education</a></li>
+<li><a href="#digital-literacy">Digital Literacy: How to Use Computers and the Internet</a></li>
+<li><a href="#libraries">Libraries</a></li>
+<li><a href="#citizenship-studies">Citizenship Studies</a></li>
+<li><a href="#literacy">Literacy</a></li>
+<li><a href="#diploma-ged-hiset">High School Diplomas and their Equivalents (GED or HiSET)</a></li>
+<li><a href="#esl">English as a Second Language (ESL)</a></li>
+<li><a href="#education-for-people-with-disabilities">For People with Disabilities</a></li>
+<li><a href="#veterans-education">For U.S. Military Veterans</a></li>
+</ul>
+<h3><span><a id="adult-education">Adult Education</a></span></h3>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a>’s <a href="https://www.cuesta.edu/academics/continuinged/index.html" data-external-link="true">Continuing Education</a> program is open to the general community (you do not have to be enrolled at Cuesta College).
+Classes themselves are free, but some have additional costs that have to do with supplies, prerequisite documentation and tests, and other things that take place outside the classroom.
+Among their programs are classes to prepare you for a California Commercial Learning Permit so you can become a commercial truck driver.
+They also offer miscellaneous adult education classes on topics of a recreational or curiosity-satisfying nature.</p>
+<p><a href="#" data-directory-link="SLO-Partners" aria-label="View directory entry for SLO Partners"><strong>SLO Partners</strong></a> <a href="https://slopartners.org/programs/" data-external-link="true">programs</a> include bootcamps to learn in-demand skills in fields like dental assistant, hospitality, and manufacturing.
+There is a financial assistance program to help you pay for tuition.</p>
+<p><a href="#" data-directory-link="San-Luis-Coastal-Adult-School" aria-label="View directory entry for San Luis Coastal Adult School"><strong>San Luis Coastal Adult School</strong></a> offers a free <a href="https://ae.slcusd.org/culinary" data-external-link="true">Food Services Program</a> that can prepare you for a career in the culinary industry.</p>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> offers skill-building, professional development, and college prep courses, at its <a href="https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/learningexpresslibrary/libraryhome" data-external-link="true">LearningExpress Library</a>.</p>
+<p><a href="https://alison.com" data-external-link="true">Alison.com</a> offers free online courses in several fields of study, including vocational training and “soft skills.”
+You can get a certificate and/or diploma after completing a course of study, but this sometimes costs money (the course itself is free).
+Note that Alison.com is accredited in the United Kingdom, not the United States, which may affect how much these certificates and diplomas are respected by employers or colleges here.</p>
+<p><a href="https://www.lifelearnerscc.org/" data-external-link="true">Lifelong Learners of the Central Coast</a> offers low-cost classes and seminars on a variety of topics.
+You can also become an annual member for a $25 fee, and this gives you substantial discounts on all classes throughout the year.
+Contact them at <a href="mailto:lifelearnerscentralcoast@gmail.com" aria-label="Email lifelearnerscentralcoast@gmail.com">lifelearnerscentralcoast@gmail.com</a> for details.</p>
+
+
+<p><a href="https://www.toastmasters.org/" data-external-link="true">Toastmasters</a> is a peer-led course of practical exercises that improve your public speaking skills.
+Clubs typically meet for one hour once per week and members practice public speaking exercises together and provide critiques and advice.
+They welcome guests to participate.
+It is not free.
+There is a $60 membership fee every six months, and some individual groups also charge small membership fees of their own.
+Toastmasters in SLO County groups include:</p>
+<table>
+<thead>
+<tr>
+<th>Club</th>
+<th>Meeting Time</th>
+<th>Location</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Club"><a href="https://slotoastmasters.toastmastersclubs.org/" data-external-link="true">SLO Toastmasters Club 83</a></td>
+<td data-label="Meeting Time">Th 6:30–7:30am</td>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.280401" data-lon="-120.662255" data-zoom="17" data-label="Toastmasters">872 Higuera St., SLO</a></td>
+</tr>
+<tr>
+<td data-label="Club"><a href="https://www.toastmasters.org/Find-a-Club/00005204-slo-noontime-toastmasters-club-5204" data-external-link="true">SLO Noontime Toastmasters Club (5204)</a></td>
+<td data-label="Meeting Time">Tu Noon–1pm</td>
+<td data-label="Location">Mt. Carmel Lutheran Church, <a href="#" class="map-link" data-lat="35.292670" data-lon="-120.654628" data-zoom="17" data-label="Mt. Carmel Lutheran Church">1701 Fredericks St., SLO</a></td>
+</tr>
+<tr>
+<td data-label="Club"><a href="https://slomotion.toastmastersclubs.org/" data-external-link="true">SLO Motion Toastmasters Club</a></td>
+<td data-label="Meeting Time">M Noon–1pm</td>
+<td data-label="Location">SLO City/County Library, <a href="#" class="map-link" data-lat="35.282263" data-lon="-120.662223" data-zoom="17" data-label="SLO Library">995 Palm St., SLO</a></td>
+</tr>
+<tr>
+<td data-label="Club"><a href="https://www.toastmasters.org/Find-a-Club/28676059-cal-poly-toastmasters" data-external-link="true">Cal Poly Toastmasters</a></td>
+<td data-label="Meeting Time">W Noon–1pm</td>
+<td data-label="Location"><a href="#" class="map-link" data-lat="35.303892" data-lon="-120.659629" data-zoom="17" data-label="Toastmasters">Bldg. 70 (Facilities)</a>, Room 110 on the Cal Poly San Luis Obispo campus</td>
+</tr>
+<tr>
+<td data-label="Club"><a href="https://www.toastmasters.org/Find-a-Club/00009797-speakeasy-toastmasters-club" data-external-link="true">Speakeasy Toastmasters Club</a></td>
+<td data-label="Meeting Time">Th 12:10–1:15pm</td>
+<td data-label="Location">various locations around Paso Robles</td>
+</tr>
+</tbody></table>
+<p>The local <a href="#" data-directory-link="UC-Cooperative-Extension" aria-label="View directory entry for University of California Cooperative Extension"><strong>University of California Cooperative Extension</strong></a> offers courses in gardening, food preservation, and rangeland and watershed management.
+Many programs are free or low-cost.</p>
+<h3><span><a id="digital-literacy">Digital Literacy: How to Use Computers and the Internet</a></span></h3>
+<p><a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> offers a digital literacy class designed to teach you basic to intermediate computer skills with a focus on communication and productivity using Google’s free suite of apps.
+Computers are provided for use in class.
+To register, submit <a href="https://docs.google.com/forms/d/e/1FAIpQLSd0dB-A6zwwnTexekCxR4uoPS_QrnglZJ4fS4YwCgmaUSMFzw/viewform" data-external-link="true">this online form</a>.</p>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> offers free basic computer skills courses and courses in Amazon Web Services tools at its <a href="https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/learningexpresslibrary/libraryhome" data-external-link="true">LearningExpress Library</a>.
+They also have a set of <a href="https://my.nicheacademy.com/slolibrary" data-external-link="true">video tutorials</a> that include basic computer skills as well as guides to how to use several popular computer tools (like Gmail, Facebook, Microsoft Office, and Instagram).</p>
+<p><a href="#" data-directory-link="Goodwill" aria-label="View directory entry for Goodwill Central Coast"><strong>Goodwill Central Coast</strong></a> offers a variety of <a href="https://www.ccgoodwill.org/digital-literacy-classes/" data-external-link="true">digital literacy classes</a>.
+Contact them at <a href="mailto:digitalliteracy@ccgoodwill.org" aria-label="Email digitalliteracy@ccgoodwill.org">digitalliteracy@ccgoodwill.org</a> for details.</p>
+<p><a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a> has two computers you can use on-site, and they offer free assistance and one-on-one tutoring sessions. </p>
+<p><a href="#" data-directory-link="Atascadero-Senior-Center" aria-label="View directory entry for Atascadero Senior Center"><strong>Atascadero Senior Center</strong></a> periodically has “tech help” sessions at which an expert is available to help with your technical challenges or to teach you a new skill.</p>
+<h3><span><a id="libraries">Libraries</a></span></h3>
+<p>The <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> has not only books, but online research databases, computers with internet access, English conversation practice sessions, and several <a href="https://catalog.slolibrary.org/online-learning" data-external-link="true">online learning</a> programs.</p>
+<p>Cal Poly’s <a href="https://library.calpoly.edu/" data-external-link="true">Robert E. Kennedy Library</a> is a resource not just for Cal Poly students and faculty but for the inhabitants of the Central Coast in general. 
+The library supports the principle of open access to its collections by the community and region. 
+Members of the community can come to the library during main library opening hours and can access most databases while on the premises by bringing their own device and signing onto Cal Poly guest wireless. </p>
+<p>Smaller libraries with more eclectic collections include the lending library at the <a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a> and “Little Free Libraries.”
+Little Free Libraries are boxes in public areas (for example adjacent to sidewalks) where people leave books they are giving away.
+Anyone is free to take books for their own use from Little Free Libraries.
+There is no check-out/check-in procedure. Just take what you want to read, or leave what you’re finished reading.
+They are typically open 24-hours a day, every day.
+See <a href="#" data-directory-link="Little-Free-Libraries" aria-label="View directory entry for Little Free Libraries"><strong>Little Free Libraries</strong></a> in the Directory for a list of dozens of them in SLO County.</p>
+<p>The <a href="#" data-directory-link="SLO-County-Law-Library" aria-label="View directory entry for SLO County Law Library"><strong>SLO County Law Library</strong></a> gives you free access to law- and court-related books and databases.</p>
+<h3><span><a id="citizenship-studies">Citizenship Studies</a></span></h3>
+<p><a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> offers a U.S. Citizenship class that teaches the process of establishing U.S. citizenship and prepares you to pass the Naturalization Interview &amp; Test.
+The course is every Thursday from 5–8pm at the Oceano Learning Center, and you can begin the course any Thursday.
+You must be able to read and understand basic English.
+Register <a href="https://docs.google.com/forms/d/e/1FAIpQLScDFqtdG77YXPshx4OSOw8GaYUSudizOLA1JeYVb7UCC9l-Ag/viewform" data-external-link="true">online</a> or call them for more information.</p>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> gives you access to the <a href="https://learning.pronunciator.com/getstarted-procitizen-ES.php?library_id=18096" data-external-link="true">ProCitizen</a> citizenship prep course, covering the civics, reading, and writing parts of the U.S. citizenship exam.
+Its <a href="https://landing.brainfuse.com/authenticate.asp?u=main.sloh.ca.brainfuse.com" data-external-link="true">Brainfuse HelpNow eLearning</a> program and <a href="https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/center/learningexpresslibrary/recursos-para-hispanohablantes/home/mejore-sus-habilidades-escritas-orales-y-gramaticales" data-external-link="true">EBSCOlearning</a> program also include some U.S. citizenship test preparation.</p>
+<p>If you are a refugee from another country, you may be able to get some help with your education from <a href="#" data-directory-link="SLO4Home" aria-label="View directory entry for SLO for HOME"><strong>SLO for HOME</strong></a>.</p>
+<h3><span><a id="literacy">Literacy</a></span></h3>
+<p><a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> offers Basic English Literary course that takes place all year at its Oceano Learning Center location.
+The course is every Tuesday from 5–8pm and you can begin the course any Tuesday.
+Register <a href="https://docs.google.com/forms/d/e/1FAIpQLScDFqtdG77YXPshx4OSOw8GaYUSudizOLA1JeYVb7UCC9l-Ag/viewform" data-external-link="true">online</a> or call them for more information.</p>
+<p><a href="#" data-directory-link="Literacy-Connection" aria-label="View directory entry for The Literacy Connection"><strong>The Literacy Connection</strong></a> is a free, volunteer-based, one-on-one tutoring program that helps adults improve their literacy skills.</p>
+<h3><span><a id="diploma-ged-hiset">High School Diplomas and their Equivalents (GED or HiSET)</a></span></h3>
+<p>If you did not earn a high school diploma, you can instead get a certificate that demonstrates that you have high-school-graduate-level competency.
+This can help you apply for jobs or for higher education.
+To get such a certificate, you must pass a test: either the GED test or the HiSET test.</p>
+<p>You can also take such a test to earn such a certificate if you are still in high school but you want to leave school early rather than continue to graduation.</p>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a>’s Continuing Education program includes free, non-credit courses that are designed to help you build the schools you need to pass the <a href="https://www.cuesta.edu/academics/continuinged/ged/index.html" data-external-link="true">California High School Equivalency (GED) exam</a>.
+Courses are offered in English and in Spanish.
+They also offer free tutoring, and free access to software programs to help you study.</p>
+<p><a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> offers free <a href="https://www.cuesta.edu/academics/continuinged/ged/index.html" data-external-link="true">High School Diploma</a> classes to adults.
+This will enable you to earn an actual high school diploma, but these classes can also prepare you to take and pass the GED or HiSET.
+Register <a href="https://adulted.luciamarschools.org/info-registration" data-external-link="true">on their website</a>.
+When you get your high school diploma or HiSET equivalency credential, you can also get a referral to Cuesta or Hancock Colleges if you want to continue your education there.</p>
+<p><a href="#" data-directory-link="Templeton-Adult-School" aria-label="View directory entry for Templeton Adult School"><strong>Templeton Adult School</strong></a> offers free <a href="https://www.cuesta.edu/academics/continuinged/ged/index.html" data-external-link="true">High School Diploma</a> classes to adults on a flexible schedule.
+Call them or email <a href="mailto:clondon@templetonusd.org" aria-label="Email clondon@templetonusd.org">clondon@templetonusd.org</a> to begin the process of enrollment.</p>
+<p><a href="#" data-directory-link="San-Luis-Coastal-Adult-School" aria-label="View directory entry for San Luis Coastal Adult School"><strong>San Luis Coastal Adult School</strong></a> offers free <a href="https://ae.slcusd.org/hsd-esl/high-school-equivalency" data-external-link="true">High School Diploma / Equivalency classes</a> in San Luis Obispo, Morro Bay, and at the San Luis Obispo jail.</p>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> offers on-line lessons, practice tests, and other learning tools, in English and Spanish, at its <a href="https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/center/learningexpresslibrary/hsequivalencycenter/home/are-you-prepared" data-external-link="true">High School Equivalency Center</a>.</p>
+<p>The <a href="https://cdss.ca.gov/cal-learn" data-external-link="true">Cal-Learn</a> program helps pregnant or parenting teens finish high school or get an equivalent certificate. 
+It helps with child care, transportation, educational expenses, and will even give you cash bonuses for getting good grades or for graduating. 
+Apply for this program through the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a> or contact <a href="mailto:Cal-Learn@dss.ca.gov" aria-label="Email Cal-Learn@dss.ca.gov">Cal-Learn@dss.ca.gov</a> if you have questions. </p>
+<p>The SLO County Office of Education’s <a href="https://www.slocoe.org/about/programs/homeless-and-foster-youth-services-coordinating-program/" data-external-link="true">“Homeless and Foster Youth Services Coordinating Program”</a> can help homeless and foster youth manage their enrollment in school, including choosing which school to attend, getting their records transferred from previous schools, and finding resources that will be useful to them.
+To access this program, contact <a href="https://www.slocoe.org/about/programs/homeless-and-foster-youth-services-coordinating-program/school-district-liaisons-and-contacts/" data-external-link="true">the liaison for your school district</a> or contact the County Office of Education at <a href="tel:+1-805-782-7268" aria-label="Call 805-782-7268">805-782-7268</a> or <a href="mailto:jthomas@slocoe.org" aria-label="Email jthomas@slocoe.org">jthomas@slocoe.org</a>.</p>
+<h3><span><a id="esl">English as a Second Language (ESL)</a></span></h3>
+<p>English as a Second Language (ESL) classes are for learners who already have another native or “mother” language, and they want to learn English as well.</p>
+<p><a href="#" data-directory-link="San-Luis-Coastal-Adult-School" aria-label="View directory entry for San Luis Coastal Adult School"><strong>San Luis Coastal Adult School</strong></a> offers free <a href="https://ae.slcusd.org/hsd-esl/english-as-a-second-language" data-external-link="true">ESL classes</a> in Morro Bay and San Luis Obispo.</p>
+<p><a href="#" data-directory-link="Lucia-Mar-Adult-Education" aria-label="View directory entry for Lucia Mar Adult Education"><strong>Lucia Mar Adult Education</strong></a> offers free <a href="https://adulted.luciamarschools.org/english-as-a-second-language" data-external-link="true">ESL classes</a> at its Nipomo and Oceano learning centers</p>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> offers free <a href="https://www.cuesta.edu/academics/divisions/studentdevsuccess/esl/index.html" data-external-link="true">ESL classes</a> in Arroyo Grande, Paso Robles, and San Luis Obispo.</p>
+<p><a href="#" data-directory-link="Literacy-Connection" aria-label="View directory entry for The Literacy Connection"><strong>The Literacy Connection</strong></a> offers free <a href="https://catalog.slolibrary.org/tlc" data-external-link="true">ESL tutoring</a> and on-line conversation practice groups.
+To apply, complete <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=rWKjGn83q0Oo9xU3mPGODwd44kGa185AiEhu-KlwkiNUNVRINDQ4VUw5OE9CQzNVQkxHSzc3TkFDUi4u" data-external-link="true">the form on their website</a> or call <a href="tel:+1-805-781-5077" aria-label="Call 805-781-5077">805-781-5077</a>.</p>
+<p>Recent refugees from other countries can also get ESL help from <a href="#" data-directory-link="SLO4Home" aria-label="View directory entry for SLO for HOME"><strong>SLO for HOME</strong></a>.</p>
+<h3><span><a id="education-for-people-with-disabilities">For People with Disabilities</a></span></h3>
+<p><a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a>’s Continuing Education program has an <a href="https://www.cuesta.edu/academics/continuinged/adultsdisabilities/index.html" data-external-link="true">Adults with Disabilities</a> program of specialized courses that develop independent living &amp; employment skills of people with intellectual disabilities.</p>
+<h3><span><a id="veterans-education">For U.S. Military Veterans</a></span></h3>
+<p>As a U.S. military veteran, you may qualify for <a href="https://www.va.gov/education/about-gi-bill-benefits/" data-external-link="true">“GI Bill” education benefits</a> that can help you pay for school and cover expenses while you’re training for a job.
+You can apply for these benefits <a href="https://www.va.gov/education/how-to-apply/" data-external-link="true">online at the Veterans Affairs website</a> or by phone at <a href="tel:+1-888-442-4551" aria-label="Call 888-442-4551">888-442-4551</a>.</p>
+<p>If you were not dishonorably discharged and if you have a service-connected disability rating of at least 10% from the Department of Veterans Affairs, you may be eligible for the Veteran Readiness &amp; Employment (VR&amp;E) program.
+VR&amp;E can help you with with job training, education, and job seeking skills coaching.
+You can apply for this program by submitting a <a href="https://www.va.gov/find-forms/about-form-28-1900/" data-external-link="true">Form 28-1900</a>.
+You can also get help from <a href="#" data-directory-link="Veterans-Services" aria-label="View directory entry for Veterans Services"><strong>Veterans Services</strong></a>.</p>
+<p>People in the U.S. military, U.S. military veterans, and their spouses, adult children, and caregivers can also take free, online training courses in fields like data analytics, cybersecurity, artificial intelligence (AI), cloud computing, and information technology (IT) support through the <a href="https://www.va.gov/education/other-va-education-benefits/ibm-skillsbuild-program/" data-external-link="true">IBM SkillsBuild program</a></p>
+<hr>
+<h2><span><a id="phones">Phones and Phone Service</a></span></h2>
+<p>The <a href="https://www.californialifeline.com/" data-external-link="true">California LifeLine Program</a> (<a href="tel:+1-866-272-0357" aria-label="Call 866-272-0357">866-272-0357</a>) gives low-income households discounts on home phone or cell phone service.
+In many cases the discounts are enough to make the service free.
+You apply for this program through a commercial phone service provider that supports the program.
+Some providers also give you a free phone when you register for California LifeLine through their service, for example <a href="https://airtalkwireless.com/lifeline-application" data-external-link="true">AirTalk Wireless</a>, <a href="https://entouchwireless.com/states/california-lifeline-free-phone-service/" data-external-link="true">enTouch Wireless</a>, or <a href="https://www.genmobile.com/pages/lifeline-program" data-external-link="true">Gen Mobile</a>.</p>
+<p>The <a href="#" data-directory-link="California-Connect" aria-label="View directory entry for California Connect"><strong>California Connect</strong></a> program can loan you, for free, assistive telecommunications equipment that helps if you have medically-documented functional limitations of hearing, vision, mobility, speech, and/or interpretation of information.
+The <a href="https://www.cpuc.ca.gov/consumer-support/financial-assistance-savings-and-discounts/ddtp" data-external-link="true">Deaf and Disabled Telecommunications Program (DDTP)</a> can give you specialized telephone equipment, accessories, and services such as amplified phones for the hard-of-hearing, big-button phones for those with low-vision, and cordless phones for people with mobility disabilities.
+This program is for California residents with medically-certified limitations of hearing, vision, mobility, speech, learning, or memory.</p>
+<hr>
+<h2><span><a id="internet-and-email">Internet Access / Email / Digital Access Assistance</a></span></h2>
+<blockquote>
+<p>See the <a href="#digital-literacy">Digital Literacy: How to Use Computers and the Internet</a> section of this guide for classes and tutorials that can help you learn how to use the internet.</p>
+</blockquote>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> have computers you can use on-site.
+They also have printing services for a small fee.
+They may also be able to help you establish an email account.
+You can also borrow a Wi-Fi hotspot from the library.</p>
+<p>The <a href="#" data-directory-link="SLO-Cal-Careers-Center" aria-label="View directory entry for SLO Cal Careers Center"><strong>SLO Cal Careers Center</strong></a> has computers you can use for job-search purposes.
+They can also help you establish a CalJOBS account and submit online job applications.</p>
+<p>The County of San Luis Obispo Information Technology Department provides free Wi-Fi access in all San Luis Obispo County government buildings.</p>
+<p>Both the <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> office and the <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> offer computer and internet access to their clients. </p>
+<p><a href="#" data-directory-link="Arroyo-Grande-Recreation-Services" aria-label="View directory entry for Arroyo Grande Recreation Services"><strong>Arroyo Grande Recreation Services</strong></a> offers a Basic iPhone for Seniors class.</p>
+<p><a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a> has two computers you can use on-site, and they offer free assistance and one-on-one tutoring sessions including specialized Android and iPad/iPhone workshops. 
+<a href="#" data-directory-link="Nipomo-Senior-Center" aria-label="View directory entry for Nipomo Senior Center"><strong>Nipomo Senior Center</strong></a> also has a computer with internet access which is available to the public on a first come, first serve basis.</p>
+<hr>
+<h2><span><a id="charging-stations">Charging Stations for Devices</a></span></h2>
+<p>The <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> office has device charging stations for its clients. </p>
+<p><a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a> has a device charging station available at the sites where it operates during operating hours.</p>
+<p><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> have computers you can use on-site with USB charging ports.
+There are also some electrical outlets you can use to charge devices.</p>
+<p>The free <a href="#" data-directory-link="Front-Porch" aria-label="View directory entry for Front Porch"><strong>Front Porch</strong></a> cafe on the Cal Poly campus has many charging outlets.</p>
+<p><a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> has electrical outlets you can use to charge your mobile devices. </p>
+
+
+<hr>
+<h2><span><a id="children-youth-parents">Children, Youth, and People with Children</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ol>
+<li><a href="#parenting">Help with Parenting</a></li>
+<li><a href="#daycare">Daycare, Preschool, and After-School Programs</a></li>
+<li><a href="#holiday-gifts-for-children">Holiday Gifts for Children</a></li>
+<li><a href="#homeless-youth">Resources for Homeless Youth</a></li>
+</ol>
+<p><a href="#" data-directory-link="Help-Me-Grow" aria-label="View directory entry for Help Me Grow SLO County"><strong>Help Me Grow SLO County</strong></a> offers no-cost developmental screenings for infants, and connections to resources and education if these screenings discover developmental issues.</p>
+<p><a href="#" data-directory-link="Family-Care-Network" aria-label="View directory entry for Family Care Network"><strong>Family Care Network</strong></a> serves families with children who are experiencing or at risk of homelessness, are impacted by unaddressed mental health challenges, or are involved with Child Welfare Services or the Justice System.
+Services include therapy and other mental health services, facilitating foster care and adoption, independent living skills, educational continuity,
+They also help families experiencing homelessness to move into safe housing (Family Care Network operates housing complexes for this purpose).
+They offer services in English and Spanish.</p>
+<p>The <a href="https://www.slocm.org/" data-external-link="true">SLO Children’s Museum</a> is full of interactive exhibits for children aged 2–10.
+If you are “housing insecure” you can get a free “City Play Pass” to the museum from <a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for CAPSLO"><strong>CAPSLO</strong></a>.
+If you have a SNAP/EBT card, you can also get up to four admissions for $3 each.
+Open Th–M 10am–4pm, <a href="#" class="map-link" data-lat="35.278932" data-lon="-120.666116" data-zoom="17" data-label="SLO Children’s Museum">1010 Nipomo St., SLO</a>.
+For more info: <a href="tel:+1-805-544-5437" aria-label="Call 805-544-KIDS">805-544-KIDS</a> or <a href="mailto:info@slocm.org" aria-label="Email info@slocm.org">info@slocm.org</a>.</p>
+<p><a href="#" data-directory-link="Child-Care-Resource-Connection" aria-label="View directory entry for Child Care Resource Connection"><strong>Child Care Resource Connection</strong></a> operates a <a href="https://capslo.org/toylendinglibrary/" data-external-link="true">toy lending library</a>.</p>
+<p><a href="#" data-directory-link="California-Childrens-Services" aria-label="View directory entry for California Children’s Services"><strong>California Children’s Services</strong></a> pays for and helps arrange doctor visits, hospital stays, surgery, physical therapy, tests, medical equipment, etc. for children and youths whose parents otherwise could not afford it.</p>
+<p><a href="#" data-directory-link="Marthas-Place-Childrens-Center" aria-label="View directory entry for Martha’s Place Children’s Center"><strong>Martha’s Place Children’s Center</strong></a> helps children ages 0–5 who have (or may have) behavioral or mental health issues or who were exposed to alcohol or other intoxicants while in the womb.
+It provides screening, assessment, referral, and treatment.
+These services are free to people with Medi-Cal/CenCal coverage, and available on a sliding feed schedule otherwise.</p>
+<blockquote>
+<p>See <a href="#calfresh-ebt-wic">CalFresh / EBT (Food Stamps) and WIC</a> in the <a href="#food">Food Resources</a> section of this guide for information about the Women, Infants, and Children (WIC) program.</p>
+</blockquote>
+<blockquote>
+<p>See <a href="#family-law">Family Law / Child Support</a> in the <a href="#legal-help">Legal Help &amp; Crime Victim Protection</a> section of this guide for information about enforcing child support orders and other family law issues.</p>
+</blockquote>
+<blockquote>
+<p>See the <a href="#medical-resources-specific-populations">Medical Resources for Specific Populations: Children</a> in the <a href="#health-medical-care">Health &amp; Medical Care</a> section of this guide for pediatric and other child-oriented medical services.</p>
+</blockquote>
+<h3><span><a id="parenting">Help with Parenting</a></span></h3>
+<blockquote>
+<p>See the <a href="#emergency-contacts">Hotlines and Emergency Contacts</a> section of this guide for the Fussy Baby Network Warmline, the National Maternal Mental Health Hotline, and a number you can call to learn about Safe Surrender Site locations.</p>
+</blockquote>
+<p><a href="#" data-directory-link="Parent-Connection-of-SLO-County" aria-label="View directory entry for Parent Connection of SLO County"><strong>Parent Connection of SLO County</strong></a> hosts free parenting skills workshops and parenting support groups, and can help you find resources for your particular needs.</p>
+<p><a href="#" data-directory-link="San-Luis-Coastal-Adult-School" aria-label="View directory entry for San Luis Coastal Adult School"><strong>San Luis Coastal Adult School</strong></a> offers <a href="https://ae.slcusd.org/parent-part" data-external-link="true">Parent Participation classes</a> that teach useful parenting skills to people with children up to the age of five (you attend the class with your child).
+Classes are held in San Luis Obispo and Morro Bay.
+Scholarships that cover part of the class fees are available to people with low incomes or special circumstances.</p>
+<p>The free <a href="https://www.t-mha.org/workshop-details.php?id=80" data-external-link="true">Triple P Fear Less Class</a> offered by <a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a> helps parents and caregivers of children (ages 6–14) who experience anxiety to foster confident and healthy children, cultivate strong family relationships, and effectively address misbehavior.</p>
+<p><a href="#" data-directory-link="Pregnancy-Parenting-Support" aria-label="View directory entry for Pregnancy &amp; Parenting Support"><strong>Pregnancy &amp; Parenting Support</strong></a> has a “baby bank” from which you can get free maternity and breastfeeding supplies, diapers, baby wipes, formula, safe sleep equipment, child car seats, books, and toys.
+(Car seat installation by appointment only.)</p>
+<blockquote>
+<p>See the <a href="#parenthood-peer-support">Peer Support Groups: Pregnancy and Parenthood</a> section for information about a variety of support groups for new parents and pregnant people.</p>
+</blockquote>
+<blockquote>
+<p>See <a href="#pregnancy-childbirth-lactation">Pregnancy, Childbirth, Lactation</a> in the <a href="#health-medical-care">Health &amp; Medical Care</a> section of this guide for pregnancy and postpartum resources.</p>
+</blockquote>
+<h3><span><a id="daycare">Daycare, Preschool, and After-School Programs</a></span></h3>
+<p><a href="#" data-directory-link="Child-Care-Resource-Connection" aria-label="View directory entry for Child Care Resource Connection"><strong>Child Care Resource Connection</strong></a> connects SLO County families with child care centers, licensed family child care homes, and after-school programs.
+They can provide child care payment assistance for income-eligible families.
+If you are in the <a href="#" data-directory-link="CalWORKs" aria-label="View directory entry for CalWORKs Homeless Assistance Program"><strong>CalWORKs Homeless Assistance Program</strong></a>, you can apply for child care from this program through the <a href="#" data-directory-link="SLO-County-Department-of-Social-Services" aria-label="View directory entry for SLO County Department of Social Services"><strong>SLO County Department of Social Services</strong></a>.
+Otherwise <a href="https://app.mycareconnect.io/carewait/capslo" data-external-link="true">complete an online application</a> or call <a href="tel:+1-888-727-2272" aria-label="Call 888-727-2272">888-727-2272</a> to begin the process of applying through the California Alternative Payment Program.
+This program may have a waiting list.</p>
+<p><a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for CAPSLO"><strong>CAPSLO</strong></a> operates <a href="https://capslo.org/head-start-and-early-head-start/" data-external-link="true">Head Start and Early Head Start programs</a> for children during their first five years of life.
+The programs aim to help children gain school readiness skills, confidence, and self-esteem.
+Head Start child care centers also serve children three free meals a day.
+These programs operate in <a href="https://capslo.org/eecc/" data-external-link="true">several locations in SLO County</a>.
+To enroll your child in these programs, find a service provider that is convenient to you and appropriate for the child’s age and then <a href="https://www.childplus.net/apply/en-us/4C3A30704DEAD016C09968C44ACD9A8B/CE180CB5372A691D8A0368833B588572" data-external-link="true">apply for the waitlist</a>.
+For more information, including eligibility requirements, contact <a href="mailto:childcare@capslo.org" aria-label="Email childcare@capslo.org">childcare@capslo.org</a> or <a href="tel:+1-888-315-6741" aria-label="Call 888-315-6741">888-315-6741</a>.</p>
+<p>There is also a “Migrant and Seasonal Head Start” program designed specifically for the children of migrant farm workers.
+You can apply for that program by completing <a href="https://www.childplus.net/apply/en-us/4C3A30704DEAD016C09968C44ACD9A8B/CE180CB5372A691D8A0368833B588572" data-external-link="true">the form on this page</a>.
+For more information, contact <a href="mailto:mshschildcare@capslo.org" aria-label="Email mshschildcare@capslo.org">mshschildcare@capslo.org</a> or <a href="tel:+1-888-633-6747" aria-label="Call 888-633-6747">888-633-6747</a>.</p>
+<p><a href="http://luciamarschools.org/251185_2" data-external-link="true">Bright Futures</a> is a program in the Lucia Mar Unified School District that gives K-8 students a safe before- and after-school environment including academic support and enrichment classes, as well as a free supper.
+There are limited spaces available, and sometimes there is a waiting list.
+Priority is given to foster youth, students experiencing homelessness, English language learners, and students qualifying for free/reduced price lunch services.
+You can apply to enroll your child in this program at the <a href="http://luciamarschools.org/251185_2" data-external-link="true">Bright Futures</a> website.</p>
+<p>The <a href="#" data-directory-link="Child-Development-Resource-Center" aria-label="View directory entry for Child Development Resource Center"><strong>Child Development Resource Center</strong></a> operates several programs including childcare for children aged 2–5 that includes early-childhood education, therapy and rehabilitation for children who need it, meals (breakfast, lunch, and an afternoon snack), and family events.
+They specialize in working with children who come from circumstances that included poverty, homelessness, foster care, domestic violence, or child abuse.
+To apply for the childcare program, complete and submit <a href="https://www.childrensresource.org/regristration" data-external-link="true">an application</a>.
+There may be a waiting list.
+Tuition is a sliding-scale fee based on income, and financial aid is available.</p>
+<p>Boys &amp; Girls Clubs offer free, out-of-school enrichment programs for schoolchildren during the week: after school and during school breaks like summer vacation.
+There is an annual membership fee and also fees per child per day, but Boys &amp; Girls Clubs are committed to ensuring that cost is not a barrier to participation.
+Ask them about scholarships and subsidies.
+There are two Boys &amp; Girls Clubs chapters in SLO County:</p>
+<ul>
+<li><a href="https://www.bgcslo.org/" data-external-link="true">Boys &amp; Girls Clubs of South SLO County</a> which covers Grover Beach, Oceano, Pismo Beach, and Shell Beach (<a href="mailto:myclubhub@bgcslo.org" aria-label="Email myclubhub@bgcslo.org">myclubhub@bgcslo.org</a>, <a href="tel:+1-805-481-7339" aria-label="Call 805-481-7339">805-481-7339</a>)</li>
+<li><a href="https://centralcoastkids.org/" data-external-link="true">Boys &amp; Girls Clubs of Mid Central Coast</a> which covers Atascadero, Creston, Guadalupe, Paso Robles, and Shandon (<a href="mailto:info@centralcoastkids.org" aria-label="Email info@centralcoastkids.org">info@centralcoastkids.org</a>, <a href="tel:+1-805-922-7163" aria-label="Call 805-922-7163">805-922-7163</a>)</li>
+</ul>
+<p>Students of <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> who qualify for <a href="https://www.cuesta.edu/student-support/support-programs/eops/" data-external-link="true">Extended Opportunity Programs and Services</a> and who are single heads-of-households can get help paying for child care services from <a href="https://www.cuesta.edu/student-support/support-programs/eops/care.html" data-external-link="true">Cooperative Agencies Resources for Education (CARE)</a>.
+Contact <a href="mailto:cafecenters@cuesta.edu" aria-label="Email cafecenters@cuesta.edu">cafecenters@cuesta.edu</a> or <a href="tel:+1-805-546-3144" aria-label="Call 805-546-3144">805-546-3144</a> to learn how to apply.</p>
+<p><a href="#" data-directory-link="SLO-County-YMCA" aria-label="View directory entry for SLO County YMCA"><strong>SLO County YMCA</strong></a> offers <a href="https://www.ciymca.org/child-watch" data-external-link="true">one hour of childcare</a> to members while they are exercising at the facility.
+You must reserve this in advance.
+They also operate <a href="https://www.ciymca.org/summer-camp" data-external-link="true">summer camps</a> for children and teens.
+They also operate before- and after-school care, and programs during school holidays and breaks, featuring homework help, enriching activities, and healthy snacks.
+There is sometimes a wait list to apply for these <a href="https://channel.recliquecore.com/programs/21393244/san-luis-obispo-school-age-care/" data-external-link="true">School Age Care</a> and <a href="https://channel.recliquecore.com/programs/1291/school-s-out-care/?locations=140" data-external-link="true">School’s Out Care</a> programs.
+They occasionally offer <a href="https://channel.recliquecore.com/programs/1269/kid-s-night-out/?locations=140" data-external-link="true">Kid’s Night Out</a> evening childcare programs too.
+<a href="https://www.ciymca.org/financial-assistance" data-external-link="true">Financial assistance</a> is available to ensure that you can afford these programs.</p>
+<blockquote>
+<p>See <a href="#summer-meal-sites">Summer Meal Sites (for Children)</a> in the <a href="#food">Food Resources</a> section of this guide for information on how children can get meals during the Summer months when school is out.</p>
+</blockquote>
+<h3><span><a id="holiday-gifts-for-children">Holiday Gifts for Children</a></span></h3>
+<p>There are several programs in SLO County that provide gifts for children during the holiday season.
+You typically need to apply a month or so ahead of time to receive these gifts.
+You may need to upload documents such as the children’s birth certificates to prove eligibility and proof of residence.</p>
+<blockquote>
+<p>See the <a href="#ids-and-other-documents">IDs and Other Documents</a> section of this guide for ways to obtain or replace documents like these.</p>
+</blockquote>
+<p><a href="#" data-directory-link="Salvation-Army" aria-label="View directory entry for Salvation Army"><strong>Salvation Army</strong></a> operates the “Angel Tree” program which provides free Christmas gifts for children.
+Register at <a href="https://www.saangeltree.org/" data-external-link="true">this web page</a>.</p>
+<p>The <a href="https://www.prtoybank.org/" data-external-link="true">Toy Bank of Greater Paso Robles</a> gives toys and coats to families with children aged 0–12 years who live in Paso Robles, San Miguel, Shandon, Bradley and Heritage Ranch and who have a household income blow the federal poverty line, or are unemployed, receiving Medi-Cal, receiving SNAP/EBT, or homeless.
+To receive gifts from the program, register in November at <a href="https://www.prtoybank.org/copy-of-family-registration" data-external-link="true">this web page</a>.
+For questions, contact <a href="tel:+1-805-369-9816" aria-label="Call 805-369-9816">805-369-9816</a> or <a href="mailto:registration@prtoybank.org" aria-label="Email registration@prtoybank.org">registration@prtoybank.org</a>.</p>
+<p>Toys for Tots gives toys to children during the holidays.
+They operate in <a href="https://atascadero-ca.toysfortots.org/" data-external-link="true">Atascadero/Santa Margarita/Templeton/Pozo/Creston/California Valley</a>.
+Register for toys for your children <a href="https://atascadero-ca.toysfortots.org/local-coordinator-sites/lco-sites/local-toy-request-single-form.aspx" data-external-link="true">at this web page</a>.
+You must select and collect the toys in person (but without your children) at their distribution site.
+For more information, contact <a href="tel:+1-805-391-4430" aria-label="Call 805-391-4430">805-391-4430</a> or <a href="mailto:atascadero.ca@toysfortots.org" aria-label="Email atascadero.ca@toysfortots.org">atascadero.ca@toysfortots.org</a>.</p>
+<p>Toys for Tots also operates in <a href="https://cambria-ca.toysfortots.org/" data-external-link="true">Cambria/San Simeon</a>.
+Register for toys for your children <a href="https://cambria-ca.toysfortots.org/local-coordinator-sites/lco-sites/local-toy-request-single-form.aspx" data-external-link="true">at this web page</a> unless your child attends Cambria Grammar School (in which case, apply through the School Family Advocate instead).
+For more information, contact <a href="tel:+1-805-927-1876" aria-label="Call 805-927-1876">805-927-1876</a> or <a href="mailto:cambria.ca@toysfortots.org" aria-label="Email cambria.ca@toysfortots.org">cambria.ca@toysfortots.org</a>.</p>
+<p>Some people who are imprisoned at the SLO County Jail’s “Honor Farm” refurbish children’s bicycles so they can be given away as gifts during the holiday season.
+To apply for a free bicycle for your child, contact your child’s elementary or middle school resource officer.</p>
+<blockquote>
+<p>See the <a href="#miscellaneous-free-items">(Mostly) Free Stuff</a> section of this guide for more possible gift ideas.</p>
+</blockquote>
+<h3><span><a id="homeless-youth">Resources for Homeless Youth</a></span></h3>
+<blockquote>
+<p>See the <a href="#emergency-contacts">Hotlines and Emergency Contacts</a> section of this guide for the Youth Crisis Line, the National Runaway Safeline, the Love is Respect line, and the Trevor Lifeline.</p>
+</blockquote>
+<p>The <a href="#" data-directory-link="5CHC" aria-label="View directory entry for 5Cities Homeless Coalition"><strong>5Cities Homeless Coalition</strong></a> has a <a href="https://5chc.org/programs/homeless-youth-outreach" data-external-link="true">Homeless Youth Outreach</a> program that offers individualized case management to unaccompanied homeless youth (ages 16–24) with the goal of helping them with immediate needs, housing, independent living, steady employment, and continued education.</p>
+<p>SLO County youth (ages 21 or below, or current or former foster youth up to age 26) who are enrolled in <a href="#" data-directory-link="CenCal" aria-label="View directory entry for CenCal Health"><strong>CenCal Health</strong></a> qualify for <a href="#" data-directory-link="Enhanced-Care-Management" aria-label="View directory entry for Enhanced Care Management"><strong>Enhanced Care Management</strong></a> through <a href="#" data-directory-link="Seneca-Central-Coast" aria-label="View directory entry for Seneca Central Coast"><strong>Seneca Central Coast</strong></a> if one of the following is true:</p>
+<ul>
+<li>They are experiencing homelessness.</li>
+<li>They are transitioning out of incarceration.</li>
+<li>They are a current or former foster youth.</li>
+<li>They have significant behavioral health needs.</li>
+<li>They experience frequent hospitalization.</li>
+</ul>
+<p>Enhanced Care Management teams you up with a professional who can help you find medical providers, make appointments, arrange transportation to appointments, and meet other healthcare needs.
+To apply for Enhanced Care Management, contact <a href="#" data-directory-link="CenCal" aria-label="View directory entry for CenCal Health"><strong>CenCal Health</strong></a> who can help you with the process, or contact Seneca Central Coast directly.</p>
+<p><a href="#" data-directory-link="Atascadero-Parks-and-Recreation" aria-label="View directory entry for Atascadero Recreation"><strong>Atascadero Recreation</strong></a> has a <a href="https://www.atascadero.org/service/teen-center" data-external-link="true">Teen Center</a>, open weekday afternoons until 6pm, with air hockey, pool, ping pong, PS5, movies, board games, dodgeball, and basketball.
+Membership is $20/year.
+Atascadero Recreation also has organized sports programs, classes, and camps.
+There is a Youth Activity Scholarship Fund that can pay for up to $250 per child in registration fees for qualifying children in the Atascadero School District (<a href="https://www.atascadero.org/sites/default/files/Scholarship%20application%20English%20%28fiscal%20year%202025-2026%29.pdf" data-external-link="true">details here</a>)</p>
+<p><a href="#" data-directory-link="Paso-Robles-Parks-and-Recreation" aria-label="View directory entry for Paso Robles Parks &amp; Recreation"><strong>Paso Robles Parks &amp; Recreation</strong></a> has a free <a href="https://www.prcity.com/1177/Teen-Center" data-external-link="true">Teen Center</a>, open weekday afternoons until 5pm, with video games, music, a pool table, a gym, and a small cafe.
+Paso Robles Parks &amp; Recreation also offers many <a href="https://anc.apm.activecommunities.com/prcityrecreation/activity/search?onlineSiteId=0&amp;locale=en-US&amp;activity_select_param=2&amp;activity_category_ids=8&amp;activity_category_ids=13&amp;viewMode=list" data-external-link="true">classes, sports, and other activities</a>.
+They typically cost money, but there is <a href="https://www.prcity.com/1193/Scholarships" data-external-link="true">a scholarship program</a> for people with low incomes.</p>
+<p><a href="#" data-directory-link="City-of-SLO-Parks-and-Recreation" aria-label="View directory entry for City of SLO Parks and Recreation"><strong>City of SLO Parks and Recreation</strong></a> offers <a href="https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide" data-external-link="true">a variety of sports clinics, classes, and camps</a>.
+They have a <a href="https://www.slocity.org/home/showpublisheddocument/37652/638875686889030000" data-external-link="true">limited fee reduction program</a> that helps eligible SLO city children obtain scholarship credit towards program fees.</p>
+<blockquote>
+<p>See also <a href="#medical-resources-specific-populations">Medical Resources for Specific Populations: Teens &amp; Youth</a> in the <a href="#health-medical-care">Health &amp; Medical Care</a> section of this guide for youth-oriented medical care.</p>
+</blockquote>
+<blockquote>
+<p>See the <a href="#behavioral-health-peer-support">Peer Support Groups: Behavioral Health</a> section for information about Alateen and Narateen groups for teens who have family members who are addicts.</p>
+</blockquote>
+<blockquote>
+<p>See the <a href="#glbtq-peer-support">Peer Support Groups: GLTBQ+</a> section for information about support groups for queer and trans youth.</p>
+</blockquote>
+<blockquote>
+<p>See <a href="#free-clothes-for-kids">Free Clothes for Kids</a> in the <a href="#clothing">Clothing</a> section of this guide for information about “Coats for Kids,” “Operation School Bell,” “Traveling Children’s Closet,” “The Teen’s Closet,” and “Outreach Apparel.”</p>
+</blockquote>
+<h4><span>Educational Continuity (McKinney-Vento Act)</span></h4>
+<p>Federal law (the McKinney-Vento Homeless Assistance Act) protects homeless students in elementary through high school in several ways:</p>
+<ol>
+<li>You have the right to enroll in school even if you currently lack documents such as proof of residency, immunization records, or birth certificates.</li>
+<li>You have the right to attend the same school you were enrolled in when you were last housed, even if you have since lost your home.</li>
+<li>You have the right to transportation to and from school.</li>
+<li>You have the right to the same educational services as non-homeless students.</li>
+<li>If you are an unaccompanied homeless youth, you have the right to enroll in school without the consent of your parent or guardian.</li>
+</ol>
+<p>Homelessness, as the McKinney-Vento Act defines it, also includes situations when you are living at someone else’s house, living in a motel or campground, living in a vehicle, living in a shelter, or squatting in an abandoned building.</p>
+<p>Every school district has a McKinney-Vento liaison whom you can go to if you need help defending these rights.
+You can find <a href="https://www.slocoe.org/about/programs/homeless-and-foster-youth-services-coordinating-program/school-district-liaisons-and-contacts/" data-external-link="true">a list of these liaisons and their contact information</a> at the SLO County Office of Education website.</p>
+<p>The SLO County Office of Education’s <a href="https://www.slocoe.org/about/programs/homeless-and-foster-youth-services-coordinating-program/" data-external-link="true">“Homeless and Foster Youth Services Coordinating Program”</a> can help homeless and foster youth manage their enrollment in school, including choosing which school to attend, getting their records transferred from previous schools, and finding resources that will be useful to them.
+To access this program, contact the McKinney-Vento liaison for your school district or contact the County Office of Education at <a href="tel:+1-805-782-7268" aria-label="Call 805-782-7268">805-782-7268</a> or <a href="mailto:jthomas@slocoe.org" aria-label="Email jthomas@slocoe.org">jthomas@slocoe.org</a>.</p>
+<blockquote>
+<p>See <a href="#diploma-ged-hiset">High School Diplomas and their Equivalents</a> in the <a href="#education-job-skills-training">Education</a> section of this guide for ways to stay on track to get your diploma.</p>
+</blockquote>
+
+
+<hr>
+<h2><span><a id="peer-support-groups">Peer Support Groups</a></span></h2>
+<p>In peer support groups, you gather with other people who are in a similar situation to you in some way to talk.
+You may share practical advice, or just give each other emotional support.
+There are many peer support groups active in SLO County.
+These are some of them:</p>
+<h3><span><a id="conditions-peer-support">Disabilities, Medical Conditions, and Mental Illnesses</a></span></h3>
+<p><strong>Alzheimer’s disease:</strong> There are monthly <a href="https://www.alz.org/cacentralcoast/support/supportgroups" data-external-link="true">Alzheimer’s support groups</a> for caregivers and other people affected by Alzheimer’s disease in Arroyo Grande, Atascadero, Cambria, Morro Bay, Nipomo, Paso Robles, and SLO, as well as on-line.
+There are also support groups for people recently diagnosed, and for people suffering bereavement because of a loved one with dementia.
+To register for a group, call <a href="tel:+1-800-272-3900" aria-label="Call 800-272-3900">800-272-3900</a>.</p>
+<p><strong>Amyotrophic lateral sclerosis (ALS):</strong> An ALS support group meets monthly via Zoom.
+To join, contact organizer Julie Scurich at <a href="mailto:jscurich@alsnetwork.org" aria-label="Email jscurich@alsnetwork.org">jscurich@alsnetwork.org</a> or <a href="tel:+1-831-247-9878" aria-label="Call 831-247-9878">831-247-9878</a>.</p>
+<p><strong>Cancer:</strong> <a href="https://cscslo.org/" data-external-link="true">Cancer Support Community</a> offers a variety of no-cost services for people with cancer, including health education and exercise classes, as well as several support groups, some of which meet in Templeton, some on-line.</p>
+<p><a href="https://www.dignityhealth.org/central-coast/locations/marianregional/services/cancer-care" data-external-link="true">Mission Hope Cancer Center</a> in Arroyo Grande also hosts <a href="https://www.dignityhealth.org/central-coast/locations/marianregional/classes-and-events/cancer-support-programs" data-external-link="true">cancer support groups</a> including in-person groups for people with breast cancer and for oral, head, and neck cancer, and a number of other groups that meet on-line.</p>
+<p><a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a> hosts several support groups at the <a href="https://www.dignityhealth.org/central-coast/locations/frenchhospital/services/hearst-cancer-resource-center" data-external-link="true">Hearst Cancer Resource Center</a>.
+These include groups <a href="https://www.dignityhealth.org/content/dam/dignity-health/central-coast/pdfs/hcrc/patients-with-cancer-support-group-4.pdf" data-external-link="true">for patients with cancer</a> and <a href="https://www.dignityhealth.org/content/dam/dignity-health/central-coast/pdfs/hcrc/thriving-with-advanced-cancer-2024-1.pdf" data-external-link="true">advanced cancer</a>, and groups for people with specific types of cancer, such as cancers of the <a href="https://www.dignityhealth.org/content/dam/dignity-health/central-coast/pdfs/hcrc/BloodCancersGRPFlyr29Apr24.pdf" data-external-link="true">blood</a>, <a href="https://www.dignityhealth.org/content/dam/dignity-health/central-coast/pdfs/hcrc/breast-cancer-support-group-5.pdf" data-external-link="true">breast</a>, or <a href="https://www.dignityhealth.org/content/dam/dignity-health/central-coast/pdfs/hcrc/prostate-cancer-support-group-2023-1.pdf" data-external-link="true">prostate</a>.
+To register, call HCRC at <a href="tel:+1-805-542-6234" aria-label="Call 805-542-6234">805-542-6234</a> or email <a href="mailto:HCRC@dignityhealth.org" aria-label="Email HCRC@dignityhealth.org">HCRC@dignityhealth.org</a>.</p>
+<p><strong>Caregivers:</strong> The <a href="https://www.cottagehealth.org/services/rehabilitation/caregiver-services/" data-external-link="true">Coast Caregiver Resource Center</a> has several support groups, some of which meet on-line, others in SLO or Morro Bay.
+They include groups for caregivers of people with dementia, for LGBTQ caregivers, for caregivers of Parkinson’s disease patients, and groups that are conducted in Spanish.</p>
+<p><strong>Diabetes:</strong> <a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a> hosts a quarterly <a href="https://www.dignityhealth.org/central-coast/locations/frenchhospital/classes-and-events/diabetes" data-external-link="true">diabetes support group</a>.</p>
+<p><strong>Mental illness:</strong> The SLO County chapter of National Alliance on Mental Illness holds <a href="https://www.namislo.org/nami-support-groups" data-external-link="true">support groups</a> for family members of people with mental health challenges, online, in Arroyo Grande, and in Atascadero, every month.
+Contact <a href="mailto:sgroups.nami.sloco@gmail.com" aria-label="Email sgroups.nami.sloco@gmail.com">sgroups.nami.sloco@gmail.com</a> for details.</p>
+<p><a href="#" data-directory-link="TMHA" aria-label="View directory entry for Transitions Mental Health Association (TMHA)"><strong>Transitions Mental Health Association (TMHA)</strong></a> has weekly <a href="https://www.t-mha.org/family-support-groups.php" data-external-link="true">support groups</a> in person and on Zoom for people with loved ones who experience mental illness, in English and in Spanish.
+They also have a variety of <a href="https://storage.googleapis.com/t-mha-org/uploads/WC%20In%20Person%20Group%20Flyer%20All2.pdf" data-external-link="true">in-person support groups</a> and more informal gatherings for people with mental illness, as well as several virtual/online support groups.</p>
+<p><strong>Parkinson’s disease:</strong> The Central Coast Parkinson Association holds monthly in-person <a href="https://www.myccpa.org/support-groups" data-external-link="true">support groups</a> in Atascadero, Morro Bay, Pismo Beach, and San Luis Obispo.
+They also hold a monthly, on-line support group, and a monthly in-person group in Paso Robles, for caregivers only.</p>
+<p><strong>Stroke:</strong> <a href="#" data-directory-link="Arroyo-Grande-Community-Hospital" aria-label="View directory entry for Arroyo Grande Community Hospital"><strong>Arroyo Grande Community Hospital</strong></a> hosts a monthly <a href="https://www.dignityhealth.org/central-coast/locations/frenchhospital/classes-and-events/stroke-support-groups" data-external-link="true">stroke support group</a>.
+<a href="#" data-directory-link="Adventist-Health-Sierra-Vista" aria-label="View directory entry for Adventist Health Sierra Vista"><strong>Adventist Health Sierra Vista</strong></a> hosts a <a href="https://www.stroke.org/en/stroke-groups/hope-for-stroke-survivors-ahsl" data-external-link="true">hope for stroke survivors</a> group for people who have had strokes and for their caregivers.
+Another <a href="https://www.stroke.org/en/stroke-groups/hope-for-stroke" data-external-link="true">hope for stroke</a> group meets in Templeton.</p>
+<h3><span><a id="grief-peer-support">Grief</a></span></h3>
+<p>Hospice SLO operates a weekly, on-line Family Caregiver Support Group for SLO County residents that you can register for <a href="https://hospiceslo.org/support-groups/family-caregiver-support-group-meets-weekly-on-zoom" data-external-link="true">at this page</a>.
+They also have a Grief Support and Education group that meets <a href="https://hospiceslo.org/support-groups/general-grief-support-and-education-group-%E2%80%93-meets-weekly-for-6-weeks-on-zoom" data-external-link="true">online</a> and others that meet in person <a href="https://hospiceslo.org/support-groups/general-grief-support-and-education-group-%E2%80%93-meets-weekly-for-6-weeks-in-north-county" data-external-link="true">in Paso Robles</a> and <a href="https://hospiceslo.org/support-groups/general-grief-support-and-education-group-%E2%80%93-meets-weekly-for-6-weeks-in-slo" data-external-link="true">in SLO city</a>.
+They also have an in-person support group in SLO city specifically for people who are <a href="https://hospiceslo.org/support-groups/spouse-andor-partner-loss-support-and-education-group-meets-weekly-for-six-weeks-in" data-external-link="true">grieving the loss of a spouse or partner</a>.
+They occasionally hold <a href="https://hospiceslo.org/support-groups" data-external-link="true">other support groups</a> as well.</p>
+<p><a href="#" data-directory-link="Central-Coast-Home-Health" aria-label="View directory entry for Central Coast Home Health and Hospice"><strong>Central Coast Home Health and Hospice</strong></a> facilitates <a href="https://centralcoasthomehealth.com/index.php/support-groups/" data-external-link="true">grief support groups</a> weekly at the <a href="#" data-directory-link="Morro-Bay-Senior-Center" aria-label="View directory entry for Morro Bay Senior Center"><strong>Morro Bay Senior Center</strong></a>, <a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a>, and <a href="#" data-directory-link="SLO-Senior-Center" aria-label="View directory entry for SLO Senior Center"><strong>SLO Senior Center</strong></a>.
+Call <a href="tel:+1-805-540-6020" aria-label="Call 805-540-6020">805-540-6020</a> to speak with a bereavement counselor prior to attending.</p>
+<p>Several SLO County churches host <a href="https://griefshare.org/" data-external-link="true">GriefShare support groups</a> with a Christian focus on grieving.</p>
+<h3><span><a id="behavioral-health-peer-support">Behavioral Health</a></span></h3>
+<blockquote>
+<p>See <a href="#twelve-step">12-Step and Similar Recovery Programs</a> in the <a href="#drug-use-and-recovery">Drug Use, Recovery, and Harm Reduction</a> section above for support groups for people recovering from drug addictions.</p>
+</blockquote>
+<p><a href="https://al-anon.org/al-anon-meetings/" data-external-link="true">Al-Anon</a> has support groups for family members of alcoholics that meet online and in Arroyo Grande, Atascadero, Cambria, Cayucos, Grover Beach, Morro Bay, Nipomo, Paso Robles, Pismo Beach, and SLO.
+There is also an <a href="https://al-anon.org/newcomers/teen-corner-alateen/" data-external-link="true">Alateen</a> meeting in Grover Beach specifically for teen-aged family members of alcoholics.</p>
+<p><a href="https://www.naranoncentralca.org/" data-external-link="true">Nar-Anon</a> has in-person weekly meetings for family members of people addicted to drugs that meet in Atascadero as well as several online meetings.
+There are also <a href="https://www.nar-anon.org/find-a-narateen-meeting" data-external-link="true">Narateen</a> on-line weekly meetings specifically for teen-aged family members of addicts.</p>
+<p>An eating disorder support group meets on Wednesdays from 7–8pm at <a href="#" data-directory-link="GALA" aria-label="View directory entry for GALA Pride &amp; Diversity Center"><strong>GALA Pride &amp; Diversity Center</strong></a> in SLO city and by Zoom.
+Contact <a href="mailto:libby@notyouraveragenutritionist.com" aria-label="Email libby@notyouraveragenutritionist.com">libby@notyouraveragenutritionist.com</a> for more information.</p>
+<p><a href="https://oa.org/" data-external-link="true">Overeaters Anonymous</a> holds weekly meetings in Arroyo Grande, Morro Bay, and SLO.</p>
+<p><a href="https://debtorsanonymous.org/" data-external-link="true">Debtors Anonymous</a> holds <a href="https://debtorsanonymous.org/meeting-search-virtual/?tz=PT" data-external-link="true">meetings by phone or Zoom</a> every day of the week.</p>
+<h3><span><a id="glbtq-peer-support">GLBTQ</a></span></h3>
+<p>The <a href="#" data-directory-link="GALA" aria-label="View directory entry for GALA Pride &amp; Diversity Center"><strong>GALA Pride &amp; Diversity Center</strong></a> maintains <a href="https://galacc.org/resources/#support" data-external-link="true">a list of support groups</a>, including:</p>
+<ul>
+<li><strong>Therapist-led trans/genderqueer monthly support group</strong>—contact <a href="mailto:laurenphelpsmft@gmail.com" aria-label="Email laurenphelpsmft@gmail.com">laurenphelpsmft@gmail.com</a> for more information</li>
+<li><strong>“Q” Youth</strong> (grades 6–12)—contact <a href="mailto:youthdirector@galacc.org" aria-label="Email youthdirector@galacc.org">youthdirector@galacc.org</a> or drop-in at GALA any Thursday from 6–8pm</li>
+<li><a href="https://1af473-cd.myshopify.com/pages/tcc-youth-support-group" data-external-link="true">Trans and gender-nonconforming teen support group</a></li>
+<li><a href="https://1af473-cd.myshopify.com/pages/tcc-tuesdays-adult-support-group" data-external-link="true">Trans and gender-nonconforming adult support group</a></li>
+<li><a href="https://1af473-cd.myshopify.com/pages/tcc-transmasc-support-group" data-external-link="true">Transmasculine, and gender-nonconforming masculine-identifying support group</a></li>
+<li><strong>LGBT Seniors</strong>—third Wednesday of the month 4:30–6:30pm at GALA or by Zoom</li>
+<li><strong>Stand Out Parent Support Group</strong>—for parents of LGBTQ+ youth; contact <a href="mailto:email@galacc.org" aria-label="Email email@galacc.org">email@galacc.org</a> for more information</li>
+</ul>
+<h3><span><a id="parenthood-peer-support">Pregnancy and Parenthood</a></span></h3>
+<p><a href="#" data-directory-link="Adventist-Health-Twin-Cities" aria-label="View directory entry for Adventist Health Twin Cities"><strong>Adventist Health Twin Cities</strong></a> hosts <a href="https://www.adventisthealth.org/central-coast/events/ahtc-newborn-and-parent-support-naps" data-external-link="true">“Newborn and Parent Support”</a> and <a href="https://www.adventisthealth.org/central-coast/events/ahtc-navigating-motherhood" data-external-link="true">“Navigating Motherhood”</a> weekly support groups.</p>
+<p><a href="#" data-directory-link="French-Hospital-Medical-Center" aria-label="View directory entry for French Hospital Medical Center"><strong>French Hospital Medical Center</strong></a> operates the online weekly support group <a href="https://www.dignityhealth.org/central-coast/locations/frenchhospital/services/maternity/maternal-emotional-wellness" data-external-link="true">“The Mommy Hour”</a>.
+To join, contact facilitator Wendy Beres at <a href="mailto:wendy.beres@dignityhealth.org" aria-label="Email wendy.beres@dignityhealth.org">wendy.beres@dignityhealth.org</a> or <a href="tel:+1-805-541-2229" aria-label="Call 805-541-2229">805-541-2229</a>.
+They also host a <a href="https://www.dignityhealth.org/central-coast/locations/frenchhospital/classes-and-events/maternity-classes" data-external-link="true">“Bellies and Babies”</a> weekly in-person support group.
+For more information call <a href="tel:+1-805-542-6659" aria-label="Call 805-542-6659">805-542-6659</a>.</p>
+<p>There is a <a href="https://momsclubofatascadero.weebly.com/" data-external-link="true">Moms Club</a> support group in Atascadero that also covers Templeton, Paso Robles, and San Miguel.
+Write to <a href="mailto:atownmoms@gmail.com" aria-label="Email atownmoms@gmail.com">atownmoms@gmail.com</a> for more information.</p>
+<p><a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for Community Action Partnership San Luis Obispo (CAPSLO)"><strong>Community Action Partnership San Luis Obispo (CAPSLO)</strong></a> hosts <a href="https://capslo.org/Pops2/" data-external-link="true">Parent Cafés</a> and <a href="https://capslo.org/Pops2/" data-external-link="true">POPS2 groups</a> (for fathers specifically) with childcare and a meal provided.
+For details on how to join, contact <a href="mailto:pops@capslo.org" aria-label="Email pops@capslo.org">pops@capslo.org</a> or <a href="tel:+1-805-295-1628" aria-label="Call 805-295-1628">805-295-1628</a>.</p>
+<p><a href="https://pacificmidwiferycare.com/" data-external-link="true">Pacific Midwifery</a> offers free “MaMa Mentoring” groups on Tuesdays in Arroyo Grande.
+Contact <a href="mailto:megan@pacificmidwiferycare.com" aria-label="Email megan@pacificmidwiferycare.com">megan@pacificmidwiferycare.com</a> (<a href="tel:+1-805-994-0446" aria-label="Call 805-994-0446">805-994-0446</a>) for details.</p>
+<p>Postpartum Support International also organizes <a href="https://postpartum.net/get-help/psi-online-support-meetings/" data-external-link="true">many free online support groups</a>.</p>
+<h3><span><a id="other-peer-support">Other</a></span></h3>
+<p><a href="https://www.corazonlatino.org/" data-external-link="true">Corazón Latino</a> holds monthly emotional support groups for people in the Latinx community online and in Paso Robles.</p>
+<hr>
+<h2><span><a id="recreation-fitness-socializing-connection">Recreation, Fitness, Socializing, Connection</a></span></h2>
+<h3><span><a id="fitness">Fitness</a></span></h3>
+<p>There are free, outdoor fitness courts with exercise equipment at Emerson Park in SLO (<a href="#" class="map-link" data-lat="35.275738" data-lon="-120.664269" data-zoom="17" data-label="Fitness Court">Pismo St. &amp; Nipomo St.</a>), and behind French Hospital in SLO (<a href="#" class="map-link" data-lat="35.278313" data-lon="-120.652977" data-zoom="17" data-label="Fitness Court">along the bike path between Breck St. and the French Hospital parking lot</a>).
+The “Vita Fitness Courses” in Meadow Park (<a href="#" class="map-link" data-lat="35.267591" data-lon="-120.662198" data-zoom="16" data-label="Vita Fitness Course">between Corrida Drive and South Street in SLO</a>) and around <a href="#" class="map-link" data-lat="35.265279" data-lon="-120.682712" data-zoom="14" data-label="Laguna Lake Park">Laguna Lake Park</a> in SLO have some stations with rudimentary equipment that are designed for fitness exercises.</p>
+
+
+<p>The <a href="#" data-directory-link="SLO-County-YMCA" aria-label="View directory entry for SLO County YMCA"><strong>SLO County YMCA</strong></a> has a gym in SLO city with weight machines, fitness classes (on-line and in person), aqua fitness classes, swim lessons, and more.
+Membership is not free, but the YMCA policy is that “no one is denied membership because of inability to pay.”
+Ask them about options for people with low incomes.</p>
+<p><a href="#" data-directory-link="Arroyo-Grande-Recreation-Services" aria-label="View directory entry for Arroyo Grande Recreation Services"><strong>Arroyo Grande Recreation Services</strong></a> offers low-cost BarreConnect, fitness, somatic breathwork, Pilates, Tai Chi, yoga, and Zumba classes.</p>
+<p><a href="#" data-directory-link="Atascadero-Parks-and-Recreation" aria-label="View directory entry for Atascadero Recreation"><strong>Atascadero Recreation</strong></a> offers low-cost yoga classes.</p>
+<p><a href="#" data-directory-link="Grover-Beach-Community-Services" aria-label="View directory entry for Grover Beach Community Services"><strong>Grover Beach Community Services</strong></a> classes include Tai Chi, stretch &amp; balance, dance fitness, and body movement.</p>
+<p><a href="#" data-directory-link="Paso-Robles-Parks-and-Recreation" aria-label="View directory entry for Paso Robles Parks &amp; Recreation"><strong>Paso Robles Parks &amp; Recreation</strong></a> offers many fitness classes including aquatic fitness, yoga, and Zumba.
+They typically cost money, but there is <a href="https://www.prcity.com/1193/Scholarships" data-external-link="true">a scholarship program</a> for people with low incomes.</p>
+<p><a href="#" data-directory-link="City-of-SLO-Parks-and-Recreation" aria-label="View directory entry for City of SLO Parks and Recreation"><strong>City of SLO Parks and Recreation</strong></a> offers low-cost yoga classes (they provide the yoga mat and any other necessary supplies) and sports (such as pickleball, volleyball, table tennis, softball, dodgeball, and basketball).</p>
+<p>The <a href="https://darebee.com/workouts/" data-external-link="true">DAREBEE</a> website has more than 2,500 free, illustrated workout guides, most of which do not require any special equipment.</p>
+<p>Some local yoga studios offer occasional “community yoga” classes that are free or on a donation or sliding-scale basis.</p>
+<h4><span>Fitness For Seniors</span></h4>
+<p><a href="#" data-directory-link="Arroyo-Grande-Recreation-Services" aria-label="View directory entry for Arroyo Grande Recreation Services"><strong>Arroyo Grande Recreation Services</strong></a> offers low-cost senior fitness classes.</p>
+<p><a href="#" data-directory-link="Atascadero-Senior-Center" aria-label="View directory entry for Atascadero Senior Center"><strong>Atascadero Senior Center</strong></a> offers fitness classes such as senior yoga, Tai Chi, and Qigong.</p>
+<p><a href="#" data-directory-link="Central-Coast-Senior-Center" aria-label="View directory entry for Central Coast Senior Center (Oceano)"><strong>Central Coast Senior Center (Oceano)</strong></a> offers low-cost yoga, chair exercises, and Tai Chi.</p>
+<p><a href="#" data-directory-link="Morro-Bay-Senior-Center" aria-label="View directory entry for Morro Bay Senior Citizens"><strong>Morro Bay Senior Citizens</strong></a> offers yoga, Tai Chi, strength training, balance class, Adult Class Exercise for Seniors (ACES), PACE (People with Arthritis Can Exercise).</p>
+<p><a href="#" data-directory-link="Nipomo-Senior-Center" aria-label="View directory entry for Nipomo Senior Center"><strong>Nipomo Senior Center</strong></a> offers low-impact chair exercise classes.</p>
+<p><a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a> offers yoga, balance and strength classes, flexercise, arthritis exercise, and brain fitness classes.</p>
+<p><a href="#" data-directory-link="SLO-Senior-Center" aria-label="View directory entry for SLO Senior Center"><strong>SLO Senior Center</strong></a> leads “SLO Hikers &amp; Walkers” hikes of local trails and strolls through downtown, designed for people age 55 and older.
+See the <a href="https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs" data-external-link="true">Hikers &amp; Walkers</a> section of the city’s Senior Center web page for details on upcoming hikes and walks.
+They also host low-cost yoga classes (the first class is free), a free chair exercise class, and a free strength &amp; balance class, all for people age 55 and older.</p>
+<h3><span><a id="recreation-and-socializing">Recreation and Socializing</a></span></h3>
+<p>SLO City has a free, public skate park, open daily 7am–10pm, at <a href="#" class="map-link" data-lat="35.290166" data-lon="-120.664167" data-zoom="17" data-label="Santa Rosa Park">Santa Rosa Park</a>.
+You must wear a helmet and elbow &amp; knee pads to use the skate park.</p>
+<p>The <a href="#" data-directory-link="SLO-County-YMCA" aria-label="View directory entry for SLO County YMCA"><strong>SLO County YMCA</strong></a> runs a local basketball league and organizes pick-up game hours.</p>
+<p>The city of SLO offers free <a href="https://downtownslo.com/events/concerts" data-external-link="true">Concerts in the Plaza</a> downtown on Friday evenings during the summer.
+<a href="#" data-directory-link="Arroyo-Grande-Recreation-Services" aria-label="View directory entry for Arroyo Grande Recreation Services"><strong>Arroyo Grande Recreation Services</strong></a> offers free concerts at the Rotary Bandstand mid-day on Sundays during the summer.
+<a href="#" data-directory-link="Grover-Beach-Community-Services" aria-label="View directory entry for Grover Beach Community Services"><strong>Grover Beach Community Services</strong></a> offers free concerts on Sundays in Ramona Park during the summer.
+<a href="#" data-directory-link="Morro-Bay-Senior-Center" aria-label="View directory entry for Morro Bay Active Adults"><strong>Morro Bay Active Adults</strong></a> offers free concerts on Thursdays in the early fall at Tidelands Park.
+<a href="#" data-directory-link="Paso-Robles-Parks-and-Recreation" aria-label="View directory entry for Paso Robles Recreation Services"><strong>Paso Robles Recreation Services</strong></a> offers free concerts on Thursday evenings during the summer in the Downtown City Park.</p>
+<p><a href="#" data-directory-link="Arroyo-Grande-Recreation-Services" aria-label="View directory entry for Arroyo Grande Recreation Services"><strong>Arroyo Grande Recreation Services</strong></a> offers low-cost classes in things like improvisation, bagpipes, bridge, line dance, drumming, and fabric arts.</p>
+<p><a href="#" data-directory-link="Atascadero-Parks-and-Recreation" aria-label="View directory entry for Atascadero Recreation"><strong>Atascadero Recreation</strong></a> offers an adult basketball and kickball league, as well as drop-in basketball three days a week, and drop-in volleyball one day a week.
+They also offer classes in arts &amp; crafts</p>
+<p><a href="#" data-directory-link="Grover-Beach-Community-Services" aria-label="View directory entry for Grover Beach Community Services"><strong>Grover Beach Community Services</strong></a> classes include acrylic &amp; oil painting, dance, calligraphy, ukulele, and sailing.</p>
+<p><a href="#" data-directory-link="Paso-Robles-Parks-and-Recreation" aria-label="View directory entry for Paso Robles Parks &amp; Recreation"><strong>Paso Robles Parks &amp; Recreation</strong></a> offers many classes and activities including karate, pickleball, line dancing, crafting, dog training, and first aid.
+They typically cost money, but there is <a href="https://www.prcity.com/1193/Scholarships" data-external-link="true">a scholarship program</a> for people with low incomes.</p>
+<p><a href="#" data-directory-link="Pismo-Beach-Recreation-Division" aria-label="View directory entry for Pismo Beach Recreation Division"><strong>Pismo Beach Recreation Division</strong></a> has two beach wheelchairs available to the public to be borrowed for four hours at a time at no charge.
+Call <a href="tel:+1-805-773-2422" aria-label="Call 805-773-2422">805-773-2422</a> for details.</p>
+<p>There are <a href="https://slothrowers.com/slo-courses/" data-external-link="true">five major disc golf courses</a> in SLO County.</p>
+<p>The SLO city bicycling community operates several free events, such as bike-in movie nights, group rides, and free bike breakfasts, many of which take place during <a href="https://rideshare.org/program/bike-month/" data-external-link="true">“Bike Month”</a> (lately, May).
+The first Thursday of every month, soon after SLO’s downtown farmers’ market, is the “Bike Happening” in which dozens to hundreds of bicyclists do circuits around downtown, hooting and hollering.</p>
+<p>The <a href="https://bayososfolkdancers.weebly.com/" data-external-link="true">Bay Osos Folk Dancers</a> club meets on Tuesdays from 11am–3pm at the <a href="#" data-directory-link="South-Bay-Community-Center" aria-label="View directory entry for South Bay Community Center"><strong>South Bay Community Center</strong></a> to learn and practice folk and line dances.
+Donations are requested to cover costs.</p>
+<h4><span>Recreation and Socializing For Seniors</span></h4>
+<p><a href="#" data-directory-link="Atascadero-Senior-Center" aria-label="View directory entry for Atascadero Senior Center"><strong>Atascadero Senior Center</strong></a> offers classes, board and card games, arts &amp; crafts sessions, discussion groups, movies, walking groups.
+Most are free for members ($20 annual dues), and $2 for non-members.
+They also have a lending library of games and puzzles.</p>
+<p><a href="#" data-directory-link="Central-Coast-Senior-Center" aria-label="View directory entry for Central Coast Senior Center (Oceano)"><strong>Central Coast Senior Center (Oceano)</strong></a> hosts games, a ukulele group, line dancing, and bingo.</p>
+<p><a href="#" data-directory-link="Morro-Bay-Senior-Center" aria-label="View directory entry for Morro Bay Senior Citizens"><strong>Morro Bay Senior Citizens</strong></a> hosts bingo, bocce, bridge, chess, dance, drawing &amp; watercolor, ping-pong, pool and billiards, hand &amp; foot cards, and special-interest classes.</p>
+<p>There are pickleball courts in <a href="#" class="map-link" data-lat="35.398611" data-lon="-120.858761" data-zoom="17" data-label="Del Mar Park">Del Mark Park in Morro Bay</a>, open to all from 8am–Noon and open by reservation (for a fee through the Morro Bay Recreation Department) in the afternoons.
+Free lessons are available (balls and paddles provided) on Saturdays from 8:30–9:00am.</p>
+<p><a href="#" data-directory-link="Nipomo-Senior-Center" aria-label="View directory entry for Nipomo Senior Center"><strong>Nipomo Senior Center</strong></a> hosts bingo, canasta, a potluck, and has free coffee daily.</p>
+<p><a href="#" data-directory-link="Paso-Robles-Senior-Center" aria-label="View directory entry for Paso Robles Senior Center"><strong>Paso Robles Senior Center</strong></a> hosts scrabble, hand &amp; foot, pinochle, meditation &amp; mindfulness, knitting, bridge, mahjong, poker, bingo, Mexican train, Rummikub, cribbage, movies, a book club, and a walking group.</p>
+<p><a href="#" data-directory-link="SLO-Senior-Center" aria-label="View directory entry for SLO Senior Center"><strong>SLO Senior Center</strong></a> operates free “Around the Town” tours of local places of interest for people age 55 and older.
+See the <a href="https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs" data-external-link="true">Around the Town</a> section of the city’s Senior Center web page for details on upcoming tours and instructions on how to register.
+They also host bingo, bridge, mahjong, Mexican train dominoes, pinochle, and other activities at various times during the week (some of these are free, some cost a few dollars).</p>
+<hr>
+<h2><span><a id="pet-care-and-pet-supplies">Pet Care and Pet Supplies</a></span></h2>
+<p><a href="#" data-directory-link="SLO-County-Animal-Services" aria-label="View directory entry for SLO County Animal Services"><strong>SLO County Animal Services</strong></a> operates the only open-intake animal shelter in SLO County.
+Services include dog licensing, pet microchipping, lost and found pet assistance, animal adoption, assistance animal identification tags, rabies control, animal welfare investigations, nuisance animal response, and humane education programs.
+They have an <a href="https://24petconnect.com/SLOCStray" data-external-link="true">on-line registry of all animals currently at the pound, with photos</a> and you can use a web interface to <a href="https://24petconnect.com/BreedRequest/Lost?shelterlist=SLOC&amp;zip=93405" data-external-link="true">report a lost pet</a>.
+You can call <a href="tel:+1-805-781-4407" aria-label="Call 805-781-4407">805-781-4407</a> to listen to a found animal recording that describes recently-found animals that are being held at the pound.</p>
+<p><a href="#" data-directory-link="CCPAW" aria-label="View directory entry for Central Coast Partnership for Animal Welfare"><strong>Central Coast Partnership for Animal Welfare</strong></a> conducts regular free pet food distributions in Grover Beach and Oceano.
+You can also call their emergency pet care phone line to arrange for emergency veterinary treatment.</p>
+<p><a href="#" data-directory-link="C.A.R.E.4Paws" aria-label="View directory entry for C.A.R.E.4Paws"><strong>C.A.R.E.4Paws</strong></a>, in partnership with “The Street Dog Coalition,” operates mobile pet wellness clinics in Nipomo, Grover Beach, Arroyo Grande, San Luis Obispo, and Oceano, as well as several sites in Santa Barbara County.
+These provide vaccines, spay/neuter service, health exams, medical care, and pet food assistance.
+They specialize in care for pets of homeless people.
+They also operate the “Pet Refuge” program, which can temporarily board pets for people whose housing situation has become unstable or who are temporarily unable to care for their pets. </p>
+<p><a href="#" data-directory-link="Woods-Humane-Society" aria-label="View directory entry for Woods Humane Society"><strong>Woods Humane Society</strong></a> has a <a href="https://woodshumanesociety.org/pet-pantry/" data-external-link="true">Pet Pantry</a> for pet owners facing challenges and offers financial assistance for spay/neuter procedures.
+They can also help you find lost pets and can find new homes for pets when their owners can no longer take care of them.
+Some services are by-appointment only.</p>
+<p><a href="#" data-directory-link="North-County-Paws-Cause" aria-label="View directory entry for North County Paws Cause"><strong>North County Paws Cause</strong></a> can help people in northern SLO County who need help caring for their cats while they are homeless or transitioning into new housing.</p>
+<p><a href="#" data-directory-link="Pets-of-the-Homeless" aria-label="View directory entry for Pets of the Homeless"><strong>Pets of the Homeless</strong></a> is a national organization that focuses on feeding and providing veterinary care to pets of people experiencing homelessness.
+If your pet needs veterinary care, call them to arrange an interview with a case manager who will determine your eligibility, approve an exam, and help make an appointment at local hospital or clinic.
+There is no charge to the pet owner, but donations are appreciated.</p>
+<p>The <a href="#" data-directory-link="40-Prado" aria-label="View directory entry for 40 Prado Homeless Services Center"><strong>40 Prado Homeless Services Center</strong></a> has a pet kennel for guests (both overnight guests and warming/cooling center guests).
+Pets must have documentation of rabies vaccinations.</p>
+<p><a href="#" data-directory-link="Cal-Poly-Doggy-Days" aria-label="View directory entry for Cal Poly “Doggy Days” Veterinary Clinics"><strong>Cal Poly “Doggy Days” Veterinary Clinics</strong></a> are periodic pop-up clinics that offer free veterinary care including vaccinations, exams, and nail trims.
+They happen 3–4 times per quarter at various locations around SLO County, often coordinating with other community outreach programs like <a href="#" data-directory-link="Shower-the-People" aria-label="View directory entry for Shower the People"><strong>Shower the People</strong></a>.</p>
+<p><a href="#" data-directory-link="Kritter-Care" aria-label="View directory entry for Kritter Care"><strong>Kritter Care</strong></a>, based in Morro Bay, can give dog &amp; cat food, pet supplies, and assistance with vet bills to pet owners who have only limited funds.</p>
+<p><a href="#" data-directory-link="Helping-Friends-Program" aria-label="View directory entry for Voice for the Animals Helping Friends Program"><strong>Voice for the Animals Helping Friends Program</strong></a> helps seniors, people with disabilities, terminal illnesses, and individuals on fixed incomes to pay for medical treatments for their pets.</p>
+<p><a href="https://www.thepetfund.com/" data-external-link="true">The Pet Fund</a> is a national organization that provides financial assistance to pet owners who need non-emergency veterinary care but lack sufficient funds.
+Submit an <a href="https://www.thepetfund.com/for-pet-owners/the-pet-fund-application" data-external-link="true">application</a> at their website.
+You must document your financial need and provide veterinary care estimates.</p>
+<p><a href="#" data-directory-link="Red-Rover-Relief" aria-label="View directory entry for Red Rover Relief"><strong>Red Rover Relief</strong></a> provides one-time urgent care grants of up to $1,000 to pay for pet medical emergencies.
+This is only for people in the U.S. with income under $60,000 per year.
+You must make a fundraising effort first before you contact Red Rover Relief.
+You must supply a current veterinary diagnosis and treatment plan.
+Grants do not cover exams or testing.</p>
+<hr>
+<h2><span><a id="disaster-preparedness">Disaster Planning/Preparation</a></span></h2>
+<p>Fires, floods, and earthquakes sometimes strike SLO County.
+Extremes of weather like heat waves, freezing temperatures, and storms are also increasingly common.
+Epidemics, tsunamis, and hazardous materials releases can also happen.
+If you are homeless and sleeping outdoors, you can be especially vulnerable to such dangers.</p>
+<p>The <a href="#" data-directory-link="SLO-County-Office-of-Emergency-Services" aria-label="View directory entry for SLO County Office of Emergency Services"><strong>SLO County Office of Emergency Services</strong></a> has resources that can help you prepare for and respond to emergency situations.
+Their <a href="https://readyslo.org/" data-external-link="true">ReadySLO.org</a> site includes the following sections:</p>
+<ol>
+<li><a href="https://www.prepareslo.org/" data-external-link="true">PrepareSLO.org</a>—how to prepare for the next emergency, how to learn your evacuation zone number, and how to understand emergency alerts</li>
+<li><a href="https://www.emergencyslo.org/" data-external-link="true">EmergencySLO.org</a>—information about ongoing emergencies, evacuation orders and warnings, evacuation shelters, and road closures</li>
+<li><a href="https://www.recoverslo.org/" data-external-link="true">RecoverSLO.org</a>—after an emergency, this page lists some ways to recover from it</li>
+</ol>
+<p>You can register to get local emergency alerts by text message on your phone at <a href="https://public.alertsense.com/SignUp/?RegionId=1317" data-external-link="true">AlertSLO</a>.
+You can choose which sorts of alerts you are interested in receiving (for example “Flood / Flash Flood” and “Fire”).</p>
+<p>The <a href="#" data-directory-link="Red-Cross" aria-label="View directory entry for Red Cross"><strong>Red Cross</strong></a> operates emergency shelters during major disasters.
+They usually have pet-friendly options.</p>
+<h3><span><a id="fire-safety">Fire Safety in Camp</a></span></h3>
+<p>If you are camping outdoors, be very careful with fire.
+California frequently experiences major wildfires, and campfires are a frequent cause.</p>
+<p>Build fires at least 25 feet away from tents, shrubs, and flammable materials.
+Do not build fires under overhanging tree branches.
+Avoid fires on windy days and during periods when fire danger is particularly high (such as mid to late Summer).
+Do not use flammable liquids like gasoline or lighter fluid to start camp fires.</p>
+<p>Keep fires small.
+It is wiser and takes less effort to make a small fire and sit close to it than to make a big fire and sit far away.</p>
+<p>Use existing fire rings when these are available.
+Otherwise clear a five-foot (two-meter) radius around the fire of all vegetation and flammable material.</p>
+<p>Have a bucket of water handy.</p>
+<p>Do not leave a fire unattended.
+Always extinguish it thoroughly first.
+To extinguish a fire thoroughly, soak it with water.
+Stir the ashes to expose any unburned material, and soak it again.
+The fire is not thoroughly extinguished until you can place your hand anywhere into the ashes without getting burned.</p>
+<p>Note that in SLO County it is not legal to have a campfire outside of a developed campground unless you have a valid <a href="https://www.ca.gov/departments/147/services/1239/" data-external-link="true">California Campfire Permit</a>.
+In many times and places in SLO County it is not legal to make a campfire whether you have such a permit or not.</p>
+<h3><span><a id="extreme-cold-and-heat">Extreme Cold and Heat</a></span></h3>
+<p>SLO County is in general blessed with a moderate climate, but rainy or dangerously cold overnight weather is common in Winter, and dangerously hot daytime weather is common in Summer.
+See the <a href="#warming-cooling-centers">Warming/Cooling Centers</a> of this guide for some ways to get shelter from these temperature extremes.
+Warming centers typically open when temperatures are due to drop to 38°F or below or there is more than a 50% chance of rain.</p>
+<hr>
+<h2><span><a id="advocacy-and-organizing">Advocacy &amp; Lobbying: Influencing Government Homelessness Policy</a></span></h2>
+<p><strong>In this section:</strong></p>
+<ul>
+<li><a href="#influencing-policy">Influencing policy</a></li>
+<li><a href="#reporting-concerns">Reporting Concerns and Problems</a></li>
+<li><a href="#reporting-crimes">Reporting Crimes</a></li>
+<li><a href="#reporting-misconduct">Reporting Government Misconduct</a></li>
+</ul>
+<p>San Luis Obispo County is an especially challenging place for people trying to avoid or to escape homelessness.
+Nearly one in four homeless people in the United States lives in California.
+California has one of the highest per-capita rates of homelessness in the nation, and the highest percentage of unsheltered homeless people.
+In San Luis Obispo County, there are only enough shelter beds for about 20–30% of the people known to be homeless here, and so the county has the third highest percentage of <em>unsheltered</em> homelessness of any mostly-rural county in the U.S.
+The city of San Luis Obispo is one of the top ten most expensive cities in the U.S. based on how much income (relative to the median income) you must have to afford to buy a home.
+10% of schoolchildren in SLO County are homeless.</p>
+<p>Why are things especially difficult here?
+There are many reasons, but the most important one is “too few homes for the number of people who need them.”
+The reasons why that is a problem are complicated, but include government policies that reduce the availability of homes and make them more expensive, resource constraints, and high demand.</p>
+<table>
+<thead>
+<tr>
+<th><strong>External links</strong></th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="External links"><a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/quarterly-homelessness-dashboard" data-external-link="true">Quarterly Homelessness Dashboard</a>: The SLO County Department of Social Services’s summary of the ongoing work of homeless management agencies.</td>
+</tr>
+<tr>
+<td data-label="External links"><a href="https://en.wikipedia.org/wiki/Homelessness_in_California" data-external-link="true">Wikipedia: Homelessness in California</a></td>
+</tr>
+<tr>
+<td data-label="External links"><a href="https://homelessnesshousingproblem.com/" data-external-link="true"><em>Homelessness is a Housing Problem</em></a> by Gregg Colburn &amp; Clayton Page Aldern</td>
+</tr>
+</tbody></table>
+<h3><span><a id="influencing-policy">Influencing Policy</a></span></h3>
+<p>The <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division" data-external-link="true">SLO County Homeless Services Division</a> is in charge of implementing County policies to address homelessness.
+These policies include <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council/forms-documents/2022/slocountywideplantoaddresshomelessness" data-external-link="true"><em>The San Luis Obispo Countywide Plan to Address Homelessness, 2022–2027</em></a>.
+You can contact them at <a href="mailto:ss_homelessservices@co.slo.ca.us" aria-label="Email SS_HomelessServices@co.slo.ca.us">SS_HomelessServices@co.slo.ca.us</a>.</p>
+<p>The Homeless Services Division is advised and overseen by the <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council" data-external-link="true">Homeless Services Oversight Council (HSOC)</a>.
+This council welcomes people with current or past lived experience of homelessness to join it.
+You can apply for a seat on this council by completing <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council/hsoc-membership/forms-documents/2024/hsoc-membership-application-form" data-external-link="true">this form</a> and submitting it to <a href="mailto:SS_HomelessServices@co.slo.ca.us" aria-label="Email SS_HomelessServices@co.slo.ca.us">SS_HomelessServices@co.slo.ca.us</a>.</p>
+<p>The meetings of this council and its committees are open to the public, either in person, or via Zoom or phone.
+Visit <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council" data-external-link="true">slocounty.gov/HSOC</a> for meeting schedules.</p>
+<p>Every two years, typically in January, a census of homeless people in the United States is attempted.
+This is called the <a href="https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/point-in-time-count" data-external-link="true">“Point-in-Time Count”</a>.
+This helps the government estimate how many people are homeless, where homeless people are, and what their characteristics are.
+This in turn helps the government decide what policy responses to prioritize.
+You can read <a href="https://www.slocounty.ca.gov/getmedia/3eb220e5-a230-4c31-9a87-e2bc24e648be/2024_pitcount_communityreport" data-external-link="true">the official report on SLO County’s 2024 Point-in-Time Count</a>.
+The Point-in-Time Count is conducted by volunteers.
+If you would like to help with the Count, email <a href="mailto:HSD_PITCount@co.slo.ca.us" aria-label="Email HSD_PITCount@co.slo.ca.us">HSD_PITCount@co.slo.ca.us</a> for details.</p>
+<p><a href="https://www.slocoyimby.org/" data-external-link="true">SLOCo YIMBY</a> is a grassroots group that advocates for building more housing in SLO County, and for policy changes like legalizing multifamily housing, streamlining permitting, increasing affordable housing funding, and strengthening renter protections.
+They mobilize citizen action and outreach campaigns in support of those goals.
+Contact <a href="mailto:hello@slocoyimby.org" aria-label="Email hello@slocoyimby.org">hello@slocoyimby.org</a> for details.</p>
+<p>The <a href="https://nationalhomeless.org/" data-external-link="true">National Coalition for the Homeless</a> campaigns on the national level for changes in U.S. federal policy to alleviate homelessness and help people who are homeless.</p>
+<p>The <a href="https://nationalunionofthehomeless.org/" data-external-link="true">National Union of the Homeless</a> has a <a href="https://sacramentohomelessunion.org/" data-external-link="true">Sacramento chapter</a> that helped SLO County homeless people fight for legal protection when the Kansas Avenue (a.k.a. Oklahoma Avenue) safe parking program was closed.
+You can contact the Sacramento chapter at <a href="mailto:sacramento.homeless.union@gmail.com" aria-label="Email sacramento.homeless.union@gmail.com">sacramento.homeless.union@gmail.com</a>.</p>
+<h3><span><a id="reporting-concerns">Reporting Concerns and Problems</a></span></h3>
+<p>Some SLO County cities have on-line platforms with which you can report non-emergency problems.
+Your report is routed to the correct department where people can address your concern:</p>
+<table>
+<thead>
+<tr>
+<th>City</th>
+<th>Platform</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="City">Arroyo Grande</td>
+<td data-label="Platform"><a href="https://ca-arroyogrande.civicplus.com/387/Report-a-Concern" data-external-link="true">Citizen Request Tracker or CitizenServ</a></td>
+</tr>
+<tr>
+<td data-label="City">Atascadero</td>
+<td data-label="Platform"><a href="https://www.atascadero.org/public-safety-reporting" data-external-link="true">Public Safety &amp; Reporting</a></td>
+</tr>
+<tr>
+<td data-label="City">Grover Beach</td>
+<td data-label="Platform"><a href="https://www.grover.org/652/Report-an-Issue" data-external-link="true">Report an Issue</a></td>
+</tr>
+<tr>
+<td data-label="City">Morro Bay</td>
+<td data-label="Platform"><a href="https://www.morrobayca.gov/983/Service-Request" data-external-link="true">CitySourced</a></td>
+</tr>
+<tr>
+<td data-label="City">Paso Robles</td>
+<td data-label="Platform"><a href="https://seeclickfix.com/web_portal/mWPmZTZqbheqdCAtKircrZNq/issues/map" data-external-link="true">SeeClickFix</a></td>
+</tr>
+<tr>
+<td data-label="City">Pismo Beach</td>
+<td data-label="Platform"><a href="https://iframe.publicstuff.com/#?client_id=1428#picker-top" data-external-link="true">Pismo Pulse</a></td>
+</tr>
+<tr>
+<td data-label="City">SLO</td>
+<td data-label="Platform"><a href="https://www.slocity.org/services/how-do-i/ask-slo-copy/report-request" data-external-link="true">AskSLO</a></td>
+</tr>
+</tbody></table>
+<p>Some cities have special contacts specifically for issues concerning homelessness.
+For homeless-specific questions in Paso Robles, contact <a href="mailto:homelessinfo@prcity.com" aria-label="Email homelessinfo@prcity.com">homelessinfo@prcity.com</a>.
+In SLO city, contact the Homelessness Response Manager at <a href="mailto:dwiberg@slocity.org" aria-label="Email dwiberg@slocity.org">dwiberg@slocity.org</a> or <a href="tel:+1-805-781-7025" aria-label="Call 805-781-7025">805-781-7025</a>.</p>
+<h3><span><a id="reporting-crimes">Reporting Crimes</a></span></h3>
+<p>To report a crime in process, or a crime where you know who committed it, you should contact the local police department (in a city) or the sheriff (outside city limits).
+Calling <a href="tel:+1-911" aria-label="Call 911">911</a> is the best way of reporting an emergency or a crime in progress.
+In non-emergency situations, you can call the police or sheriff departments directly:</p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Phone Number</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">(unincorporated areas)</td>
+<td data-label="Phone Number">Sheriff: <a href="tel:+1-805-781-4550;ext=3" aria-label="Call 805-781-4550&nbsp;x3">805-781-4550&nbsp;x3</a></td>
+</tr>
+<tr>
+<td data-label="Location">Arroyo Grande</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-473-5100" aria-label="Call 805-473-5100">805-473-5100</a></td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-461-5051;ext=5" aria-label="Call 805-461-5051&nbsp;x5">805-461-5051&nbsp;x5</a></td>
+</tr>
+<tr>
+<td data-label="Location">Cal Poly</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-756-2281" aria-label="Call 805-756-2281">805-756-2281</a></td>
+</tr>
+<tr>
+<td data-label="Location">Grover Beach</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-473-4511" aria-label="Call 805-473-4511">805-473-4511</a></td>
+</tr>
+<tr>
+<td data-label="Location">(highways)</td>
+<td data-label="Phone Number">CHP: <a href="tel:+1-805-835-5247" aria-label="Call 805-835-5247">805-835-5247</a></td>
+</tr>
+<tr>
+<td data-label="Location">Morro Bay</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-772-6225" aria-label="Call 805-772-6225">805-772-6225</a></td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-237-6464" aria-label="Call 805-237-6464">805-237-6464</a></td>
+</tr>
+<tr>
+<td data-label="Location">Pismo Beach</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-773-2208" aria-label="Call 805-773-2208">805-773-2208</a></td>
+</tr>
+<tr>
+<td data-label="Location">SLO city</td>
+<td data-label="Phone Number">Police: <a href="tel:+1-805-781-7312" aria-label="Call 805-781-7312">805-781-7312</a></td>
+</tr>
+</tbody></table>
+<p>In some areas, you can also report a crime in a non-emergency situation, where you do not know who committed the crime, with an on-line form:</p>
+<table>
+<thead>
+<tr>
+<th>Location</th>
+<th>Online Reporting Method</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Location">(unincorporated areas)</td>
+<td data-label="Online Reporting Method">Sheriff: <a href="https://report.citizenserviceportal.com/home/agency?agencycode=sloso" data-external-link="true">Public Safety Citizens Service Portal</a></td>
+</tr>
+<tr>
+<td data-label="Location">Atascadero</td>
+<td data-label="Online Reporting Method">Police: <a href="https://www.atascadero.org/service/crime-reporting" data-external-link="true">Crime Reporting</a></td>
+</tr>
+<tr>
+<td data-label="Location">Paso Robles</td>
+<td data-label="Online Reporting Method">Police: <a href="https://www.prcity.com/671/File-a-Police-Report" data-external-link="true">File a Police Report</a></td>
+</tr>
+<tr>
+<td data-label="Location">SLO city</td>
+<td data-label="Online Reporting Method">Police: <a href="https://www.slocity.org/government/department-directory/police-department/online-reporting" data-external-link="true">Online Reporting</a></td>
+</tr>
+<tr>
+<td data-label="Location">highways and other cities</td>
+<td data-label="Online Reporting Method">call one of the phone numbers in the table above</td>
+</tr>
+</tbody></table>
+<p>You can also submit tips to law enforcement about crimes (anonymously if you choose) through SLO County Crime Stoppers.
+You can do this either by using the on-line tip form at <a href="https://sanluisobispocounty.crimestoppersweb.com/" data-external-link="true">sanluisobispocounty.crimestoppersweb.com</a> or by calling <a href="tel:+1-805-549-7867" aria-label="Call 805-549-STOP">805-549-STOP</a>.</p>
+<p>If you are an adult who is dependent on others, and you are subjected to abuse or neglect—or if you know of another adult in such a situation—you can get help from <a href="#" data-directory-link="Adult-Protective-Services" aria-label="View directory entry for Adult Protective Services"><strong>Adult Protective Services</strong></a>.
+Make emergency calls to <a href="tel:+1-805-781-1790" aria-label="Call 805-781-1790">805-781-1790</a> (M–F 8am–5pm) or <a href="tel:+1-844-729-8011" aria-label="Call 844-729-8011">844-729-8011</a> (all other hours).</p>
+<h3><span><a id="reporting-misconduct">Reporting Government Misconduct</a></span></h3>
+<p>You can report misconduct by police or sheriff personnel to the police or sheriff departments.
+Some departments welcome such reports and use them to improve or to discipline misbehaving employees.
+Other departments are hostile to such complaints and may even retaliate against people who report misconduct.
+You may want to carefully consider the pros and cons before filing misconduct complaints.</p>
+<table>
+<thead>
+<tr>
+<th>Department</th>
+<th>Complaint Method</th>
+</tr>
+</thead>
+<tbody><tr>
+<td data-label="Department">Arroyo Grande police</td>
+<td data-label="Complaint Method"><a href="https://ca-arroyogrande.civicplus.com/464/Citizen-Complaint" data-external-link="true">Citizen Complaint</a></td>
+</tr>
+<tr>
+<td data-label="Department">Cal Poly police</td>
+<td data-label="Complaint Method"><a href="mailto:police@calpoly.edu" aria-label="Email police@calpoly.edu">police@calpoly.edu</a></td>
+</tr>
+<tr>
+<td data-label="Department">CHP (highways)</td>
+<td data-label="Complaint Method"><a href="https://www.chp.ca.gov/notify-chp/commend-or-complain/" data-external-link="true">Commend or Complain Form</a></td>
+</tr>
+<tr>
+<td data-label="Department">Grover Beach police</td>
+<td data-label="Complaint Method"><a href="https://www.grover.org/252/Citizen-Feedback---Compliments-or-Compla" data-external-link="true">Citizen Feedback</a></td>
+</tr>
+<tr>
+<td data-label="Department">Pismo Beach police</td>
+<td data-label="Complaint Method"><a href="tel:+1-805-773-2208" aria-label="Call 805-773-2208">805-773-2208</a>, in person, or by mail</td>
+</tr>
+<tr>
+<td data-label="Department">SLO city police</td>
+<td data-label="Complaint Method"><a href="https://www.slocity.org/government/department-directory/police-department/citizen-complaints-commendations" data-external-link="true">Citizen Complaint</a>, or <a href="tel:+1-805-781-7317" aria-label="Call 805-781-7317">805-781-7317</a></td>
+</tr>
+<tr>
+<td data-label="Department">SLO county sheriff</td>
+<td data-label="Complaint Method"><a href="https://forms.office.com/Pages/ResponsePage.aspx?id=dMfDhN9_4kClkCey5w-BJlj1OgktxXpPh0AbBedZg-ZUQzRSQUVOWUZIT1ZZNkdMQjQyMUk5NDJDMi4u" data-external-link="true">Citizen Complaint Report</a></td>
+</tr>
+<tr>
+<td data-label="Department">others</td>
+<td data-label="Complaint Method">call, or visit in person</td>
+</tr>
+</tbody></table>
+<p>For complaints about county employee or department misconduct, if you have been unable to resolve your complaint by contacting the department itself, you can file a complaint with the county Administrative Office by using its <a href="https://www.slocounty.ca.gov/departments/administrative-office/services/citizen-complaint-investigations" data-external-link="true">Submit a Complaint form</a>.</p>
+<p>For complaints about County Behavioral Health specifically, contact the <a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/quality-support-services/patients-rights-advocate" data-external-link="true">Patients’ Rights Advocate</a> (<a href="tel:+1-805-781-4738" aria-label="Call 805-781-4738">805-781-4738</a>).</p>
+<hr>
+<h2><span><a id="miscellaneous-free-items">(Mostly) Free Stuff</a></span></h2>
+<h3><span><a id="totally-free-stuff">Totally Free</a></span></h3>
+<p>The <a href="https://www.freecycle.org/town/SanLuisObispoCA" data-external-link="true">Freecycle San Luis Obispo</a> network is free to join (you must create an on-line account to participate).
+People in the network can announce when they have things that they no longer want and would like to give away, or can request items they are looking for.
+All items are cost-free.
+There are also “Buy Nothing” groups in the area that have a similar focus.
+The <a href="https://buynothingproject.org/find-a-group" data-external-link="true">Buy Nothing Project</a> has an app you can use to connect with people nearby who have things to give away.
+You may have better luck searching Facebook for “Buy Nothing” plus the name of the town you are in.</p>
+<p>“Little Free Libraries” are boxes in public areas (for example adjacent to sidewalks) where people leave books they are giving away.
+Anyone is free to take books for their own use from Little Free Libraries.
+There is no check-out/check-in procedure. Just take what you want to read, or leave what you’re finished reading.
+They are typically open 24-hours a day, every day.
+See <a href="#" data-directory-link="Little-Free-Libraries" aria-label="View directory entry for Little Free Libraries"><strong>Little Free Libraries</strong></a> in the Directory for a list of dozens of them in SLO County.</p>
+<p>“Little Free Pantries” are similar, but rather than holding books, they specialize in non-perishable food, feminine hygiene products, pet food, and miscellaneous other items.
+See <a href="#" data-directory-link="Little-Free-Pantries" aria-label="View directory entry for Little Free Pantries"><strong>Little Free Pantries</strong></a> in the Directory for a list of several in SLO County.</p>
+<p>The Shandon branch of <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> has a tool-lending library.
+People with county library cards can borrow power tools like drills, saws, sanders, or a router; outdoor tools like a leaf blower, hedge trimmer, or pole saw; and manual tools like ladders, levels, dollies, or a workbench.
+You must complete some extra forms and a liability waiver to use the tool lending library.</p>
+<p>PG&amp;E’s <a href="https://www.pge.com/en/save-energy-and-money/energy-saving-programs/energy-savings-assistance-program.html" data-external-link="true">Energy Savings Assistance (ESA) Program</a> helps low-income households upgrade or repair water heaters, furnaces, lighting, and appliances for no cost.
+This can also improve energy efficiency, which will lower your utility bills.
+See their website for information on who is eligible and how to apply, or call <a href="tel:+1-800-933-9555" aria-label="Call 800-933-9555">800-933-9555</a>.</p>
+<p><a href="#" data-directory-link="CAPSLO" aria-label="View directory entry for CAPSLO"><strong>CAPSLO</strong></a> can connect low-income households with providers of no-cost weatherization through their <a href="https://capslo.org/energy-services/" data-external-link="true">Home and Energy Services</a> program.
+They can also connect seniors (aged 60+) with providers of no-cost minor home repairs through that program.
+Call their Energy Office for details.</p>
+<p>The <a href="#" data-directory-link="Front-Porch" aria-label="View directory entry for Front Porch"><strong>Front Porch</strong></a> cafe on the Cal Poly campus will pour you a free cup of coffee.</p>
+<p>If you are a <a href="#" data-directory-link="Cuesta-College" aria-label="View directory entry for Cuesta College"><strong>Cuesta College</strong></a> student, you can get free hygiene products, a scarf, hats, backpacks, laundry soap, menstruation products, and sometimes gift cards to fast food restaurants from the <a href="https://www.cuesta.edu/student-support/support-programs/basic-needs-center/homeless-food-resources.html" data-external-link="true">Basic Needs Office</a>. </p>
+<blockquote>
+<p>See <a href="#holiday-gifts-for-children">Holiday Gifts for Children</a> in the <a href="#children-youth-parents">Children, Youth, and People with Children</a> section of this guide for information on how to get free toys, coats, bicycles, and other such gifts for your children during the holidays.</p>
+</blockquote>
+<h3><span><a id="low-cost-stuff">Low-Cost</a></span></h3>
+<blockquote>
+<p>See <a href="#thrift-stores">Clothing: Thrift Stores</a> for a list of low-cost thrift stores in SLO County. Many sell a variety of goods other than clothing.</p>
+</blockquote>
+<p><a href="#" data-directory-link="Habitat-for-Humanity" aria-label="View directory entry for Habitat for Humanity ReStore"><strong>Habitat for Humanity ReStore</strong></a> sells recycled construction materials, building supplies, furniture, appliances, and home décor at low prices.</p>
+<p><a href="https://www.slomakerspace.com/" data-external-link="true">SLO MakerSpace</a> can give you access to a variety of tools–everything from basic hand tools to laser cutters and 3D printers.
+You can get a free “partner pass” membership through <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a>.
+This allows you to access some tools during some operating hours.
+To access their full set of tools always, you may need to pay for a full membership.
+You will also need to attend a general orientation.
+Some advanced tools also require that you take tool-specific orientation classes before you can use them, and some of those cost money.</p>
+<hr>
+<h2><span><a id="other-guides">Other Guides, Web Pages, Information Sources</a></span></h2>
+<p>Some other groups assemble resource guides like this one.
+Some have a different focus (for instance, they highlight resources for seniors or for veterans) or cover a different region.
+Here are some of these local guides:</p>
+<ul>
+<li><a href="https://centralcoastseniors.org/senior-connection/resources/publications/" data-external-link="true"><em>Central Coast Senior Resource Guide</em></a>: a comprehensive guide covering services for seniors in SLO and Santa Barbara Counties. Also exists as a searchable on-line directory at <a href="https://centralcoastseniors.myresourcedirectory.com/" data-external-link="true">centralcoastseniors.myresourcedirectory.com</a>.</li>
+<li><a href="https://www.prcity.com/293/Senior-Services" data-external-link="true"><em>North County Senior Resource Guide</em></a>: available in English and Spanish; covers education, meals, housing, in-home care, transportation, mental health, legal support, financial assistance, recreation, and healthcare</li>
+<li><a href="https://static1.squarespace.com/static/59681974579fb3a01279b99b/t/691783a98308c513367e2078/1763148713791/MHRG+-+MASTER+UPDATE+-+11-15-25.pdf" data-external-link="true"><em>San Luis Obispo County Mental Health Resource Guide</em></a></li>
+<li><a href="https://211slo.org/" data-external-link="true">211 SLO County</a>: United Way’s directory of SLO County resources</li>
+<li><a href="https://5chc.org/community-services" data-external-link="true">Community Support Services</a>: a list of services available in southern SLO County, maintained by 5Cities Homeless Coalition</li>
+<li><a href="https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/maternal-child-health/navigateslo" data-external-link="true">NavSLO</a>: SLO County Public Health Agency’s directory of resources</li>
+<li><a href="https://docs.google.com/document/d/17-ZYN4uYV-PNWLGu2QAZXMv6wQItZGcsZfpBLysbL70/mobilebasic" data-external-link="true">HelpSLO Resource List of Aid Groups, Programs, and Services in SLO County</a></li>
+<li><a href="https://docs.google.com/document/d/1iVGbPgBH0IzZWpfp2gkt-2gmF3_Q0zK0HPNgsZgM2TE/mobilebasic" data-external-link="true">2024 Financial Aid/Assistance Resources - San Luis Obispo</a>: Faith LeGrande’s list that they put together while searching for help</li>
+<li><a href="https://www.needhelppayingbills.com/html/san_luis_obispo_county_assista.html" data-external-link="true">Assistance Programs in SLO County</a>: from the “Need Help Paying Bills” website</li>
+<li><a href="https://www.t-mha.org/helpful-links.php" data-external-link="true">(TMHA) Helpful Links</a>: with a focus on resources having to do with mental health</li>
+<li><a href="https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/resource-center" data-external-link="true">SLO County Behavioral Health Resource Center</a></li>
+<li><a href="https://www.losososcares.com/_files/ugd/49eed7_be57bde969e54688ab18bdc4ba28c2f3.pdf" data-external-link="true">Resource Guide Estero Bay</a>: focusing on Los Osos and nearby communities</li>
+<li><a href="https://localwiki.org/slo/Sharing_SLO" data-external-link="true">Sharing SLO wiki</a>: “an overview of some of San Luis Obispo’s sharing economy”</li>
+<li><a href="https://www.sloundocusupport.org/immigrantservicesguide" data-external-link="true">Immigrant Services Guide</a>: resources for undocumented immigrants in SLO County</li>
+<li><a href="https://www.slocounty.ca.gov/departments/social-services/workforce-development-board/forms-documents/job-seeker-resource-guide" data-external-link="true">SLO County <em>Job Seeker Resource Guide</em></a></li>
+<li><a href="https://www.statesidelegal.org/sites/default/files/Homeless%20Veteran%20Resource%20Guide_0.pdf" data-external-link="true"><em>The Homeless Veteran’s Resource Guide</em></a></li>
+</ul>
+<p>If you would like some in-person help, you can get assistance on a variety of issues from the Library Outreach Team at <a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO County Public Libraries"><strong>SLO County Public Libraries</strong></a> branches:</p>
+
+
+<ul>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for Atascadero Library"><strong>Atascadero Library</strong></a>, Wednesdays, 10:30am–Noon</li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for Arroyo Grande Library"><strong>Arroyo Grande Library</strong></a>, Thursdays, 9:30am–11am</li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for Los Osos Library"><strong>Los Osos Library</strong></a>, Fridays, 1–2:30pm</li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for Morro Bay Library"><strong>Morro Bay Library</strong></a>, Thursdays, 12:30pm–2pm</li>
+<li><a href="#" data-directory-link="SLO-County-Public-Libraries" aria-label="View directory entry for SLO city Library"><strong>SLO city Library</strong></a>, Tuesdays, 10–11:30am &amp; 2:30–4pm</li>
+</ul>
+<p>You can drop in, or make an appointment by calling or texting <a href="tel:+1-805-540-0057" aria-label="Call 805-540-0057">805-540-0057</a>.</p>
+

--- a/web-app/public/processed/search-index.json
+++ b/web-app/public/processed/search-index.json
@@ -1,0 +1,3985 @@
+[
+  {
+    "id": "table-of-contents",
+    "title": "Table of Contents",
+    "content": " 📖\n\nhotlines and emergencies\nself-advocacy\nshelter & housing\nproperty storage\nfood\nwater refill\ntransportation\nclothing\nlaundry\nshowers & hygiene\nhealth & medical care\ndrug use & recovery\ntattoo removal\nend-of-life help\npersonal safety\nlegal help\nids & documents\nmail & po boxes\nbanking & money\ntax preparation\nemergency financial help\nsocial security & benefits\nobtaining employment\neducation & job training\nphones & phone service\ninternet & email\ndevice charging\nchildren & parents\npeer support\nrecreation & community\npet care\ndisaster preparedness\nadvocacy & organizing\nfree stuff\nother guides\ndirectory\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "emergency-contacts",
+    "title": "Hotlines and Emergency Contacts",
+    "content": "\n \n  phone numberdescription\n \n  ⇨ emergency and crisis lines:\n   911medical and safety emergencies\n   988 / 988national suicide prevention lifeline\n   800-783-0607central coast hotline: 24/7 suicide prevention and mental health crisis line that provides immediate emotional support\n   text \"home\" to 741741crisis text line for immediate emotional support, or connect.crisistextline.org/chat on-line\n   833-317-hope (español: 833-642-7696)the warm line: free, confidential emotional support\n  \n  ⇨ for young people:\n   800-843-5200youth crisis line, for people in california ages 12-24; call or text\n   800-run-away / 800-786-2929national runaway safeline: 24/7 confidential support for runaway and homeless youth\n   866-331-9474 / text \"loveis\" to 22522\"love is respect\" information and support for young people with concerns about their romantic relationship\n  ⇨ for lgbtq people:\n   866-488-7386 or text \"start\" to 678678trevor lifeline: crisis intervention and suicide prevention for lgbtq+ youth\n   877-565-8860trans lifeline: crisis hotline for transgender people\n  ⇨ for victims of sexual assault and intimate partner violence:\n   805-545-8888local sexual assault, sexual abuse, and intimate partner violence crisis line\n   800-799-safe / text \"start\" to 88788national domestic violence hotline\n  ⇨ for parents:\n   833-tlc-mama / 833-tlc-mamanational maternal mental health hotline (call or text)\n   888-431-2229fussy baby network warmline\n   877-babysafsafe surrender site locations in california (where to confidentially give up a newborn you cannot take care of)\n  ⇨ other specialized crisis lines:\n   805-781-1790 (m-f, 8am-5pm), or 805-729-8011adult protective services\n   805-781-kidschild welfare services emergency suspected child abuse reporting line\n   838255 (text)veterans crisis text line\n   800-985-5990disaster distress helpline (in case of emotional distress due to natural or man-made disaster)\n  ⇨ health and behavioral health information:\n   800-222-1222poison hotline: treatment advice from experts in poisoning care\n   877-435-7443help-4-hep helpline: peer-to-peer support for anyone with concerns about hepatitis c (m-f 9am-5pm eastern time)\n   800-838-1381slo county behavioral health access line: main number for scheduling appointments and getting information about all behavioral health services including navigation and peer support\n   800-540-6576behavioral health navigator: get help finding the help you need and understanding the local behavioral health system\n   855-600-warmcalifornia peer run warm line (also available as a web-based text chat here) for people with \"a wide range of challenges, including anxiety, depression, and substance use\" (m/tu/w/f 7am-11pm; th 8am-10pm)\n   800-300-8086kick it california, smoking cessation help\n   800-662-helpsubstance abuse and mental health service administration (samhsa) national helpline (free, confidential, 24/7 substance abuse treatment referral and info)\n   800-541-3211central coast alcoholics anonymous 24/7 helpline\n   800-549-7730central coast narcotics anonymous 24/7 helpline\n  ⇨ finding help:\n   211connects you to expert, caring, confidential help of all sorts\n  ⇨ legal aid and consumer protection:\n   800-834-5001community legal aid socal hotline for housing discrimination, tenant rights, and consumer protection\n   800-399-4529legal aid foundation of los angeles (lafla) for legal assistance\n  ⇨ housing and homeless services:\n   805-574-16385cities homeless coalition for housing assistance and coordinated entry\n   805-781-7025city of slo homelessness response manager\n  ⇨ immigration:\n   805-870-8855immigrant rapid response hotline (report ice activity or connect with legal support); register for text alerts by texting \"alert\" to this number)\n   888-373-7888 or text 233733national human trafficking hotline\n \n\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "self-advocacy",
+    "title": "Standing Up for Yourself and Communicating with Service Providers",
+    "content": "when you meet with case managers and service providers, you can make it more likely that they can help you.\nthis section of the guide gives some tips about how to do this.\nbuild good relationships with case managers and service providers\nyou can get better results by being prepared.\nbring your id, any paperwork about your situation, and a list of questions or needs.\nbe honest and direct when you explain your situation, your needs, and any problems you face.\nask questions if you need help understanding programs, requirements, or next steps.\nwhen providers help you, tell them you appreciate it.\ngood relationships help everyone.\nstay in touch with providers who are especially helpful, even when you're not actively using their services.\nmanage appointments and commitments\nset phone alarms or ask for reminder calls when they are available so you do not miss appointments.\nmake sure you have a way to travel to appointments (see the transportation section).\nbring something to do in case there is a wait, and expect some delays in busy service settings.\nif you need to change an appointment, call ahead rather than just not attending.\narrive early to appointments if you can.\nif you will be late, call ahead.\nkeep a notebook or use your phone to note appointments, contacts, and any promises people make to you.\nif someone promises to do something for you but you don't hear back in a reasonable time, check back with them.\nknow your rights\nmany service providers have non-discrimination policies and try to treat people with respect, though policies vary between agencies.\nsome services have specific rules about who can use them (like veterans-only programs, or programs with income limits).\nprivacy policies vary by agency.\ngovernment homeless service providers (and service providers that get government grants and contracts) often share information about their clients through the hmis (homeless management information system).\nbefore such a service provider enters information about you into the hmis, you will receive a privacy notice (español) and will be asked for your consent.\nyou can ask to review this privacy notice at any time. \nthis privacy notice states: \"you are still eligible for services if you refuse to have your standard information shared in hmis.\" \nask about hmis consent for release of information (roi) forms and what they mean before you sign them.\nyou have the right to see the information that has been collected about you in the hmis, to have your own copy of this information, to request changes to it, and to have it marked private (so that it will not be shared with other service providers who use hmis). \nthe privacy of the information in the hmis is protected by law, but the government does not always follow the law, so be cautious.\nmany programs have procedures for appealing decisions or for filing complaints.\nask program staff or search online to find the specific process.\nlegal aid organizations can help with appeals (see the legal assistance section).\ndocument everything\nkeep copies of important documents and applications.\nstore documents in waterproof bags.\nuse your backpack as a pillow when you sleep.\nkeep your most important items in clothes pockets.\nif you have enough income, consider getting a safety deposit box for the most important or hard-to-replace documents.\nuse your phone to take photos of important paperwork.\nactivate automatic cloud backup (icloud for iphone, google photos for android) so your photos survive if your phone is lost or stolen.\nphones (iphones & androids) typically come with some amount of free cloud storage, so you can keep access to your photos even if you lose your phone.\nkeep the dates, names, and outcomes of important conversations.\nkeep case numbers, application numbers, and confirmation numbers.\nfocus on your goals and strengths\ntell people clearly what you are working toward (housing, employment, healthcare, etc.).\nshare your skills, experience, education, and personal strengths when they matter for the services you want.\nfor example, tell employment services about your work experience.\ncome to meetings with ideas about what might work for your situation.\nfollow through on promises you make and take active steps toward your goals.\nnavigate system barriers\nlearn the rules for programs: who can use them, when applications are due, and what steps you need to take.\nif you don't qualify for one program, ask about other options.\nif you have disabilities or special needs that make it difficult to access a program, ask about help they can provide.\nif you're not getting the help you think you should be getting, ask to speak with supervisors.\nuse formal complaint procedures and appeal processes.\nor find someone who knows the system well to help you (like a case manager, behavioral health navigator, legal aid worker, or peer advocate).\nwork with multiple service providers\ntell each provider about other services you get, when it matters.\nfor example, tell housing programs about your income sources.\nbut casual services like showers don't need to know about each other.\nif an agency plans to apply for a service in your name, tell them if you already applied on your own.\nthis prevents duplicate applications and wasted time.\nkeep track of which applications you made or that others made for you.\nthis helps you avoid doing the same thing twice.\nshare information with service providers that relates directly to the services you want.\nfor example, share your income for benefits applications or your medical history for healthcare.\nkeep other personal details private if you don't feel like sharing them.\nkeep a list of contact information for all your service providers.\nask for direct phone numbers or business cards from people who work with you.\nthis helps you avoid phone trees if you need to call back.\nset goals and track progress\nmake your goals \"s.m.a.r.t.\" (specific, measurable, achievable, relevant, and time-bound). \ndivide big goals (like getting housing) into smaller steps you can manage.\nnotice and celebrate your achievements, even small ones.\nbe flexible and willing to change your goals as your situation changes.\nwhen things go wrong\neven when you feel frustrated, stay calm and speak respectfully.\nthis approach usually gets better results and faster solutions than arguing.\nnote details about problems, including dates, names, and what went wrong.\ndon't quit too soon.\npersevering often pays off when you work with complex systems.\nfind and use resources\nuse this guide or call 211 to get information about available services. \ntalk with other people in similar situations-they often have valuable information and tips.\nthe other guides section of this guide lists some other resource guides that may have information this guide missed.\nthings change.\ncontact service providers directly to verify their most current information before you travel to their locations.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "build-good-relationships",
+    "title": "Build Good Relationships with Case Managers and Service Providers",
+    "content": "you can get better results by being prepared.\nbring your id, any paperwork about your situation, and a list of questions or needs.\nbe honest and direct when you explain your situation, your needs, and any problems you face.\nask questions if you need help understanding programs, requirements, or next steps.\nwhen providers help you, tell them you appreciate it.\ngood relationships help everyone.\nstay in touch with providers who are especially helpful, even when you're not actively using their services.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "manage-appointments",
+    "title": "Manage Appointments and Commitments",
+    "content": "set phone alarms or ask for reminder calls when they are available so you do not miss appointments.\nmake sure you have a way to travel to appointments (see the transportation section).\nbring something to do in case there is a wait, and expect some delays in busy service settings.\nif you need to change an appointment, call ahead rather than just not attending.\narrive early to appointments if you can.\nif you will be late, call ahead.\nkeep a notebook or use your phone to note appointments, contacts, and any promises people make to you.\nif someone promises to do something for you but you don't hear back in a reasonable time, check back with them.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "know-your-rights",
+    "title": "Know Your Rights",
+    "content": "many service providers have non-discrimination policies and try to treat people with respect, though policies vary between agencies.\nsome services have specific rules about who can use them (like veterans-only programs, or programs with income limits).\nprivacy policies vary by agency.\ngovernment homeless service providers (and service providers that get government grants and contracts) often share information about their clients through the hmis (homeless management information system).\nbefore such a service provider enters information about you into the hmis, you will receive a privacy notice (español) and will be asked for your consent.\nyou can ask to review this privacy notice at any time. \nthis privacy notice states: \"you are still eligible for services if you refuse to have your standard information shared in hmis.\" \nask about hmis consent for release of information (roi) forms and what they mean before you sign them.\nyou have the right to see the information that has been collected about you in the hmis, to have your own copy of this information, to request changes to it, and to have it marked private (so that it will not be shared with other service providers who use hmis). \nthe privacy of the information in the hmis is protected by law, but the government does not always follow the law, so be cautious.\nmany programs have procedures for appealing decisions or for filing complaints.\nask program staff or search online to find the specific process.\nlegal aid organizations can help with appeals (see the legal assistance section).\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "document-everything",
+    "title": "Document Everything",
+    "content": "keep copies of important documents and applications.\nstore documents in waterproof bags.\nuse your backpack as a pillow when you sleep.\nkeep your most important items in clothes pockets.\nif you have enough income, consider getting a safety deposit box for the most important or hard-to-replace documents.\nuse your phone to take photos of important paperwork.\nactivate automatic cloud backup (icloud for iphone, google photos for android) so your photos survive if your phone is lost or stolen.\nphones (iphones & androids) typically come with some amount of free cloud storage, so you can keep access to your photos even if you lose your phone.\nkeep the dates, names, and outcomes of important conversations.\nkeep case numbers, application numbers, and confirmation numbers.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "focus-on-goals",
+    "title": "Focus on Your Goals and Strengths",
+    "content": "tell people clearly what you are working toward (housing, employment, healthcare, etc.).\nshare your skills, experience, education, and personal strengths when they matter for the services you want.\nfor example, tell employment services about your work experience.\ncome to meetings with ideas about what might work for your situation.\nfollow through on promises you make and take active steps toward your goals.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "navigate-system-barriers",
+    "title": "Navigate System Barriers",
+    "content": "learn the rules for programs: who can use them, when applications are due, and what steps you need to take.\nif you don't qualify for one program, ask about other options.\nif you have disabilities or special needs that make it difficult to access a program, ask about help they can provide.\nif you're not getting the help you think you should be getting, ask to speak with supervisors.\nuse formal complaint procedures and appeal processes.\nor find someone who knows the system well to help you (like a case manager, behavioral health navigator, legal aid worker, or peer advocate).\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "work-with-multiple-providers",
+    "title": "Work with Multiple Service Providers",
+    "content": "tell each provider about other services you get, when it matters.\nfor example, tell housing programs about your income sources.\nbut casual services like showers don't need to know about each other.\nif an agency plans to apply for a service in your name, tell them if you already applied on your own.\nthis prevents duplicate applications and wasted time.\nkeep track of which applications you made or that others made for you.\nthis helps you avoid doing the same thing twice.\nshare information with service providers that relates directly to the services you want.\nfor example, share your income for benefits applications or your medical history for healthcare.\nkeep other personal details private if you don't feel like sharing them.\nkeep a list of contact information for all your service providers.\nask for direct phone numbers or business cards from people who work with you.\nthis helps you avoid phone trees if you need to call back.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "set-goals-and-track-progress",
+    "title": "Set Goals and Track Progress",
+    "content": "make your goals \"s.m.a.r.t.\" (specific, measurable, achievable, relevant, and time-bound). \ndivide big goals (like getting housing) into smaller steps you can manage.\nnotice and celebrate your achievements, even small ones.\nbe flexible and willing to change your goals as your situation changes.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "when-things-go-wrong",
+    "title": "When Things Go Wrong",
+    "content": "even when you feel frustrated, stay calm and speak respectfully.\nthis approach usually gets better results and faster solutions than arguing.\nnote details about problems, including dates, names, and what went wrong.\ndon't quit too soon.\npersevering often pays off when you work with complex systems.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "find-and-use-resources",
+    "title": "Find and Use Resources",
+    "content": "use this guide or call 211 to get information about available services. \ntalk with other people in similar situations-they often have valuable information and tips.\nthe other guides section of this guide lists some other resource guides that may have information this guide missed.\nthings change.\ncontact service providers directly to verify their most current information before you travel to their locations.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "shelter-housing",
+    "title": "Shelter & Housing",
+    "content": "in this section:\n\neviction prevention\nwarming/cooling centers\novernight shelter\nlegal camping, safe parking, and rv parks\ntransitional and long-term housing\nfor u.s. military veterans\nsober living homes and residential treatment options\n\neviction prevention\nif you are homeless or are threatened with eviction with a \"pay rent or quit\" notice, or if you have had to move your family into a hotel, you can get immediate help from the calworks homeless assistance program. \nthis program can pay your security deposit, one month's rent, or a utility deposit payment. \nto qualify you must have \"apparent eligibility\" for calworks and less than $100 in liquid assets. \nyou must first get a referral from the slo county department of social services. \nthe first step in this process is to apply for calworks, which you can do on-line at benefitscal.\nif you are homeless or are threatened with eviction with a \"pay rent or quit\" notice, or if you have had to move your family into a hotel, you can get help from the housing support program (hsp). \nthis program will help you find housing, and give you rent and moving assistance, among other things. \nyou must be eligible for calworks to participate, and you can only use this program once in your lifetime. \nthe first step in this process is to apply for calworks, which you can do on-line at benefitscal. \n5cities homeless coalition (5chc) operates a housing assistance program that offers financial assistance for rent, security deposit, or other immediate needs for people who are homeless in danger of becoming homeless. \ncontact 5chc to arrange a confidential coordinated entry interview. \nyou need to bring identification, including social security cards and birth certificates for you and those living with you, an account of how much income you received during the previous three months, your lease agreement if any, and any eviction notice you received. \n\nsee the legal help, mediation, and crime victim protection section for options about preventing illegal evictions.\n\n\nsee the emergency financial help section for more possible ways to get short-term financial help in a crisis.\n\nwarming/cooling centers\nwarming centers open only on unusually cold or rainy nights (temperatures expected to drop below 38°f or a 50% chance of rain).\nthey offer overnight shelter beds.\ncooling centers open only during the day when the weather is unusually hot.\nthey offer you an air-conditioned place where you can get out of the sun.\nit can be difficult to know on any particular day whether or not these centers are open, so it is a good idea to call ahead.\n\nthis web page may show the current status of the county's warming/cooling centers.\nyou can register here to receive notifications about the county's warming centers.\n\nthe slo city warming/cooling center is at the 40 prado homeless services center.\nwhen it operates as a warming center, check in is between 7pm and 9pm, and you must leave by 8am. \npeople with p.c. 290 convictions are not allowed in the center. \nwhen it operates as a cooling center, you must leave by 6pm. \ncooling center guests can get breakfast, lunch, and dinner. \npets with rabies vaccinations are allowed in their kennel. \nthe warming center offers a free hot meal. \ntransportation is available between the warming center and morro bay and los osos. \npick-up times from those areas are as follows: \n\n6:15pm: morro bay park (734 harbor st., morro bay) \n6:00pm: south bay community center (2180 palisades ave., los osos) \n\nthe 5cities homeless coalition warming center at 1023 e. grand ave. in arroyo grande operates between 5:30pm and 7am. \nyou must check in between 5:30pm and 8pm. \npets are ok if you have proof of license/vaccinations. \n\npeople with p.c. 290 convictions are not allowed in the center. \ncall 805-202-3615 to verify the center is open and to learn about free transportation options to the center from grover beach, oceano, and pismo beach. \nthe warming center offers dinner and a light breakfast. \ntext \"add me\" to 805-295-1501 to receive text updates to your phone when the warming center opens, or email info@5chc.org and ask to be added to their notification list. \nthe el camino homeless organization (echo) runs a ten-bed warming center at its paso robles shelter location. \nit operates between 6:00pm and 7:00am. check in between 4:30pm and 5:30pm. \nthey will also serve you a meal. \nno dogs except for service dogs are allowed in the warming center. \nnipomo senior center operates an air-conditioned cooling center any time the temperature is above 90°f outside. \nyou do not have to be a senior center member to shelter there when the cooling center is open. \novernight shelter\nif you are unsheltered and need a place to sleep tonight, these are some options:\nthe 40 prado homeless services center has a hundred overnight shelter beds. \nmany are reserved for people who have previously registered with 40 prado, but a limited number are available on a walk-in basis. \nto get a bed, first come on-site and complete the intake process. \nthereafter, on any day when you need an overnight shelter bed, check in to secure a bed or to be placed on the waiting list. \npriority is given to slo county residents. \nthey offer meals (breakfast, lunch, and dinner), showers, laundry, mail/phone services, an integrated medical clinic (primary and urgent care five days a week with an on-site pharmacy), recuperative care beds, and animal kennels. \nto stay at the shelter, you must have a valid photo id, you must not be a p.c. 290 registered sex offender, and you must participate in case management. \nyou must also be able to care for yourself independently (bathing, feeding, dressing, etc.). \nthe 40 prado center is the only walk-in, overnight homeless shelter in slo county.\nthe el camino homeless organization (echo) used to operate a shelter in the north county, but now only offers 90-day transitional housing there (see below) and an occasional warming shelter.\nthe good samaritan shelter operates a set of shelters in santa maria and other places in santa barbara county. \ncall ahead during office hours to learn which shelter has room for you. \nthey also have laundry facilities, hot meals, substance use treatment, and mental health services. \nif you are homeless because you are escaping dangerous circumstances of domestic violence or sexual assault, you can get safe, confidential, emergency shelter at safe houses operated by lumina alliance. \ncall their crisis and information line to get access to this program. \nthey will also help you with trained advocacy, accompaniment to medical/legal appointments, case management, and therapy for survivors and children. \nthey operate throughout slo county, and are open to people of all genders, ages, and backgrounds. \nif you are homeless and have a medically verified need for 24/7 temporary housing because you are seriously ill, recovering from surgery or injury or high-risk pregnancy, or something of that nature, you may qualify for the medically fragile homeless program. \nthey will help you with immediate housing, supportive services and coordinated case management to ensure physical recovery, access to income sources, connection to services, and a more permanent housing alternative when you exit the program. \nyou cannot apply for this program yourself, but you must get a referral from an agency like adult protective services,\nslo county department of social services, \nhousing support program (hsp),\ncenter for family strengthening (cfs), \nor calworks. \nif you are being treated by a hospital or other medical professionals, consider telling them that you are homeless and asking them if they can help you with this process.\nif you need shelter because you have a medical condition that requires you to have some medical supervision, you may be able to get a referral to a rehabilitative care or skilled nursing or assistive living facility. \nyou can get such a referral from your primary care physician. \nyou may also be able to get some help from adult protective services. \na note about \"in-home\" supportive services\n\n\nthe in-home supportive services (ihss) program helps pay for services provided to senior, blind, or disabled people who have difficulty caring for themselves and cannot live at home safely without in-home care. \ndespite the \"in-home\" name, this program is potentially also available to people who shelter at homeless shelters or safe-parking sites.\namong the services that this program can help pay for are meal preparation, laundry, grocery shopping, personal care services (such as bowel and bladder care, bathing, grooming and paramedical services, help getting dressed, help getting into and out of a wheelchair), and accompaniment to medical appointments. \nto qualify for ihss, you must be disabled, blind, or age 65 or older. \nyou must also be unable to live safely in your current home or shelter environment without assistance, and you must be financially needy. \nthe process of applying for ihss is difficult, so it is a good idea for you to get some help from a case manager or other social worker. \nlegal camping, safe parking, and rv parks\nif you sleep in your vehicle, there are some free, legal \"safe parking\" spots available at the 40 prado homeless services center where you can stay from 6pm to 7am. \nto register for one of these spots, first complete the referral form at the capslo website. \nyou will also have access to the various other services offered at 40 prado (such as meals, showers, laundry, mail/phone services, an integrated medical clinic, and an animal kennel). \nyour vehicle must be registered and you must have proof of insurance. \nyou must participate in case management. \nyou must not be a p.c. 290 registered sex offender to use this service. \nslo county residents get priority. \ncontact sam neal (sneal@capslo.org, 805-459-1073) with questions. \nthere are some free, legal \"safe parking\" spots available in the slo city area through the rotating overnight safe parking program.\nto register for one of these spots, first complete the intake process at the 40 prado offices any day from 8am to 2pm.\nyou get a place to park overnight for 90 days, with a possible 30 day extension.\nyou must move your vehicle away from the site during the day.\nyou have access to water, trash, and restrooms, and there will be occasional security checks.\nno illegal drugs, alcohol, weapons, or fires are allowed.\nyour vehicle must fit into a standard parking space.\nyou must not be a p.c. 290 registered sex offender to participate.\nslo county residents get priority.\nyou must participate in case management.\nyou can camp overnight legally at various slo county parks, but for a fee (roughly $25-50 per night, plus a $10 reservation fee and sometimes also a per-vehicle fee). \nsome parks have both tent camping and rv hook-up sites. \nnone have dump stations. \nall have restrooms, some also have coin-operated showers. \nstays are limited to 15 consecutive days in any 30-day period during the summer, or a maximum of 30 days in any 60-day period during the winter, and to a maximum of 60 days in any 12-month period. \nthere are several rv parks in slo county, including short-term campsites (ranging from $52 to $104 per night plus reservation fee) and longer-term rv parks ($600-$750/month).\nthese include:\n\nbella vista by the sea (cayucos)\ncoastal dunes rv park & campground (grover beach)\nel chorro regional park campground (between slo and morro bay)\nflying flags avila beach\nle sage riviera rv park (grover beach)\nlopez lake recreation area\nport san luis harbor district rv camping (avila beach)\nsanta margarita koa holiday\nsilver city resort (morro bay)\n\nsome sites have rv size limits and other restrictions.\nsee the directory entries for specific information about rates, size limits, available hookups, and amenities at each location.\nif you are an elks lodge member, slo elks lodge #322 at 222 elks lane in slo also has several $30/night rv spots and a free dump station. \ncontact them at 805-543-0322 (m-f, 10am-4pm) or rvcamping@elks322.org. \ntransitional and long-term housing\nthis section discusses more long-term housing options including transitional housing (a temporary home while you search for more long-term housing) and affordable housing or subsidized housing (a long-term home).\nthe coordinated entry system (ces) is slo county's system for matching people in need with transitional or long-term housing that is appropriate for them.\nif you want to get such housing, you should try to enter this system.\nthis can be more effective than trying to contact the many individual transitional or long-term housing programs one at a time.\nto enter this system, contact one of the many participating agencies, such as slo county department of social services, 5cities homeless coalition, community action partnership san luis obispo (capslo), transitions mental health association, good samaritan shelter, or slo county health department. \na program called housing now finds homes for the most vulnerable chronically homeless people from slo county.\nyou cannot apply directly to participate in this program, but if you enter the coordinated entry system (see above), that system may eventually place you in this program so that you can quickly get a home. \nthe behavioral health bridge housing (bhbh) has some quality, affordable short-term (less than 90 days) and medium term (90 days to two years) housing for people in slo county who have severe behavioral health issues who are homeless or at risk of homelessness. \nfor information on the application process, how to demonstrate eligibility, and bed availability call mark lamore, director of homeless services at transitions mental health association (tmha), at 805-540-6500. \n5cities homeless coalition (5chc) operates a housing assistance program that offers case management and financial assistance for rent, deposit, and immediate needs, and housing assistance through various funding grants. \nthis is available both to currently homeless people and to people in danger of becoming homeless. \ncontact 5chc to arrange a confidential coordinated entry interview. \nel camino homeless organization (echo) operates transitional (90-day) shelters in atascadero and paso robles that serve people experiencing homelessness. \npeople who live in these shelters also get individualized case management services to help them find employment and long-term housing. \nthere is often a long waiting list for shelter beds. \nthey will not admit p.c. 290 registered sex offenders. \nthe calworks homeless assistance program can pay a one-time security deposit and/or last month's rent and/or utility deposit for families who are homeless or who received a \"pay rent or quit\" notice on their current rental home. \nto qualify you must meet calworks eligibility requirements and have less than $100 in liquid assets. \nfamily care network's housing support program (hsp) provides financial assistance for housing deposits and rent to families that are experiencing homelessness or are at risk of homelessness in slo county.\nthey also offer case management and life skills workshops (budgeting, credit repair, communication), bus passes, gas cards, and paperwork assistance. \nbalay ko on barka (a.k.a. \"my home for hope\") and cabins for change, both in grover beach, operate many individual \"tiny homes\" that serve as transitional housing. \nthe cabins come with 24/7 support, case management, connections to food services and recovery, and house stabilization guidance. \nthey have on-site showers. \nthey accept vaccinated, well-behaved dogs. \nthey will not admit p.c. 290 registered sex offenders. \nthey typically have a long waiting list. \napply through 5cities homeless coalition to get on the waiting list. \nhousing authority of slo (haslo) operates several affordable housing properties in slo county.\ntypically in these projects, residents pay part of the rent, while the rest of the rent is paid for them by subsidies or vouchers. \nto qualify to rent one of these housing units, you must have enough income to pay your part of the rent, but you must not have so much income that you could afford non-subsidized housing. \ntypically this means households that earn less than 30% of the area median income. \npreference is given to slo county residents and to veterans. \nsome housing is restricted to seniors (age 62 and above). \nyou need to provide proof of income and your prior rental history. \nmost of these housing units have wait lists, and only some of them accept new applications at any time. \npaso robles housing authority operates several affordable housing properties in paso robles designed for people who have around 30-60% of the area median income. \nyou can download an application from their website. \nif your application is accepted, you will be put on the waiting list. \nyou must include copies of the latest three months' paycheck stubs, proof of other sources of income, and a copy of your last two years' federal income tax returns. \nyou may be rejected if you recently were evicted, defaulted on debts, or have certain criminal convictions. \nlumina alliance operates a six- to 24-month transitional housing program for individuals and families who are fleeing domestic violence, dating violence, sexual assault, and/or stalking. \npeople housed through this program also get access to advocacy services, employment assistance, counseling, legal help, children's services, life skills development, and help obtaining permanent housing. \nif you are homeless or need housing due to fleeing abusive situation, have low or very low income, and are willing to participate in lumina's program and to cooperate with them in following a safety plan, you may qualify for transitional housing through this program. \nslo county adults with mental illness may qualify for supportive housing in multiple county locations through the transitions mental health association (tmha) residential housing program.\nthe homeshare slo program matches property owners who have an extra room with people who need a place to live. \n\n\nrestorative partners runs a housing program with multiple transitional housing programs for men, women, and families in various slo county locations. \nthese programs are for people in recovery from addiction and people transitioning from incarceration. \nsome are specific to women with children. \nalong with housing, residents get help with employment support, financial literacy, life skills, addiction recovery, and help finding permanent housing. \nthere is a wait list. \nsalvation army has a \"rapid rehousing program\" that helps people find and qualify for long-term housing. \ncontact hattie davis (hattie.davis@usw.salvationarmy.org) for details. \nthe housekeys program is the city of slo's affordable home-ownership program.\nit serves households with about 30-50% of the area median income. \ntheir idea of \"affordable\" may not be yours.\nif you want to apply for housing through this program, begin the application process described on their website.\nhabitat for humanity slo county operates a home ownership program for first-time low-income home buyers and home preservation assistance (minor repairs, landscaping, painting) for low-income homeowners. \napply via their website. \npeoples' self-help housing operates a \"sweat equity\" homeownership program in which families help to build their own homes. \nthey also operate affordable rental housing developments and supportive housing programs. \nthey serve low-income families, farmworkers, seniors, veterans, people with disabilities, and formerly-homeless people. \ncontact them directly to access the program. \nsome other low-income options include:\n\nroosevelt family apartments in nipomo. \nsan luis bay apartments in nipomo. \n\nif you are a refugee from another country, you may be able to get some help establishing housing from slo for home. \nfor seniors\n\n\nhousing authority of slo (haslo), paso robles housing authority, and peoples' self-help housing operate several affordable senior housing rental properties. \nthere are some additional subsidized and affordable housing options especially for seniors (sometimes defined as age 55 and above, or as 62 and above).\nthese include:\n\ncortina d'arroyo grande senior apartments (241 n. courtland ave., arroyo grande) - 805-489-6888 \nparkview manor (365 south elm st., arroyo grande) - 805-489-5101 \njudson terrace (slo), has 107 low-income affordable apartments for people aged 55 and up, and 32 low-income affordable apartments for people aged 62 and up. they only accept applications when the waiting list is open. \n\naffordable housing options for seniors with section 8 vouchers include:\n\nmorro del mar senior apartments (555 main st., morro bay) - 805-225-1837 \nvilla paseo senior apartments (2800 ramada dr., paso robles) - 805-227-4588 \nlas brisas retirement community (slo) \n\naffordable housing options for disabled / handicapped seniors can be found at:\n\ncalifornia manor (10165 el camino real, atascadero) - 805-466-0759 \nhacienda del norte (529 10th st., paso robles) - 805-238-5793 \nbrizzolara st. apartments (611 brizzolara, slo) \nmarvin gardens (1105 laurel lane, slo) \n\nyou can find additional senior housing listings at the central coast commission for senior citizens website.\nif you need assistive living or residential care for the elderly (rcfe) housing, there are some options in slo county, but none of them accept medi-cal. \nif you need such housing and medi-cal is your only health insurance, you can get on a waiting list for a facility outside of slo county. \nthis is a lengthy process, so if you think you might need such a living situation in the future (even as long as a year or more from now), you should try to start this process now. \ndiscuss this with your case manager if you have one, or with the long-term care ombudsman.\n\n\nfor u.s. military veterans\nu.s. military veterans who have low incomes and who are homeless or at risk of homelessness can get help from supportive services for veteran families.\nthis help includes housing assistance, case management, and financial assistance; rapid re-housing and homelessness prevention services; temporary financial assistance for rent, deposits, and utilities; housing barriers assessments, emergency housing stability assistance, housing counseling, rental agreement education, landlord-tenant mediation, and future housing stability planning. \nyou must have a dd214 with discharge other than dishonorable. \nthe rvs for veterans program can get you a free rv (e.g. motorhome, travel trailer, or fifth wheel). \nthese are donated by other members of the community, and are available as they are donated. \ncontact them to be put on a waiting list for the next rv. \npriority is given to homeless veterans, veterans who receive insufficient benefits to pay rent, veterans who do not qualify for va assistance, and veterans who need to live alone because of ptsd. \nsometimes the program also has rvs available for people who are experiencing homelessness who are not veterans. \nthe rvs are in working condition, with no leaks; you must obtain insurance. \nhomeless veterans can get help from the u.s. department of housing and urban development's v.a. supportive housing (vash) program, which can give you vouchers to pay for permanent housing. \ncall 877-4aid-vet or ask for help from slo county veterans services. \n\nsee automobile insurance and repair for tips on how to obtain low-cost auto insurance.\n\nsober living homes and residential treatment options\nslo hub helps you find a residential (live-in) recovery program that's right for you, and can pay the deposit and rent for the opening months of your residency if you cannot afford it or if your insurance does not cover it. \nslo county behavioral health department contracts with sober living environments throughout slo county (from oceano to paso robles) at rates of $35-55 per day. \nthese facilities accept medi-cal and offer sliding scale fees based on ability to pay. \nvisit slo county drug and alcohol services or contact the behavioral health access line at 800-838-1381 for referrals. \nhere are some residential treatment options in slo county:\n\n\n\n\ncaptive hearts (grover beach) for women only \ncasa solana (grover beach) for women only. also known as \"sunshine house.\" \ngryphon society (grover beach) for men only \ndiscipleship home (oceano) for men only \ngryphon society (slo) for women only \nmiddlehouse (slo) for men only \nsun street centers (slo) for men only \n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "eviction-protection",
+    "title": "Eviction Prevention",
+    "content": "if you are homeless or are threatened with eviction with a \"pay rent or quit\" notice, or if you have had to move your family into a hotel, you can get immediate help from the calworks homeless assistance program. \nthis program can pay your security deposit, one month's rent, or a utility deposit payment. \nto qualify you must have \"apparent eligibility\" for calworks and less than $100 in liquid assets. \nyou must first get a referral from the slo county department of social services. \nthe first step in this process is to apply for calworks, which you can do on-line at benefitscal.\nif you are homeless or are threatened with eviction with a \"pay rent or quit\" notice, or if you have had to move your family into a hotel, you can get help from the housing support program (hsp). \nthis program will help you find housing, and give you rent and moving assistance, among other things. \nyou must be eligible for calworks to participate, and you can only use this program once in your lifetime. \nthe first step in this process is to apply for calworks, which you can do on-line at benefitscal. \n5cities homeless coalition (5chc) operates a housing assistance program that offers financial assistance for rent, security deposit, or other immediate needs for people who are homeless in danger of becoming homeless. \ncontact 5chc to arrange a confidential coordinated entry interview. \nyou need to bring identification, including social security cards and birth certificates for you and those living with you, an account of how much income you received during the previous three months, your lease agreement if any, and any eviction notice you received. \n\nsee the legal help, mediation, and crime victim protection section for options about preventing illegal evictions.\n\n\nsee the emergency financial help section for more possible ways to get short-term financial help in a crisis.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "warming-cooling-centers",
+    "title": "Warming/Cooling Centers",
+    "content": "warming centers open only on unusually cold or rainy nights (temperatures expected to drop below 38°f or a 50% chance of rain).\nthey offer overnight shelter beds.\ncooling centers open only during the day when the weather is unusually hot.\nthey offer you an air-conditioned place where you can get out of the sun.\nit can be difficult to know on any particular day whether or not these centers are open, so it is a good idea to call ahead.\n\nthis web page may show the current status of the county's warming/cooling centers.\nyou can register here to receive notifications about the county's warming centers.\n\nthe slo city warming/cooling center is at the 40 prado homeless services center.\nwhen it operates as a warming center, check in is between 7pm and 9pm, and you must leave by 8am. \npeople with p.c. 290 convictions are not allowed in the center. \nwhen it operates as a cooling center, you must leave by 6pm. \ncooling center guests can get breakfast, lunch, and dinner. \npets with rabies vaccinations are allowed in their kennel. \nthe warming center offers a free hot meal. \ntransportation is available between the warming center and morro bay and los osos. \npick-up times from those areas are as follows: \n\n6:15pm: morro bay park (734 harbor st., morro bay) \n6:00pm: south bay community center (2180 palisades ave., los osos) \n\nthe 5cities homeless coalition warming center at 1023 e. grand ave. in arroyo grande operates between 5:30pm and 7am. \nyou must check in between 5:30pm and 8pm. \npets are ok if you have proof of license/vaccinations. \n\npeople with p.c. 290 convictions are not allowed in the center. \ncall 805-202-3615 to verify the center is open and to learn about free transportation options to the center from grover beach, oceano, and pismo beach. \nthe warming center offers dinner and a light breakfast. \ntext \"add me\" to 805-295-1501 to receive text updates to your phone when the warming center opens, or email info@5chc.org and ask to be added to their notification list. \nthe el camino homeless organization (echo) runs a ten-bed warming center at its paso robles shelter location. \nit operates between 6:00pm and 7:00am. check in between 4:30pm and 5:30pm. \nthey will also serve you a meal. \nno dogs except for service dogs are allowed in the warming center. \nnipomo senior center operates an air-conditioned cooling center any time the temperature is above 90°f outside. \nyou do not have to be a senior center member to shelter there when the cooling center is open. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "overnight-shelter",
+    "title": "Overnight Shelter",
+    "content": "if you are unsheltered and need a place to sleep tonight, these are some options:\nthe 40 prado homeless services center has a hundred overnight shelter beds. \nmany are reserved for people who have previously registered with 40 prado, but a limited number are available on a walk-in basis. \nto get a bed, first come on-site and complete the intake process. \nthereafter, on any day when you need an overnight shelter bed, check in to secure a bed or to be placed on the waiting list. \npriority is given to slo county residents. \nthey offer meals (breakfast, lunch, and dinner), showers, laundry, mail/phone services, an integrated medical clinic (primary and urgent care five days a week with an on-site pharmacy), recuperative care beds, and animal kennels. \nto stay at the shelter, you must have a valid photo id, you must not be a p.c. 290 registered sex offender, and you must participate in case management. \nyou must also be able to care for yourself independently (bathing, feeding, dressing, etc.). \nthe 40 prado center is the only walk-in, overnight homeless shelter in slo county.\nthe el camino homeless organization (echo) used to operate a shelter in the north county, but now only offers 90-day transitional housing there (see below) and an occasional warming shelter.\nthe good samaritan shelter operates a set of shelters in santa maria and other places in santa barbara county. \ncall ahead during office hours to learn which shelter has room for you. \nthey also have laundry facilities, hot meals, substance use treatment, and mental health services. \nif you are homeless because you are escaping dangerous circumstances of domestic violence or sexual assault, you can get safe, confidential, emergency shelter at safe houses operated by lumina alliance. \ncall their crisis and information line to get access to this program. \nthey will also help you with trained advocacy, accompaniment to medical/legal appointments, case management, and therapy for survivors and children. \nthey operate throughout slo county, and are open to people of all genders, ages, and backgrounds. \nif you are homeless and have a medically verified need for 24/7 temporary housing because you are seriously ill, recovering from surgery or injury or high-risk pregnancy, or something of that nature, you may qualify for the medically fragile homeless program. \nthey will help you with immediate housing, supportive services and coordinated case management to ensure physical recovery, access to income sources, connection to services, and a more permanent housing alternative when you exit the program. \nyou cannot apply for this program yourself, but you must get a referral from an agency like adult protective services,\nslo county department of social services, \nhousing support program (hsp),\ncenter for family strengthening (cfs), \nor calworks. \nif you are being treated by a hospital or other medical professionals, consider telling them that you are homeless and asking them if they can help you with this process.\nif you need shelter because you have a medical condition that requires you to have some medical supervision, you may be able to get a referral to a rehabilitative care or skilled nursing or assistive living facility. \nyou can get such a referral from your primary care physician. \nyou may also be able to get some help from adult protective services. \na note about \"in-home\" supportive services\n\n\nthe in-home supportive services (ihss) program helps pay for services provided to senior, blind, or disabled people who have difficulty caring for themselves and cannot live at home safely without in-home care. \ndespite the \"in-home\" name, this program is potentially also available to people who shelter at homeless shelters or safe-parking sites.\namong the services that this program can help pay for are meal preparation, laundry, grocery shopping, personal care services (such as bowel and bladder care, bathing, grooming and paramedical services, help getting dressed, help getting into and out of a wheelchair), and accompaniment to medical appointments. \nto qualify for ihss, you must be disabled, blind, or age 65 or older. \nyou must also be unable to live safely in your current home or shelter environment without assistance, and you must be financially needy. \nthe process of applying for ihss is difficult, so it is a good idea for you to get some help from a case manager or other social worker. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "camping-parking-rv-parks",
+    "title": "Legal Camping, Safe Parking, and RV Parks",
+    "content": "if you sleep in your vehicle, there are some free, legal \"safe parking\" spots available at the 40 prado homeless services center where you can stay from 6pm to 7am. \nto register for one of these spots, first complete the referral form at the capslo website. \nyou will also have access to the various other services offered at 40 prado (such as meals, showers, laundry, mail/phone services, an integrated medical clinic, and an animal kennel). \nyour vehicle must be registered and you must have proof of insurance. \nyou must participate in case management. \nyou must not be a p.c. 290 registered sex offender to use this service. \nslo county residents get priority. \ncontact sam neal (sneal@capslo.org, 805-459-1073) with questions. \nthere are some free, legal \"safe parking\" spots available in the slo city area through the rotating overnight safe parking program.\nto register for one of these spots, first complete the intake process at the 40 prado offices any day from 8am to 2pm.\nyou get a place to park overnight for 90 days, with a possible 30 day extension.\nyou must move your vehicle away from the site during the day.\nyou have access to water, trash, and restrooms, and there will be occasional security checks.\nno illegal drugs, alcohol, weapons, or fires are allowed.\nyour vehicle must fit into a standard parking space.\nyou must not be a p.c. 290 registered sex offender to participate.\nslo county residents get priority.\nyou must participate in case management.\nyou can camp overnight legally at various slo county parks, but for a fee (roughly $25-50 per night, plus a $10 reservation fee and sometimes also a per-vehicle fee). \nsome parks have both tent camping and rv hook-up sites. \nnone have dump stations. \nall have restrooms, some also have coin-operated showers. \nstays are limited to 15 consecutive days in any 30-day period during the summer, or a maximum of 30 days in any 60-day period during the winter, and to a maximum of 60 days in any 12-month period. \nthere are several rv parks in slo county, including short-term campsites (ranging from $52 to $104 per night plus reservation fee) and longer-term rv parks ($600-$750/month).\nthese include:\n\nbella vista by the sea (cayucos)\ncoastal dunes rv park & campground (grover beach)\nel chorro regional park campground (between slo and morro bay)\nflying flags avila beach\nle sage riviera rv park (grover beach)\nlopez lake recreation area\nport san luis harbor district rv camping (avila beach)\nsanta margarita koa holiday\nsilver city resort (morro bay)\n\nsome sites have rv size limits and other restrictions.\nsee the directory entries for specific information about rates, size limits, available hookups, and amenities at each location.\nif you are an elks lodge member, slo elks lodge #322 at 222 elks lane in slo also has several $30/night rv spots and a free dump station. \ncontact them at 805-543-0322 (m-f, 10am-4pm) or rvcamping@elks322.org. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "transitional-and-long-term-housing",
+    "title": "Transitional and Long-Term Housing",
+    "content": "this section discusses more long-term housing options including transitional housing (a temporary home while you search for more long-term housing) and affordable housing or subsidized housing (a long-term home).\nthe coordinated entry system (ces) is slo county's system for matching people in need with transitional or long-term housing that is appropriate for them.\nif you want to get such housing, you should try to enter this system.\nthis can be more effective than trying to contact the many individual transitional or long-term housing programs one at a time.\nto enter this system, contact one of the many participating agencies, such as slo county department of social services, 5cities homeless coalition, community action partnership san luis obispo (capslo), transitions mental health association, good samaritan shelter, or slo county health department. \na program called housing now finds homes for the most vulnerable chronically homeless people from slo county.\nyou cannot apply directly to participate in this program, but if you enter the coordinated entry system (see above), that system may eventually place you in this program so that you can quickly get a home. \nthe behavioral health bridge housing (bhbh) has some quality, affordable short-term (less than 90 days) and medium term (90 days to two years) housing for people in slo county who have severe behavioral health issues who are homeless or at risk of homelessness. \nfor information on the application process, how to demonstrate eligibility, and bed availability call mark lamore, director of homeless services at transitions mental health association (tmha), at 805-540-6500. \n5cities homeless coalition (5chc) operates a housing assistance program that offers case management and financial assistance for rent, deposit, and immediate needs, and housing assistance through various funding grants. \nthis is available both to currently homeless people and to people in danger of becoming homeless. \ncontact 5chc to arrange a confidential coordinated entry interview. \nel camino homeless organization (echo) operates transitional (90-day) shelters in atascadero and paso robles that serve people experiencing homelessness. \npeople who live in these shelters also get individualized case management services to help them find employment and long-term housing. \nthere is often a long waiting list for shelter beds. \nthey will not admit p.c. 290 registered sex offenders. \nthe calworks homeless assistance program can pay a one-time security deposit and/or last month's rent and/or utility deposit for families who are homeless or who received a \"pay rent or quit\" notice on their current rental home. \nto qualify you must meet calworks eligibility requirements and have less than $100 in liquid assets. \nfamily care network's housing support program (hsp) provides financial assistance for housing deposits and rent to families that are experiencing homelessness or are at risk of homelessness in slo county.\nthey also offer case management and life skills workshops (budgeting, credit repair, communication), bus passes, gas cards, and paperwork assistance. \nbalay ko on barka (a.k.a. \"my home for hope\") and cabins for change, both in grover beach, operate many individual \"tiny homes\" that serve as transitional housing. \nthe cabins come with 24/7 support, case management, connections to food services and recovery, and house stabilization guidance. \nthey have on-site showers. \nthey accept vaccinated, well-behaved dogs. \nthey will not admit p.c. 290 registered sex offenders. \nthey typically have a long waiting list. \napply through 5cities homeless coalition to get on the waiting list. \nhousing authority of slo (haslo) operates several affordable housing properties in slo county.\ntypically in these projects, residents pay part of the rent, while the rest of the rent is paid for them by subsidies or vouchers. \nto qualify to rent one of these housing units, you must have enough income to pay your part of the rent, but you must not have so much income that you could afford non-subsidized housing. \ntypically this means households that earn less than 30% of the area median income. \npreference is given to slo county residents and to veterans. \nsome housing is restricted to seniors (age 62 and above). \nyou need to provide proof of income and your prior rental history. \nmost of these housing units have wait lists, and only some of them accept new applications at any time. \npaso robles housing authority operates several affordable housing properties in paso robles designed for people who have around 30-60% of the area median income. \nyou can download an application from their website. \nif your application is accepted, you will be put on the waiting list. \nyou must include copies of the latest three months' paycheck stubs, proof of other sources of income, and a copy of your last two years' federal income tax returns. \nyou may be rejected if you recently were evicted, defaulted on debts, or have certain criminal convictions. \nlumina alliance operates a six- to 24-month transitional housing program for individuals and families who are fleeing domestic violence, dating violence, sexual assault, and/or stalking. \npeople housed through this program also get access to advocacy services, employment assistance, counseling, legal help, children's services, life skills development, and help obtaining permanent housing. \nif you are homeless or need housing due to fleeing abusive situation, have low or very low income, and are willing to participate in lumina's program and to cooperate with them in following a safety plan, you may qualify for transitional housing through this program. \nslo county adults with mental illness may qualify for supportive housing in multiple county locations through the transitions mental health association (tmha) residential housing program.\nthe homeshare slo program matches property owners who have an extra room with people who need a place to live. \n\n\nrestorative partners runs a housing program with multiple transitional housing programs for men, women, and families in various slo county locations. \nthese programs are for people in recovery from addiction and people transitioning from incarceration. \nsome are specific to women with children. \nalong with housing, residents get help with employment support, financial literacy, life skills, addiction recovery, and help finding permanent housing. \nthere is a wait list. \nsalvation army has a \"rapid rehousing program\" that helps people find and qualify for long-term housing. \ncontact hattie davis (hattie.davis@usw.salvationarmy.org) for details. \nthe housekeys program is the city of slo's affordable home-ownership program.\nit serves households with about 30-50% of the area median income. \ntheir idea of \"affordable\" may not be yours.\nif you want to apply for housing through this program, begin the application process described on their website.\nhabitat for humanity slo county operates a home ownership program for first-time low-income home buyers and home preservation assistance (minor repairs, landscaping, painting) for low-income homeowners. \napply via their website. \npeoples' self-help housing operates a \"sweat equity\" homeownership program in which families help to build their own homes. \nthey also operate affordable rental housing developments and supportive housing programs. \nthey serve low-income families, farmworkers, seniors, veterans, people with disabilities, and formerly-homeless people. \ncontact them directly to access the program. \nsome other low-income options include:\n\nroosevelt family apartments in nipomo. \nsan luis bay apartments in nipomo. \n\nif you are a refugee from another country, you may be able to get some help establishing housing from slo for home. \nfor seniors\n\n\nhousing authority of slo (haslo), paso robles housing authority, and peoples' self-help housing operate several affordable senior housing rental properties. \nthere are some additional subsidized and affordable housing options especially for seniors (sometimes defined as age 55 and above, or as 62 and above).\nthese include:\n\ncortina d'arroyo grande senior apartments (241 n. courtland ave., arroyo grande) - 805-489-6888 \nparkview manor (365 south elm st., arroyo grande) - 805-489-5101 \njudson terrace (slo), has 107 low-income affordable apartments for people aged 55 and up, and 32 low-income affordable apartments for people aged 62 and up. they only accept applications when the waiting list is open. \n\naffordable housing options for seniors with section 8 vouchers include:\n\nmorro del mar senior apartments (555 main st., morro bay) - 805-225-1837 \nvilla paseo senior apartments (2800 ramada dr., paso robles) - 805-227-4588 \nlas brisas retirement community (slo) \n\naffordable housing options for disabled / handicapped seniors can be found at:\n\ncalifornia manor (10165 el camino real, atascadero) - 805-466-0759 \nhacienda del norte (529 10th st., paso robles) - 805-238-5793 \nbrizzolara st. apartments (611 brizzolara, slo) \nmarvin gardens (1105 laurel lane, slo) \n\nyou can find additional senior housing listings at the central coast commission for senior citizens website.\nif you need assistive living or residential care for the elderly (rcfe) housing, there are some options in slo county, but none of them accept medi-cal. \nif you need such housing and medi-cal is your only health insurance, you can get on a waiting list for a facility outside of slo county. \nthis is a lengthy process, so if you think you might need such a living situation in the future (even as long as a year or more from now), you should try to start this process now. \ndiscuss this with your case manager if you have one, or with the long-term care ombudsman.\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "housing-veterans",
+    "title": "For U.S. Military Veterans",
+    "content": "u.s. military veterans who have low incomes and who are homeless or at risk of homelessness can get help from supportive services for veteran families.\nthis help includes housing assistance, case management, and financial assistance; rapid re-housing and homelessness prevention services; temporary financial assistance for rent, deposits, and utilities; housing barriers assessments, emergency housing stability assistance, housing counseling, rental agreement education, landlord-tenant mediation, and future housing stability planning. \nyou must have a dd214 with discharge other than dishonorable. \nthe rvs for veterans program can get you a free rv (e.g. motorhome, travel trailer, or fifth wheel). \nthese are donated by other members of the community, and are available as they are donated. \ncontact them to be put on a waiting list for the next rv. \npriority is given to homeless veterans, veterans who receive insufficient benefits to pay rent, veterans who do not qualify for va assistance, and veterans who need to live alone because of ptsd. \nsometimes the program also has rvs available for people who are experiencing homelessness who are not veterans. \nthe rvs are in working condition, with no leaks; you must obtain insurance. \nhomeless veterans can get help from the u.s. department of housing and urban development's v.a. supportive housing (vash) program, which can give you vouchers to pay for permanent housing. \ncall 877-4aid-vet or ask for help from slo county veterans services. \n\nsee automobile insurance and repair for tips on how to obtain low-cost auto insurance.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "sober-living-homes",
+    "title": "Sober Living Homes and Residential Treatment Options",
+    "content": "slo hub helps you find a residential (live-in) recovery program that's right for you, and can pay the deposit and rent for the opening months of your residency if you cannot afford it or if your insurance does not cover it. \nslo county behavioral health department contracts with sober living environments throughout slo county (from oceano to paso robles) at rates of $35-55 per day. \nthese facilities accept medi-cal and offer sliding scale fees based on ability to pay. \nvisit slo county drug and alcohol services or contact the behavioral health access line at 800-838-1381 for referrals. \nhere are some residential treatment options in slo county:\n\n\n\n\ncaptive hearts (grover beach) for women only \ncasa solana (grover beach) for women only. also known as \"sunshine house.\" \ngryphon society (grover beach) for men only \ndiscipleship home (oceano) for men only \ngryphon society (slo) for women only \nmiddlehouse (slo) for men only \nsun street centers (slo) for men only \n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "property-storage",
+    "title": "Property Storage Options",
+    "content": "short-term\nif you need to securely store a small amount of property for a few hours or overnight, you have a few options:\nthe 40 prado homeless services center has storage lockers available  for people who complete intake for day services there. \nyou must provide your own padlock. \nthe commercial service bounce partners with multiple locations (in slo county, these are typically ups stores) to offer short-term luggage storage that typically runs about $7 per day or $20-80 per month (depending on weight and size).\nyou can find the specific locations, terms and conditions, and costs at their website. \nin a few locations in slo county (morro st. in slo, at cal poly, and at the curbaril park-n-ride in atascadero) you can find on-demand bike lockers.\nthese cost 5¢ per hour and can be rented for up to seven consecutive days. \nuse the bikelink app to access and pay for these lockers. \nthey are for bicycles only (you cannot use them to store other personal belongings like carts or suitcases), but you can probably get away with storing pannier bags along with your bicycle. \nlong-term\nthere are several commercial long-term storage options in slo county.\nyou can find these by doing a web search for terms like \"self storage\" or \"mini storage\".\nthey typically rent spaces by the month, and have different-sized units available at different prices.\n5′×5′, 5′×10′, and 10′×10′ units are typical.\nyou can expect to pay about $60-75 per month for the least-expensive and smallest sizes, up to $150 for larger sizes. \nmost storage facilities have daytime hours of operation when you can access the storage units to add or remove property, and are closed to everyone at night.\nrecovering property taken during arrests or encampment sweeps\ndifferent agencies take responsibility for clearing homeless camps, depending on where the camps are located.\nthese agencies have different policies about whether, to what extent, and for how long they will store property that they clear from encampments, so that the owners of that property can recover it.\nthey typically will only store certain items of property, and will discard things that are hazardous, soiled, or decayed or that seem to them like mere trash.\nthey often store all items taken from an encampment sweep in one big pile, which can make it difficult for you to find your own items.\ngrover beach will post a notice after they do an encampment sweep, at the encampment's former location, \"stating where the personal property is being stored, and listing the phone number and hours a person claiming ownership can collect or make arrangements to collect their personal property.\" \nthey will store some belongings for 90 days before discarding them. \nmorro bay stores some property taken during encampment sweeps for 90 days before discarding it. \ntheir policy is to post a notice where they plan to do encampment sweeps 72 hours before they begin, and those notices should include the address, phone number, and operating hours of the location where personal property will be stored. \nslo city stores some property taken during encampment sweeps for 90 days before discarding it. \nif you have had property taken in this way, call either the public works department (805-781-7220) or the ranger service department (805-781-7302) and give them a detailed description of your property. \nif they think they may have it, you can make an appointment to retrieve it. \nif your property was seized from an camp sweep along the highway, on-ramp / off-ramp, or overpass / underpass, this may have been done by caltrans.\nthey should post notices where they plan to do encampment sweeps 72 hours before they begin, and those notices should include a phone number you can call to get assistance in retrieving your property. \nif they failed to post notices ahead of time, they should post notices afterwards that describe where items were removed from, a contact number to call to reclaim them, and the date by which they must be reclaimed. \nthey will not sift through belongings to identify valuable items, but if they see \"items of apparent value\" in plain sight, they will treat them as privately owned, lost, discarded, abandoned, or stolen property and hold it for 90 days after removing it before disposing of it. \nif a different agency from those was responsible for the sweep, try discovering which agency it was, and then contact them directly.\nif you were separated from your property because you were arrested, it is possible that those who arrested you did not make any attempt to secure your belongings.\nthey may have just left them wherever they were when you were arrested.\nif they did secure your belongings, they should return these to you when you are released from jail or they should tell you the process you can use to retrieve them, unless they are keeping the property as evidence.\nin the case of the slo county sheriff, if they were keeping the property as evidence but then decide to return it to you, they will inform you by sending you a letter that tells you where to retrieve the property. \nyou then have 30 days to retrieve the property, or it may be destroyed. \nif you do not have a stable mailing address, or if the sheriffs department does not know your mailing address, you may never see this letter!\nin such a case, you may want to contact the sheriffs department to let them know how to contact you if they decide to release your property.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "short-term-property-storage",
+    "title": "Short-Term",
+    "content": "if you need to securely store a small amount of property for a few hours or overnight, you have a few options:\nthe 40 prado homeless services center has storage lockers available  for people who complete intake for day services there. \nyou must provide your own padlock. \nthe commercial service bounce partners with multiple locations (in slo county, these are typically ups stores) to offer short-term luggage storage that typically runs about $7 per day or $20-80 per month (depending on weight and size).\nyou can find the specific locations, terms and conditions, and costs at their website. \nin a few locations in slo county (morro st. in slo, at cal poly, and at the curbaril park-n-ride in atascadero) you can find on-demand bike lockers.\nthese cost 5¢ per hour and can be rented for up to seven consecutive days. \nuse the bikelink app to access and pay for these lockers. \nthey are for bicycles only (you cannot use them to store other personal belongings like carts or suitcases), but you can probably get away with storing pannier bags along with your bicycle. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "long-term-property-storage",
+    "title": "Long-Term",
+    "content": "there are several commercial long-term storage options in slo county.\nyou can find these by doing a web search for terms like \"self storage\" or \"mini storage\".\nthey typically rent spaces by the month, and have different-sized units available at different prices.\n5′×5′, 5′×10′, and 10′×10′ units are typical.\nyou can expect to pay about $60-75 per month for the least-expensive and smallest sizes, up to $150 for larger sizes. \nmost storage facilities have daytime hours of operation when you can access the storage units to add or remove property, and are closed to everyone at night.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "recovering-seized-property",
+    "title": "Recovering Property Taken During Arrests or Encampment Sweeps",
+    "content": "different agencies take responsibility for clearing homeless camps, depending on where the camps are located.\nthese agencies have different policies about whether, to what extent, and for how long they will store property that they clear from encampments, so that the owners of that property can recover it.\nthey typically will only store certain items of property, and will discard things that are hazardous, soiled, or decayed or that seem to them like mere trash.\nthey often store all items taken from an encampment sweep in one big pile, which can make it difficult for you to find your own items.\ngrover beach will post a notice after they do an encampment sweep, at the encampment's former location, \"stating where the personal property is being stored, and listing the phone number and hours a person claiming ownership can collect or make arrangements to collect their personal property.\" \nthey will store some belongings for 90 days before discarding them. \nmorro bay stores some property taken during encampment sweeps for 90 days before discarding it. \ntheir policy is to post a notice where they plan to do encampment sweeps 72 hours before they begin, and those notices should include the address, phone number, and operating hours of the location where personal property will be stored. \nslo city stores some property taken during encampment sweeps for 90 days before discarding it. \nif you have had property taken in this way, call either the public works department (805-781-7220) or the ranger service department (805-781-7302) and give them a detailed description of your property. \nif they think they may have it, you can make an appointment to retrieve it. \nif your property was seized from an camp sweep along the highway, on-ramp / off-ramp, or overpass / underpass, this may have been done by caltrans.\nthey should post notices where they plan to do encampment sweeps 72 hours before they begin, and those notices should include a phone number you can call to get assistance in retrieving your property. \nif they failed to post notices ahead of time, they should post notices afterwards that describe where items were removed from, a contact number to call to reclaim them, and the date by which they must be reclaimed. \nthey will not sift through belongings to identify valuable items, but if they see \"items of apparent value\" in plain sight, they will treat them as privately owned, lost, discarded, abandoned, or stolen property and hold it for 90 days after removing it before disposing of it. \nif a different agency from those was responsible for the sweep, try discovering which agency it was, and then contact them directly.\nif you were separated from your property because you were arrested, it is possible that those who arrested you did not make any attempt to secure your belongings.\nthey may have just left them wherever they were when you were arrested.\nif they did secure your belongings, they should return these to you when you are released from jail or they should tell you the process you can use to retrieve them, unless they are keeping the property as evidence.\nin the case of the slo county sheriff, if they were keeping the property as evidence but then decide to return it to you, they will inform you by sending you a letter that tells you where to retrieve the property. \nyou then have 30 days to retrieve the property, or it may be destroyed. \nif you do not have a stable mailing address, or if the sheriffs department does not know your mailing address, you may never see this letter!\nin such a case, you may want to contact the sheriffs department to let them know how to contact you if they decide to release your property.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "food",
+    "title": "Food",
+    "content": "in this section:\n\nfree meals\nfree food pantries\nlittle free pantries\nfood box distributions\nsummer meal sites (for children)\nsenior meal programs\ncalfresh / ebt (food stamps) and wic\nedible wild plants\n\n\n\nfree meals\n\n\n\n\nlocation\nmeal provider\nwhen\n\n\n\natascadero\nel camino homeless organization (echo)\n5pm daily\n\n\natascadero\nrefuge church (atascadero)\n5pm tuesdays & 6pm wednesdays\n\n\ncal poly\nfront porch\nwednesday dinner\n\n\ngrover beach\npeople's kitchen (grover beach)\nnoon lunch daily\n\n\nlos osos\nlos osos cares\n5pm wednesdays\n\n\nmorro bay\nmorro bay lions foundation\n5:30pm mondays\n\n\npaso robles\nel camino homeless organization (echo)\n4:30pm daily\n\n\nslo\nmen of agape church\n11am most thursdays\n\n\nslo\nblessed to serve\n5pm mondays & thursdays\n\n\nslo\nfood not bombs\n1pm sundays\n\n\nslo\npeople's kitchen (slo)\nnoon lunch daily\n\n\nfree food pantries\nfood pantries give away unprepared food (such as fresh produce, canned goods, and packaged food).\nsome pantries have special no-cook, no-refrigeration, ready-to-eat options for people who do not have access to kitchens.\nsome give you a pre-prepared box or bag of food, others allow you to select particular items you want.\n\n\n\n\nlocation\npantry\nwhen\n\n\n\narroyo grande\nnipomo community presbyterian\nfridays 12:45-1:30pm\n\n\narroyo grande\nsaint patrick's church (south county residents only; bring photo id)\ntuesday-thursday 4-5pm\n\n\narroyo grande\nsalvation army\nmondays, wednesdays, fridays 10am-noon\n\n\natascadero\nlegacy church pantry\nthursdays 1-2pm\n\n\natascadero\nloaves and fishes (north county residents only)\nmonday-friday 1-3pm\n\n\natascadero\nrefuge church (atascadero)\ntuesday 5-6pm & wednesday 6-6:30pm, or by appt.\n\n\natascadero\nrestoration church\nfirst saturday of the month 1-2:30pm\n\n\ncal poly\ncal poly food pantry (for cal poly students and staff)\nmonday-friday 8:30am-6pm\n\n\ncambria\ncambria vineyard church\nsecond & fourth thursday noon-2pm\n\n\ncayucos\ncayucos community church\nwednesdays 10:30-11am\n\n\ncayucos\nst. joseph's catholic church\nfridays 10am-noon (thursdays 7:30-7:45 by appt.)\n\n\ncuesta college\ncougar food pantry (must be a cuesta student)\nmonday-friday 9am-4:30pm\n\n\ngrover beach\nfive cities christian women food pantry (bring photo id)\nmonday-friday 2-3:30pm\n\n\nlos osos\nking's cupboard at el morro church\ntuesdays 8-10am\n\n\nlos osos\nsouth bay seniors people helping people\nwednesdays 9:30-10:30am\n\n\nlos osos\ntrinity united methodist church (los osos)\ntuesdays & fridays 10am-noon\n\n\nmorro bay\nmorro bay lions foundation\n4:30-6:30pm mondays\n\n\nmorro bay\nopen arms pantry at rock harbor\nsaturdays 9:30-10:30am\n\n\nnipomo\nnipomo food basket (nipomo residents only)\nm/tu/th/f 10am-1pm\n\n\nnipomo\nsanta maria valley hispanic church\nsaturdays 11am-12:30pm\n\n\npaso robles\ncuesta college\nmonday-friday 9am-5pm\n\n\npaso robles\nloaves and fishes\nmonday-thursday 2-4pm (or by appt.)\n\n\npaso robles\npaso robles senior center (for seniors)\nsecond & fourth tuesday 9:30-11am\n\n\npaso robles\nsalvation army (bring photo id)\ntuesdays 10-11am\n\n\npaso robles\nthe link, 626 26th st. admin building #1, 805-503-9638\nm-th 9am-3pm; f 9am-1pm\n\n\npismo beach\nnew life u-pick pantry (1 visit per household per week; bring photo id)\ntu 6-7pm, w 10am-noon, th 1:30-3:30pm\n\n\nsan miguel\nchildren and the country life, 795 monterey rd. (mission), 805-467-2131 x115\nfirst, third, & fifth wednesday, 5-6pm\n\n\nslo\nagape church\nsundays noon-12:30pm\n\n\nslo\narise central coast\nmondays 2:30-4:30pm\n\n\nslo\nbreakthrough ministry, 4251 south higuera #200, 805-234-7441\ntuesdays 2-3pm, or by appt.\n\n\nslo\ngala pride & diversity center\nmonday-friday 10am-3pm\n\n\nslo\ngrace central coast \"god's storehouse\"\nsaturdays 8:30-9:15am\n\n\nslo\noutreach and engagement services\nmonday-friday 10am-3pm\n\n\nslo\nrenovate church\nmondays 4-6pm\n\n\nslo\nsalvation army (bring photo id)\nw/f 10am-noon, th 2-4pm\n\n\nslo\nslo food bank\nmondays, wednesdays, fridays noon-5pm\n\n\nslo\nslo grassroots\nby appointment only\n\n\nslo\nunitarian universalists san luis obispo \"we care food share\"\nwednesdays 3-4:30pm\n\n\nslo\nveterans services (for veterans only)\ndaily 8am-5pm\n\n\nslo\nzion lutheran church\nwednesdays 9:30-11:30am\n\n\n\n\nlittle free pantries\nlittle free pantries are small boxes erected in neighborhoods and maintained by the people who live nearby.\nthey are self-serve and open 24/7.\nthey are stocked by people who have extra things to give away.\nyou never know quite what you will find there, but there is usually some canned and packaged non-perishable food, and sometimes toiletries and other small essentials.\nsometimes people put perishable food in little free pantries, but you should beware of eating such food as it may have been there for a while and may no longer be safe to eat.\nsee little free pantries in the directory for a list of locations.\nfood box distributions\nthe slo food bank gives away food boxes on a regular schedule at a variety of locations in slo county.\nvisit findfoodslo.org for a complete list and schedule of these \"neighborhood food distributions.\"\nsummer meal sites (for children)\nthe california department of education has a \"summer food service program\" to help children during the summer school break who usually get meals at school. \nthis program is open to all children in the community. \nyou can find a list of summer meal sites in san luis obispo county at the california department of education website.\nsenior meal programs\nmeals that connect has several sites in slo county where they serve free, hot communal lunches every weekday. \nthe program is for people aged 60 and above. \nyou must complete an application to join the program, and you must reserve your meals two days in advance. \nthey also can deliver meals to your home if you are homebound. \nfive cities meals on wheels is a similar program specific to the five cities area that provides daily meals, delivered to the homes of people who cannot prepare nutritious meals for themselves and do not have caretakers who can do so. \nthey serve homebound neighbors in arroyo grande, grover beach, oceano, pismo beach, and shell beach. \nthey serve seniors and people with temporary or permanent disabilities. \nlow-income seniors (aged 60 and above) can get $20-50 in credit to use at participating farmers markets from the california department of food and agriculture. \nthere is limited availability, so if the program runs out of credits you may have to wait until their next budget to apply.\nlearn more about the program and apply to join it at their website.\nqualifying farmers markets include: \n\n\n\nlocation\nwhen\n\n\n\narroyo grande\nsaturday afternoon\n\n\narroyo grande\nwednesday morning\n\n\natascadero\nwednesday afternoon\n\n\ncambria\nfriday afternoon\n\n\nlos osos (baywood)\nmonday afternoon\n\n\nmorro bay\nsaturday afternoon\n\n\nmorro bay\nthursday afternoon\n\n\npaso robles\ntuesday morning\n\n\nslo (downtown)\nthursday evening\n\n\nslo (madonna)\nsaturday morning\n\n\nslo (tank farm)\ntuesday afternoon\n\n\ntempleton\nsaturday morning\n\n\ncalfresh / ebt (food stamps) and wic\nthe calfresh program is california's version of the federal nutrition program known as \"snap\" or \"food stamps.\" \nif you have a low income, california gives you an \"ebt card\" which you can use like a debit card at grocery stores and farmers markets to buy healthy foods. \nyou can apply for calfresh on-line at either of the following sites:\n\nbenefitscal.com \ngetcalfresh.org \n\nyou can also apply in person at the slo county department of social services. \nif you are a cal poly student, you can get assistance from the cal poly calfresh program.\nyou will need some identification document, proof of income, and (for students) indication of student status, and (for non-citizens) immigration status. \nsuitable proof of income includes pay stubs from last 30 days, an employer letter on company letterhead, tax forms (1040, w-2, 1099), self-employment profit/loss statement or ledger, or a signed written statement if you do not have those documents. \nsee calfresh.guide for more details.\nsome local farmers markets will double up to $15 in calfresh benefits that you spend at the market, so you can get twice as much food for your money (see slocountyfarmers.org for details): \n\n\n\nlocation\nwhen\n\n\n\narroyo grande\nwednesday morning\n\n\natascadero\nwednesday afternoon\n\n\ncambria\nfriday afternoon\n\n\nlos osos (baywood)\nmonday afternoon\n\n\nmorro bay\nthursday afternoon\n\n\npaso robles\ntuesday morning\n\n\nslo (downtown)\nthursday evening\n\n\nslo (madonna)\nsaturday morning\n\n\ntempleton\nsaturday morning\n\n\nthe women, infants, and children (wic) program also provides e-wic debit cards with which you can buy certain types of food from farmers markets and wic-approved groceries. \nedible wild plants\nthere are many edible wild plants available in slo county.\nwhen they are in season, they can add nutrition to your diet.\n\ncaution: some wild plants are poisonous.\nyou should only forage for wild plants if you know what you are doing.\nalso: beware of foraging plants in agricultural or well-tended areas, as they may have been treated with pesticides.\ndon't forage plants from waste sites, stagnant water areas, or areas subject to agricultural or industrial run-off, as the plants may absorb toxins or parasites from the soil or water.\n\nsome common edible plants in slo county are: \n\n\n\nplant\nseason\nedible part\n\n\n\nbeach strawberry\nspring-summer\nberries\n\n\nblackberries\nsummer\nberries\n\n\nbulrush\nall year\nmost parts, but should be cooked\n\n\ncattail\nall year\nmost parts, but should be cooked\n\n\nchaparral currant\nspring\nberries\n\n\nchia\nfall\nseeds\n\n\nchinquapin\nfall\nnuts\n\n\nchufa/nutgrass\nfall\ntubers\n\n\ndandelion\nspring-fall\nall parts\n\n\ngooseberry\nspring\nberries\n\n\nhollyleaf cherry\nsummer-fall\nberries\n\n\nminer's lettuce\nall year\nall parts\n\n\nnasturtium\nspring-summer\nflowers and leaves\n\n\nprickly pear\nsummer-fall\nfruit (but covered in annoying spines)\n\n\nthimbleberry\nsummer\nberries\n\n\nwatercress\nspring-summer\nleaves\n\n\nwild mustard\nspring\nflowers and leaves\n\n\nsometimes you will also see edible fruit trees like plums or cherries on sidewalks, in parks, or in other public places.\nsometimes also people plant fruit trees on their own property but then neglect to harvest the fruit, perhaps because there is more than they need.\nin such a case you can ask the property owner for permission to harvest from their trees.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "free-meals",
+    "title": "Free Meals",
+    "content": "\n\n\nlocation\nmeal provider\nwhen\n\n\n\natascadero\nel camino homeless organization (echo)\n5pm daily\n\n\natascadero\nrefuge church (atascadero)\n5pm tuesdays & 6pm wednesdays\n\n\ncal poly\nfront porch\nwednesday dinner\n\n\ngrover beach\npeople's kitchen (grover beach)\nnoon lunch daily\n\n\nlos osos\nlos osos cares\n5pm wednesdays\n\n\nmorro bay\nmorro bay lions foundation\n5:30pm mondays\n\n\npaso robles\nel camino homeless organization (echo)\n4:30pm daily\n\n\nslo\nmen of agape church\n11am most thursdays\n\n\nslo\nblessed to serve\n5pm mondays & thursdays\n\n\nslo\nfood not bombs\n1pm sundays\n\n\nslo\npeople's kitchen (slo)\nnoon lunch daily\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "free-food-pantries",
+    "title": "Free Food Pantries",
+    "content": "food pantries give away unprepared food (such as fresh produce, canned goods, and packaged food).\nsome pantries have special no-cook, no-refrigeration, ready-to-eat options for people who do not have access to kitchens.\nsome give you a pre-prepared box or bag of food, others allow you to select particular items you want.\n\n\n\n\nlocation\npantry\nwhen\n\n\n\narroyo grande\nnipomo community presbyterian\nfridays 12:45-1:30pm\n\n\narroyo grande\nsaint patrick's church (south county residents only; bring photo id)\ntuesday-thursday 4-5pm\n\n\narroyo grande\nsalvation army\nmondays, wednesdays, fridays 10am-noon\n\n\natascadero\nlegacy church pantry\nthursdays 1-2pm\n\n\natascadero\nloaves and fishes (north county residents only)\nmonday-friday 1-3pm\n\n\natascadero\nrefuge church (atascadero)\ntuesday 5-6pm & wednesday 6-6:30pm, or by appt.\n\n\natascadero\nrestoration church\nfirst saturday of the month 1-2:30pm\n\n\ncal poly\ncal poly food pantry (for cal poly students and staff)\nmonday-friday 8:30am-6pm\n\n\ncambria\ncambria vineyard church\nsecond & fourth thursday noon-2pm\n\n\ncayucos\ncayucos community church\nwednesdays 10:30-11am\n\n\ncayucos\nst. joseph's catholic church\nfridays 10am-noon (thursdays 7:30-7:45 by appt.)\n\n\ncuesta college\ncougar food pantry (must be a cuesta student)\nmonday-friday 9am-4:30pm\n\n\ngrover beach\nfive cities christian women food pantry (bring photo id)\nmonday-friday 2-3:30pm\n\n\nlos osos\nking's cupboard at el morro church\ntuesdays 8-10am\n\n\nlos osos\nsouth bay seniors people helping people\nwednesdays 9:30-10:30am\n\n\nlos osos\ntrinity united methodist church (los osos)\ntuesdays & fridays 10am-noon\n\n\nmorro bay\nmorro bay lions foundation\n4:30-6:30pm mondays\n\n\nmorro bay\nopen arms pantry at rock harbor\nsaturdays 9:30-10:30am\n\n\nnipomo\nnipomo food basket (nipomo residents only)\nm/tu/th/f 10am-1pm\n\n\nnipomo\nsanta maria valley hispanic church\nsaturdays 11am-12:30pm\n\n\npaso robles\ncuesta college\nmonday-friday 9am-5pm\n\n\npaso robles\nloaves and fishes\nmonday-thursday 2-4pm (or by appt.)\n\n\npaso robles\npaso robles senior center (for seniors)\nsecond & fourth tuesday 9:30-11am\n\n\npaso robles\nsalvation army (bring photo id)\ntuesdays 10-11am\n\n\npaso robles\nthe link, 626 26th st. admin building #1, 805-503-9638\nm-th 9am-3pm; f 9am-1pm\n\n\npismo beach\nnew life u-pick pantry (1 visit per household per week; bring photo id)\ntu 6-7pm, w 10am-noon, th 1:30-3:30pm\n\n\nsan miguel\nchildren and the country life, 795 monterey rd. (mission), 805-467-2131 x115\nfirst, third, & fifth wednesday, 5-6pm\n\n\nslo\nagape church\nsundays noon-12:30pm\n\n\nslo\narise central coast\nmondays 2:30-4:30pm\n\n\nslo\nbreakthrough ministry, 4251 south higuera #200, 805-234-7441\ntuesdays 2-3pm, or by appt.\n\n\nslo\ngala pride & diversity center\nmonday-friday 10am-3pm\n\n\nslo\ngrace central coast \"god's storehouse\"\nsaturdays 8:30-9:15am\n\n\nslo\noutreach and engagement services\nmonday-friday 10am-3pm\n\n\nslo\nrenovate church\nmondays 4-6pm\n\n\nslo\nsalvation army (bring photo id)\nw/f 10am-noon, th 2-4pm\n\n\nslo\nslo food bank\nmondays, wednesdays, fridays noon-5pm\n\n\nslo\nslo grassroots\nby appointment only\n\n\nslo\nunitarian universalists san luis obispo \"we care food share\"\nwednesdays 3-4:30pm\n\n\nslo\nveterans services (for veterans only)\ndaily 8am-5pm\n\n\nslo\nzion lutheran church\nwednesdays 9:30-11:30am\n\n\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "little-free-pantries",
+    "title": "Little Free Pantries",
+    "content": "little free pantries are small boxes erected in neighborhoods and maintained by the people who live nearby.\nthey are self-serve and open 24/7.\nthey are stocked by people who have extra things to give away.\nyou never know quite what you will find there, but there is usually some canned and packaged non-perishable food, and sometimes toiletries and other small essentials.\nsometimes people put perishable food in little free pantries, but you should beware of eating such food as it may have been there for a while and may no longer be safe to eat.\nsee little free pantries in the directory for a list of locations.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "food-box-distributions",
+    "title": "Food Box Distributions",
+    "content": "the slo food bank gives away food boxes on a regular schedule at a variety of locations in slo county.\nvisit findfoodslo.org for a complete list and schedule of these \"neighborhood food distributions.\"\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "summer-meal-sites",
+    "title": "Summer Meal Sites (for Children)",
+    "content": "the california department of education has a \"summer food service program\" to help children during the summer school break who usually get meals at school. \nthis program is open to all children in the community. \nyou can find a list of summer meal sites in san luis obispo county at the california department of education website.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "senior-meal-programs",
+    "title": "Senior Meal Programs",
+    "content": "meals that connect has several sites in slo county where they serve free, hot communal lunches every weekday. \nthe program is for people aged 60 and above. \nyou must complete an application to join the program, and you must reserve your meals two days in advance. \nthey also can deliver meals to your home if you are homebound. \nfive cities meals on wheels is a similar program specific to the five cities area that provides daily meals, delivered to the homes of people who cannot prepare nutritious meals for themselves and do not have caretakers who can do so. \nthey serve homebound neighbors in arroyo grande, grover beach, oceano, pismo beach, and shell beach. \nthey serve seniors and people with temporary or permanent disabilities. \nlow-income seniors (aged 60 and above) can get $20-50 in credit to use at participating farmers markets from the california department of food and agriculture. \nthere is limited availability, so if the program runs out of credits you may have to wait until their next budget to apply.\nlearn more about the program and apply to join it at their website.\nqualifying farmers markets include: \n\n\n\nlocation\nwhen\n\n\n\narroyo grande\nsaturday afternoon\n\n\narroyo grande\nwednesday morning\n\n\natascadero\nwednesday afternoon\n\n\ncambria\nfriday afternoon\n\n\nlos osos (baywood)\nmonday afternoon\n\n\nmorro bay\nsaturday afternoon\n\n\nmorro bay\nthursday afternoon\n\n\npaso robles\ntuesday morning\n\n\nslo (downtown)\nthursday evening\n\n\nslo (madonna)\nsaturday morning\n\n\nslo (tank farm)\ntuesday afternoon\n\n\ntempleton\nsaturday morning\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "calfresh-ebt-wic",
+    "title": "CalFresh / EBT (Food Stamps) and WIC",
+    "content": "the calfresh program is california's version of the federal nutrition program known as \"snap\" or \"food stamps.\" \nif you have a low income, california gives you an \"ebt card\" which you can use like a debit card at grocery stores and farmers markets to buy healthy foods. \nyou can apply for calfresh on-line at either of the following sites:\n\nbenefitscal.com \ngetcalfresh.org \n\nyou can also apply in person at the slo county department of social services. \nif you are a cal poly student, you can get assistance from the cal poly calfresh program.\nyou will need some identification document, proof of income, and (for students) indication of student status, and (for non-citizens) immigration status. \nsuitable proof of income includes pay stubs from last 30 days, an employer letter on company letterhead, tax forms (1040, w-2, 1099), self-employment profit/loss statement or ledger, or a signed written statement if you do not have those documents. \nsee calfresh.guide for more details.\nsome local farmers markets will double up to $15 in calfresh benefits that you spend at the market, so you can get twice as much food for your money (see slocountyfarmers.org for details): \n\n\n\nlocation\nwhen\n\n\n\narroyo grande\nwednesday morning\n\n\natascadero\nwednesday afternoon\n\n\ncambria\nfriday afternoon\n\n\nlos osos (baywood)\nmonday afternoon\n\n\nmorro bay\nthursday afternoon\n\n\npaso robles\ntuesday morning\n\n\nslo (downtown)\nthursday evening\n\n\nslo (madonna)\nsaturday morning\n\n\ntempleton\nsaturday morning\n\n\nthe women, infants, and children (wic) program also provides e-wic debit cards with which you can buy certain types of food from farmers markets and wic-approved groceries. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "edible-wild-plants",
+    "title": "Edible Wild Plants",
+    "content": "there are many edible wild plants available in slo county.\nwhen they are in season, they can add nutrition to your diet.\n\ncaution: some wild plants are poisonous.\nyou should only forage for wild plants if you know what you are doing.\nalso: beware of foraging plants in agricultural or well-tended areas, as they may have been treated with pesticides.\ndon't forage plants from waste sites, stagnant water areas, or areas subject to agricultural or industrial run-off, as the plants may absorb toxins or parasites from the soil or water.\n\nsome common edible plants in slo county are: \n\n\n\nplant\nseason\nedible part\n\n\n\nbeach strawberry\nspring-summer\nberries\n\n\nblackberries\nsummer\nberries\n\n\nbulrush\nall year\nmost parts, but should be cooked\n\n\ncattail\nall year\nmost parts, but should be cooked\n\n\nchaparral currant\nspring\nberries\n\n\nchia\nfall\nseeds\n\n\nchinquapin\nfall\nnuts\n\n\nchufa/nutgrass\nfall\ntubers\n\n\ndandelion\nspring-fall\nall parts\n\n\ngooseberry\nspring\nberries\n\n\nhollyleaf cherry\nsummer-fall\nberries\n\n\nminer's lettuce\nall year\nall parts\n\n\nnasturtium\nspring-summer\nflowers and leaves\n\n\nprickly pear\nsummer-fall\nfruit (but covered in annoying spines)\n\n\nthimbleberry\nsummer\nberries\n\n\nwatercress\nspring-summer\nleaves\n\n\nwild mustard\nspring\nflowers and leaves\n\n\nsometimes you will also see edible fruit trees like plums or cherries on sidewalks, in parks, or in other public places.\nsometimes also people plant fruit trees on their own property but then neglect to harvest the fruit, perhaps because there is more than they need.\nin such a case you can ask the property owner for permission to harvest from their trees.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "refill-a-water-bottle",
+    "title": "Where to Refill a Water Bottle",
+    "content": "most major parks and recreation facilities have water fountains and/or water bottle refill stations, as do some public libraries. \nthe city of slo also has a water bottle filling station network.\nsome of these stations are inside buildings and are only accessible when the building is open for business.\nothers are outside and are available 24/7.\nyou can find a map of these hydration stations at this link or at google maps.\n\n\n\nlocation\nhow to find it\nhours\n\n\n\ndamon/garcia field\nacross from restroom\n24/7\n\n\n872 higuera st.\noutside\n24/7\n\n\n893 marsh st.\noutside\n24/7\n\n\n919 palm st.\njust inside the door\nm-f 8am-4pm\n\n\n990 palm st. \ndown the hall\nm-f 8am-5pm\n\n\n990 palm st. \ndown the hall\nm-f 8am-5pm\n\n\n990 palm st. \ndownstairs\nm-f 8am-5pm\n\n\nsanta rosa park\nnear parking lot\n24/7\n\n\nsanta rosa park\nnear skate park\n24/7\n\n\n864 santa rosa st.\ninside, near gym\nm-f 9am-6pm\n\n\nsinsheimer park\nnear playground\n24/7\n\n\nsinsheimer park\noutside statium\n24/7\n\n\n900 southwood\nin the swim center\nm-f 6-8am, 11:30-3:30pm, 5:30-7pm; sa/su 11:30-1:30pm\n\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "transportation",
+    "title": "Transportation",
+    "content": "in this section:\n\npublic transit\ntransportation resources for seniors\ntransportation to medical appointments\nbicycles\nautomobile insurance and repair\n\npublic transit\nthere are many public transit options in slo county.\nthe rideshare website and the 511 phone service can give you an overview of most of them and can help you plan your trips.\nthe slo regional transit authority system includes several bus routes that connect cities in slo county.\nthey also govern the city bus routes in morro bay and paso robles, and the dial-a-ride and runabout paratransit services.\nyou can buy bus passes on the bus or by using the token transit app.\nthere are discounts for seniors (age 65+), medicare card holders, and people with disabilities. \nyou must apply in person at the rta office to get a discount card. \npeople over the age of 80 and people with an ada-certified disability ride free. \n\n\n\nrta line\ndestinations\n\n\n\n9\nsan miguel, paso robles, templeton, atascadero, santa margarita, slo\n\n\n10\nsanta maria, nipomo, arroyo grande, pismo beach, slo\n\n\n12\nlos osos, morro bay, slo\n\n\n15\nsan simeon, cambria, cayucos, morro bay\n\n\n21\npismo beach, arroyo grande, grover beach\n\n\n24\npismo beach, grover beach\n\n\n27 & 28\ngrover beach, arroyo grande, oceano\n\n\na & b\npaso robles\n\n\navila-pismo beach trolley\nport san luis, avila beach, pismo beach\n\n\nmorro bay transit\nmorro bay\n\n\nrunabout paratransit is a county-wide transit service for people who cannot always use the fixed-route slo rta buses because of disability. \nthis service will take you door-to-door within ¾-mile of the rta fixed routes during the same hours rta operates. \none personal care attendant can accompany you free-of-charge. \nyou have to apply and have an in-person interview to be eligible for this service (see slo regional transit authority for contact information). \nafter you register, make ride reservations 1-7 days in advance by calling 805-541-2544. \nrides are not free; they cost about twice as much as ordinary rta rides. \nhowever people who qualify to use runabout paratransit can also ride the ordinary rta service for free. \nslo transit is the san luis obispo city bus system.\nyou can use the slo transit riderportal website or phone app (iphone, android) to view routes and to see when the next bus is due to arrive.\nyou can buy bus passes on the bus or by using the token transit app.\n(another option for viewing bus arrival times and for planning travel is the moovit app.)\nthere are discounts for seniors and disabled people (you may need to apply for a special card), and for children. \nif you buy a regional day pass from slo rta, that also lets you ride slo transit buses. \nsome service providers can give you a bus pass if you cannot afford to buy one.\nfor example, catholic charities \nand the society of st. vincent de paul often have bus passes available to people who need them. \nclients of tri-counties regional center can get bus passes from them. \nthe family care network can help you get a bus pass if you cannot afford one on your own (you may first need to get a referral from a slo county department of social services employment resource specialist). \nyou can find carpool options locally by using the irideshare web application, a free program for slo county commuters.\nthe application matches commuters based on their locations, routes, destinations, and schedules to try to match them into compatible carpools.\nif you register for irideshare and you commute to work by walking, biking, taking the bus, or in a carpool or vanpool, and you need to get home from work in some other way (for example, because the carpool is leaving at the wrong time, or because your bike broke), the guaranteed ride home program will pay for your taxi, uber, or lyft ride home.\n(you need to register for their commuter club program, save your ride payment receipt, and you can only get a limited number of guaranteed rides home.) \nthere are dial-a-ride services in atascadero, morro bay, nipomo, paso robles, shandon, and templeton.\nthey typically offer curb-to-curb service and charge $2.25-8.00 each way (sometimes less for seniors, disabled people, and children): \n\n\n\n\ndial-a-ride service\nphone number\nnotes\n\n\n\natascadero\n805-466-7433\noperates m-f 7:30am-3:30pm.\n\n\nmorro bay\n805-541-2228 x3\nmust be within ¾-mile of a transit bus route. call m-f 7:30am-6:30pm to request a ride.\n\n\nnipomo\n805-929-2881\nreserve a ride at least two hours ahead of time. operates m-f 7am-6:30pm.\n\n\npaso robles\n805-239-8747\nreserve a ride at least two hours ahead of time. operates m-f 7am-1pm.\n\n\nshandon\n805-541-2544\nreserve a ride by noon the day ahead of time. operates m,w,f 8am-5pm.\n\n\ntempleton\n805-541-2544\nreserve a ride by noon the day ahead of time. operates tu,th 8am-5pm.\n\n\ngreyhound and trailways operate between-cities bus routes.\namtrak has rail lines and buses that run all over the u.s.\nalthough they are best-known for their trains, their bus service can often out-compete trailways and greyhound on price, speed, and convenience.\nyou can catch these trains and buses from the following locations in slo county:\n\n\n\nlocation\ngreyhound\ntrailways\namtrak train\namtrak bus\n\n\n\natascadero amtrak bus stop, 6000 capistrano ave., atascadero\nyes\nno\nno\nyes\n\n\ngrover beach amtrak station, 180 w. grand ave., grover beach\nyes\nno\nyes\nyes\n\n\npaso robles train station, 800 pine st., paso robles\nyes\nno\nyes\nyes\n\n\ncal poly, 1 grand ave., slo\nyes\nno\nno\nyes\n\n\nrailroad museum, 1940 santa barbara ave., slo\nyes\nyes\nno\nno\n\n\ntrain station, 1011 railroad ave., slo \nyes\nno\nyes\nyes\n\n\nrecent refugees from other countries can also get help with transportation from slo for home. \ntransportation resources for seniors\nmany transit services offer reduced fares for seniors.\npeople aged 80 and older ride for free on all slo rta and slo transit routes. \nin addition, there are some transit options specifically for seniors.\nfor example, the senior go! service serves people aged 65 and up. \nit serves all of slo county, and all trips must be in slo county. \ncall to book a curb-to-curb ride two to three days in advance. \nyou can reserve up to four round-trips per month. \nthe cost is $5 for short trips (0-20 miles) or $10 for longer trips. \nthe cambria community bus is a free service for seniors (aged 60 and up) and disabled people in the cambria/san simeon area. \ncall 805-927-4173 (español 805-975-5724) m-f 9-11am at least one day in advance to make a reservation for a ride. \nrides are door-to-door service and can include multiple stops. \nthe bus only operates on weekdays 8am-4:30pm, and in the local area (except for tuesdays, when the bus can also do trips to slo city). \nthe cayucos senior van is a similar program for residents of cayucos.\nit prioritizes transportation to medical appointments, but can also sometimes handle other needs. \nit operates m-f 9am-4pm. \ncall 805-995-3543 to make an appointment at least 48 hours ahead of time. \ncommunity partners in caring has volunteers who can give seniors free rides to and from medical appointments, food banks and meal sites, or other services. \nthey operate in nipomo and the five-cities area, as well as santa barbara county. \ntransportation to medical appointments\nthe cencal/medi-cal shuttle offers free, door-to-door transportation to medical appointments for people who are enrolled in medi-cal and who cannot use public transportation to get to their appointments. \nif you expect you will need to stop at a pharmacy after your appointment, say so when you make your shuttle reservation, and they can arrange that also. \nmake a shuttle reservation at least two days before your medical appointment by calling 855-659-4600 m-f 7am-5pm. \nif you are a community health centers of the central coast (chc) patient, and you need a ride to your chc appointment, you can get shuttle service. \nthe chc shuttle collects you at your location and takes you to the clinic, then returns you after your appointment. \nto use the shuttle, you should have a chc appointment and live in the area of the chc clinic. \nchc may also give you an rta bus pass to help you get to your appointment. \nmake a reservation at least 48 hours before your appointment by calling 877-743-3242. \nveterans who travel to va health care facilities for va-authorized appointments can get free curb-to-curb shuttle service through veterans transportation service (vts). \nanother option is the \"veterans express shuttle\" operated by ride-on transportation (call 805-541-8747 two to three days before your appointment). \nthere is also regularly-scheduled bus service between the slo veteran's memorial building (801 grand ave.) and the west los angeles va medical center (wla). \nthis bus is free to anyone with an appointment at the va. \nschedule a bus reservation through vts. \nit leaves slo at 6am, arrives at wla at 11:15am, leaves wla at 3:25pm and returns to slo at 8:30pm. \nthe american cancer society's \"road to recovery\" program offers free rides to and from cancer-related medical appointments.\ncall several days in advance of your appointment to reserve your ride. \nbicycles\nthe bike kitchen in slo city can help you learn how to do maintenance and repairs on your bicycle, and can give you access to the tools and supplies you need. \nthey also sell refurbished bicycles at low prices. \nvisit their website to see their current schedule. \nthey charge a small fee ($10/hr) to use their repair/maintenance services. \nhere are some tips for keeping your bike safe if you are camping:\n\nlock bikes together when you camp with multiple people.\nposition your bike near your tent and thread one of the tent's guy-lines through the wheel, so your tent will shake if someone moves the bike.\nuse multiple locks (for example, a u-lock and a cable). avoid using cable locks only, as they are relatively easy to break.\nconsider using a lock that makes an audible alarm when it is tampered with.\n\nautomobile insurance and repair\na car must be insured to be legally driven in california. \ncalifornia has a state-sponsored, low-cost auto insurance program. \nto qualify, you must have a valid california driver's license, a low income (for a single person, under $39,125 per year), a vehicle that is worth no more than $25,000, and have:\n\n\nno more than one at-fault, property-damage-only accident or no more than one point for a moving violation in the past three years,\nno at-fault accidents involving bodily injury or death on a driving record in the previous three years, and\nno felony or misdemeanor convictions for a violation of the vehicle code on your motor vehicle driving record.\n\nyou can apply for this insurance on-line at mylowcostauto.com or by calling 866-602-8861. \nthe family care network can help you pay for car repairs, payments, and gas if you're broke.\nyou may first need to get a referral from a slo county department of social services employment resource specialist.\nthe california bureau of automotive repair (cap)'s \"consumer assistance program\" can help you fix your car so that it satisfies california emissions standards. \nthis program will pay for up to $1,450 in necessary repairs at a star test-and-repair center for model year 1996 or newer vehicles, or up to $1,100 for 1976-1995 vehicles. \nto qualify, you must verify that you have a household income below 225% of the federally-set poverty level, and your vehicle must fail its biennial smog check. \nyou can apply online at their website or by calling 866-272-9642 (m-f 8:30am-5pm). \n\nsee emergency financial help for programs that can give you financial assistance to pay for emergency expenses like car repairs.\n\nsafe parking for people living in vehicles\n\nsee legal camping, safe parking, and rv parks to learn about options for places to park safely and legally if you live in your vehicle.\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "public-transit",
+    "title": "Public Transit",
+    "content": "there are many public transit options in slo county.\nthe rideshare website and the 511 phone service can give you an overview of most of them and can help you plan your trips.\nthe slo regional transit authority system includes several bus routes that connect cities in slo county.\nthey also govern the city bus routes in morro bay and paso robles, and the dial-a-ride and runabout paratransit services.\nyou can buy bus passes on the bus or by using the token transit app.\nthere are discounts for seniors (age 65+), medicare card holders, and people with disabilities. \nyou must apply in person at the rta office to get a discount card. \npeople over the age of 80 and people with an ada-certified disability ride free. \n\n\n\nrta line\ndestinations\n\n\n\n9\nsan miguel, paso robles, templeton, atascadero, santa margarita, slo\n\n\n10\nsanta maria, nipomo, arroyo grande, pismo beach, slo\n\n\n12\nlos osos, morro bay, slo\n\n\n15\nsan simeon, cambria, cayucos, morro bay\n\n\n21\npismo beach, arroyo grande, grover beach\n\n\n24\npismo beach, grover beach\n\n\n27 & 28\ngrover beach, arroyo grande, oceano\n\n\na & b\npaso robles\n\n\navila-pismo beach trolley\nport san luis, avila beach, pismo beach\n\n\nmorro bay transit\nmorro bay\n\n\nrunabout paratransit is a county-wide transit service for people who cannot always use the fixed-route slo rta buses because of disability. \nthis service will take you door-to-door within ¾-mile of the rta fixed routes during the same hours rta operates. \none personal care attendant can accompany you free-of-charge. \nyou have to apply and have an in-person interview to be eligible for this service (see slo regional transit authority for contact information). \nafter you register, make ride reservations 1-7 days in advance by calling 805-541-2544. \nrides are not free; they cost about twice as much as ordinary rta rides. \nhowever people who qualify to use runabout paratransit can also ride the ordinary rta service for free. \nslo transit is the san luis obispo city bus system.\nyou can use the slo transit riderportal website or phone app (iphone, android) to view routes and to see when the next bus is due to arrive.\nyou can buy bus passes on the bus or by using the token transit app.\n(another option for viewing bus arrival times and for planning travel is the moovit app.)\nthere are discounts for seniors and disabled people (you may need to apply for a special card), and for children. \nif you buy a regional day pass from slo rta, that also lets you ride slo transit buses. \nsome service providers can give you a bus pass if you cannot afford to buy one.\nfor example, catholic charities \nand the society of st. vincent de paul often have bus passes available to people who need them. \nclients of tri-counties regional center can get bus passes from them. \nthe family care network can help you get a bus pass if you cannot afford one on your own (you may first need to get a referral from a slo county department of social services employment resource specialist). \nyou can find carpool options locally by using the irideshare web application, a free program for slo county commuters.\nthe application matches commuters based on their locations, routes, destinations, and schedules to try to match them into compatible carpools.\nif you register for irideshare and you commute to work by walking, biking, taking the bus, or in a carpool or vanpool, and you need to get home from work in some other way (for example, because the carpool is leaving at the wrong time, or because your bike broke), the guaranteed ride home program will pay for your taxi, uber, or lyft ride home.\n(you need to register for their commuter club program, save your ride payment receipt, and you can only get a limited number of guaranteed rides home.) \nthere are dial-a-ride services in atascadero, morro bay, nipomo, paso robles, shandon, and templeton.\nthey typically offer curb-to-curb service and charge $2.25-8.00 each way (sometimes less for seniors, disabled people, and children): \n\n\n\n\ndial-a-ride service\nphone number\nnotes\n\n\n\natascadero\n805-466-7433\noperates m-f 7:30am-3:30pm.\n\n\nmorro bay\n805-541-2228 x3\nmust be within ¾-mile of a transit bus route. call m-f 7:30am-6:30pm to request a ride.\n\n\nnipomo\n805-929-2881\nreserve a ride at least two hours ahead of time. operates m-f 7am-6:30pm.\n\n\npaso robles\n805-239-8747\nreserve a ride at least two hours ahead of time. operates m-f 7am-1pm.\n\n\nshandon\n805-541-2544\nreserve a ride by noon the day ahead of time. operates m,w,f 8am-5pm.\n\n\ntempleton\n805-541-2544\nreserve a ride by noon the day ahead of time. operates tu,th 8am-5pm.\n\n\ngreyhound and trailways operate between-cities bus routes.\namtrak has rail lines and buses that run all over the u.s.\nalthough they are best-known for their trains, their bus service can often out-compete trailways and greyhound on price, speed, and convenience.\nyou can catch these trains and buses from the following locations in slo county:\n\n\n\nlocation\ngreyhound\ntrailways\namtrak train\namtrak bus\n\n\n\natascadero amtrak bus stop, 6000 capistrano ave., atascadero\nyes\nno\nno\nyes\n\n\ngrover beach amtrak station, 180 w. grand ave., grover beach\nyes\nno\nyes\nyes\n\n\npaso robles train station, 800 pine st., paso robles\nyes\nno\nyes\nyes\n\n\ncal poly, 1 grand ave., slo\nyes\nno\nno\nyes\n\n\nrailroad museum, 1940 santa barbara ave., slo\nyes\nyes\nno\nno\n\n\ntrain station, 1011 railroad ave., slo \nyes\nno\nyes\nyes\n\n\nrecent refugees from other countries can also get help with transportation from slo for home. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "transportation-for-seniors",
+    "title": "Transportation Resources for Seniors",
+    "content": "many transit services offer reduced fares for seniors.\npeople aged 80 and older ride for free on all slo rta and slo transit routes. \nin addition, there are some transit options specifically for seniors.\nfor example, the senior go! service serves people aged 65 and up. \nit serves all of slo county, and all trips must be in slo county. \ncall to book a curb-to-curb ride two to three days in advance. \nyou can reserve up to four round-trips per month. \nthe cost is $5 for short trips (0-20 miles) or $10 for longer trips. \nthe cambria community bus is a free service for seniors (aged 60 and up) and disabled people in the cambria/san simeon area. \ncall 805-927-4173 (español 805-975-5724) m-f 9-11am at least one day in advance to make a reservation for a ride. \nrides are door-to-door service and can include multiple stops. \nthe bus only operates on weekdays 8am-4:30pm, and in the local area (except for tuesdays, when the bus can also do trips to slo city). \nthe cayucos senior van is a similar program for residents of cayucos.\nit prioritizes transportation to medical appointments, but can also sometimes handle other needs. \nit operates m-f 9am-4pm. \ncall 805-995-3543 to make an appointment at least 48 hours ahead of time. \ncommunity partners in caring has volunteers who can give seniors free rides to and from medical appointments, food banks and meal sites, or other services. \nthey operate in nipomo and the five-cities area, as well as santa barbara county. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "transportation-to-medical-appointments",
+    "title": "Transportation to Medical Appointments",
+    "content": "the cencal/medi-cal shuttle offers free, door-to-door transportation to medical appointments for people who are enrolled in medi-cal and who cannot use public transportation to get to their appointments. \nif you expect you will need to stop at a pharmacy after your appointment, say so when you make your shuttle reservation, and they can arrange that also. \nmake a shuttle reservation at least two days before your medical appointment by calling 855-659-4600 m-f 7am-5pm. \nif you are a community health centers of the central coast (chc) patient, and you need a ride to your chc appointment, you can get shuttle service. \nthe chc shuttle collects you at your location and takes you to the clinic, then returns you after your appointment. \nto use the shuttle, you should have a chc appointment and live in the area of the chc clinic. \nchc may also give you an rta bus pass to help you get to your appointment. \nmake a reservation at least 48 hours before your appointment by calling 877-743-3242. \nveterans who travel to va health care facilities for va-authorized appointments can get free curb-to-curb shuttle service through veterans transportation service (vts). \nanother option is the \"veterans express shuttle\" operated by ride-on transportation (call 805-541-8747 two to three days before your appointment). \nthere is also regularly-scheduled bus service between the slo veteran's memorial building (801 grand ave.) and the west los angeles va medical center (wla). \nthis bus is free to anyone with an appointment at the va. \nschedule a bus reservation through vts. \nit leaves slo at 6am, arrives at wla at 11:15am, leaves wla at 3:25pm and returns to slo at 8:30pm. \nthe american cancer society's \"road to recovery\" program offers free rides to and from cancer-related medical appointments.\ncall several days in advance of your appointment to reserve your ride. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "bicycles",
+    "title": "Bicycles",
+    "content": "the bike kitchen in slo city can help you learn how to do maintenance and repairs on your bicycle, and can give you access to the tools and supplies you need. \nthey also sell refurbished bicycles at low prices. \nvisit their website to see their current schedule. \nthey charge a small fee ($10/hr) to use their repair/maintenance services. \nhere are some tips for keeping your bike safe if you are camping:\n\nlock bikes together when you camp with multiple people.\nposition your bike near your tent and thread one of the tent's guy-lines through the wheel, so your tent will shake if someone moves the bike.\nuse multiple locks (for example, a u-lock and a cable). avoid using cable locks only, as they are relatively easy to break.\nconsider using a lock that makes an audible alarm when it is tampered with.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "auto-insurance-and-repair",
+    "title": "Automobile Insurance and Repair",
+    "content": "a car must be insured to be legally driven in california. \ncalifornia has a state-sponsored, low-cost auto insurance program. \nto qualify, you must have a valid california driver's license, a low income (for a single person, under $39,125 per year), a vehicle that is worth no more than $25,000, and have:\n\n\nno more than one at-fault, property-damage-only accident or no more than one point for a moving violation in the past three years,\nno at-fault accidents involving bodily injury or death on a driving record in the previous three years, and\nno felony or misdemeanor convictions for a violation of the vehicle code on your motor vehicle driving record.\n\nyou can apply for this insurance on-line at mylowcostauto.com or by calling 866-602-8861. \nthe family care network can help you pay for car repairs, payments, and gas if you're broke.\nyou may first need to get a referral from a slo county department of social services employment resource specialist.\nthe california bureau of automotive repair (cap)'s \"consumer assistance program\" can help you fix your car so that it satisfies california emissions standards. \nthis program will pay for up to $1,450 in necessary repairs at a star test-and-repair center for model year 1996 or newer vehicles, or up to $1,100 for 1976-1995 vehicles. \nto qualify, you must verify that you have a household income below 225% of the federally-set poverty level, and your vehicle must fail its biennial smog check. \nyou can apply online at their website or by calling 866-272-9642 (m-f 8:30am-5pm). \n\nsee emergency financial help for programs that can give you financial assistance to pay for emergency expenses like car repairs.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "safe-parking",
+    "title": "Safe Parking for People Living in Vehicles",
+    "content": "\nsee legal camping, safe parking, and rv parks to learn about options for places to park safely and legally if you live in your vehicle.\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "clothing",
+    "title": "Clothing",
+    "content": "free clothes\nthe 40 prado homeless services center has some free clothing available, \nas does the associated outreach and engagement services. \nthe los osos cares resource center can give eligible people vouchers to purchase clothing with. \nel camino homeless organization (echo) has clothing, shoes, blankets, and sleeping bags for people who come to its shower program (m-f 4-5:30pm at their atascadero and paso robles locations). \n\n\nshower the people gives you new socks, underwear, and a t-shirt. \n\n\nslo grassroots has clothing to give away, but (as of december 2025) they are still looking for an office to operate from.\nyou have to make an appointment with them to view their inventory. \nfree clothes for kids\nthe children's resource network of the central coast has free clothing (and school supplies, books, diapers, and other basic resources) for children from birth to age 18. \ncall their hotline, use the \"place a request\" form on their website, or visit during walk-in hours. \nthey also operate the \"traveling children's closet,\" \"the teen's closet,\" and \"outreach apparel\" at which schoolchildren can get clothes and other supplies they need. \nassistance league of slo county operates the \"operation school bell\" program, which gives needy students credits with which they can shop for new retail school clothes. \nask authorities at the child's school to refer them to the program. \ncoats for kids of slo county holds a once-a-year (december) distribution in paso robles of cold-weather clothes like coats, jackets, sweaters, and sweatshirts. \nsee their website for details on the next distribution, or use their contact form or call 805-703-1762 with questions. \nthrift stores\nthrift stores sell second-hand (used) clothing at low prices.\narroyo grande:\n\nachievement house thrift store\n\natascadero:\n\nbrookside thrift\ngoodwill store\nnci affiliates thrift\n\ngrover beach:\n\ncalifornia cool thrift store\ngoodwill store\nsecond chances thrift store\nst. patrick's shamrock thrift\nst. barnabas thrift shop\n\nlos osos:\n\nabundance shop\n\nmorro bay:\n\nachievement house thrift store\nfoxy's thrift shop\n\npaso robles:\n\ngoodwill store\nnci affiliates thrift\n\nsan luis obispo:\n\nachievement house thrift store\nassistance league thrift store\nbargain boutique\nfred & betty's thrift store\ngoodwill outlet and goodwill store\nlumina thrift\nmission thrift\nslo thrift (not yet open as of november 2025)\nunited voluntary services thrift\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "free-clothes",
+    "title": "Free Clothes",
+    "content": "the 40 prado homeless services center has some free clothing available, \nas does the associated outreach and engagement services. \nthe los osos cares resource center can give eligible people vouchers to purchase clothing with. \nel camino homeless organization (echo) has clothing, shoes, blankets, and sleeping bags for people who come to its shower program (m-f 4-5:30pm at their atascadero and paso robles locations). \n\n\nshower the people gives you new socks, underwear, and a t-shirt. \n\n\nslo grassroots has clothing to give away, but (as of december 2025) they are still looking for an office to operate from.\nyou have to make an appointment with them to view their inventory. \nfree clothes for kids\nthe children's resource network of the central coast has free clothing (and school supplies, books, diapers, and other basic resources) for children from birth to age 18. \ncall their hotline, use the \"place a request\" form on their website, or visit during walk-in hours. \nthey also operate the \"traveling children's closet,\" \"the teen's closet,\" and \"outreach apparel\" at which schoolchildren can get clothes and other supplies they need. \nassistance league of slo county operates the \"operation school bell\" program, which gives needy students credits with which they can shop for new retail school clothes. \nask authorities at the child's school to refer them to the program. \ncoats for kids of slo county holds a once-a-year (december) distribution in paso robles of cold-weather clothes like coats, jackets, sweaters, and sweatshirts. \nsee their website for details on the next distribution, or use their contact form or call 805-703-1762 with questions. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "thrift-stores",
+    "title": "Thrift Stores",
+    "content": "thrift stores sell second-hand (used) clothing at low prices.\narroyo grande:\n\nachievement house thrift store\n\natascadero:\n\nbrookside thrift\ngoodwill store\nnci affiliates thrift\n\ngrover beach:\n\ncalifornia cool thrift store\ngoodwill store\nsecond chances thrift store\nst. patrick's shamrock thrift\nst. barnabas thrift shop\n\nlos osos:\n\nabundance shop\n\nmorro bay:\n\nachievement house thrift store\nfoxy's thrift shop\n\npaso robles:\n\ngoodwill store\nnci affiliates thrift\n\nsan luis obispo:\n\nachievement house thrift store\nassistance league thrift store\nbargain boutique\nfred & betty's thrift store\ngoodwill outlet and goodwill store\nlumina thrift\nmission thrift\nslo thrift (not yet open as of november 2025)\nunited voluntary services thrift\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "laundry",
+    "title": "Laundry",
+    "content": "the 40 prado homeless services center offers free laundry facilities every day from 8am to 4pm. \nyou do not have to be staying overnight there to use the laundry facilities, but you do need to complete their intake process first. \nthe el camino homeless organization (echo) opens the laundry facility at its paso robles location every wednesday from 10am-6pm, at which outreach clients can do a single load of laundry for free (they provide detergent). \nlaundry love operates at a los osos commercial laundry on the last wednesday of the month (check their website for the latest schedule). \nthey allow anyone to do two free loads of laundry (five loads for a family), plus bedding. \nthey provide the coins to feed the machines and the laundry detergent and dryer sheets. \n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "showers-and-hygiene",
+    "title": "Showers and Hygiene",
+    "content": "free shower services\nshower the people offers free showers from its mobile shower trailer several times a week in several locations in slo city and in grover beach. \nthey provide towels and soap. \nguests also receive free toiletries, and new socks, underwear, and t-shirts. \nthey operate rain-or-shine all year long including holidays. \n805 street outreach is a similar program that operates every monday in morro bay. \nthey also have clothing and food for guests. \nthe 40 prado homeless services center in slo city has shower facilities that it makes available to both its overnight and its day guests. \nyou do not have to be a resident there to use the showers, but you do have to undergo their intake process. \nthe el camino homeless organization (echo) offers hot showers five evenings a week (m-f 4-5:30pm) to anyone in need at both their atascadero and their paso robles locations. \nthey give you toiletries, and they also have clothing, shoes, blankets, and sleeping bags. \ncoin-operated or gym membership options\nthe slo county ymca has shower facilities at their southwood ave. gym in slo city.\nthese are available to gym members.\nmembership is not free, but the ymca policy is that \"no one is denied membership because of inability to pay.\" \nask them about options for people with low incomes.\nthe slo swim center, which costs $4.75 to enter \n(but is free to ymca members during public swim session times), \nhas showers. \nsome slo county parks have coin-operated shower facilities, including coastal dunes rv park & campground, \nel chorro regional park campground, \nlopez lake recreation area, \noceano campground, \nand santa margarita lake recreation area \nthe port san luis harbor district \"coastal gateway multi-purpose room\" has coin-operated showers. \nsome commercial gyms have showers.\nfor example, a $15 day pass to the pismo beach athletic club provides access to all of their facilities, including showers. \nsome medicare supplement plans have a \"silver sneakers\" program with which you can get free gym memberships. \n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "free-showers",
+    "title": "Free Shower Services",
+    "content": "shower the people offers free showers from its mobile shower trailer several times a week in several locations in slo city and in grover beach. \nthey provide towels and soap. \nguests also receive free toiletries, and new socks, underwear, and t-shirts. \nthey operate rain-or-shine all year long including holidays. \n805 street outreach is a similar program that operates every monday in morro bay. \nthey also have clothing and food for guests. \nthe 40 prado homeless services center in slo city has shower facilities that it makes available to both its overnight and its day guests. \nyou do not have to be a resident there to use the showers, but you do have to undergo their intake process. \nthe el camino homeless organization (echo) offers hot showers five evenings a week (m-f 4-5:30pm) to anyone in need at both their atascadero and their paso robles locations. \nthey give you toiletries, and they also have clothing, shoes, blankets, and sleeping bags. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "pay-showers",
+    "title": "Coin-Operated or Gym Membership Options",
+    "content": "the slo county ymca has shower facilities at their southwood ave. gym in slo city.\nthese are available to gym members.\nmembership is not free, but the ymca policy is that \"no one is denied membership because of inability to pay.\" \nask them about options for people with low incomes.\nthe slo swim center, which costs $4.75 to enter \n(but is free to ymca members during public swim session times), \nhas showers. \nsome slo county parks have coin-operated shower facilities, including coastal dunes rv park & campground, \nel chorro regional park campground, \nlopez lake recreation area, \noceano campground, \nand santa margarita lake recreation area \nthe port san luis harbor district \"coastal gateway multi-purpose room\" has coin-operated showers. \nsome commercial gyms have showers.\nfor example, a $15 day pass to the pismo beach athletic club provides access to all of their facilities, including showers. \nsome medicare supplement plans have a \"silver sneakers\" program with which you can get free gym memberships. \n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "health-medical-care",
+    "title": "Health & Medical Care",
+    "content": "in this section:\n\nemergency care\nurgent care options\nhealth insurance\nmedical and assistive devices\nprescription medicines\ndental care\nvision care and eyeglasses\nmental health\nreproductive health\npregnancy, childbirth, lactation\nchiropractic treatment\nresources for specific populations\npoison oak\nsunburn\n\n\nsee also the fitness subsection for information on exercise and fitness options.\n\nvituity cares mobile clinic is a free medical clinic that operates one day per month in slo city.\nit offers diagnosis, testing, and treatment, can write prescriptions, and usually also has free food and a small free clothing collection.\nemergency care\nwhen and how to call 911\ncall 911 immediately when someone needs emergency medical care that cannot wait.\nthis includes when a person:\n\ncannot breathe or struggles severely to breathe\nhas no pulse or appears unconscious and unresponsive\nbleeds heavily and cannot stop the bleeding\nshows signs of stroke (sudden face drooping, arm weakness, or speech difficulty)\nexperiences chest pain that might indicate a heart attack\nhas a severe allergic reaction with swelling or breathing problems\nsuffers a serious injury\ntakes a dangerous overdose of a drug or poison\nhas a seizure (especially if it lasts longer than five minutes or if the person has never had a seizure before)\nhas a severe mental health crisis in which they are an immediate danger to themselves or others\n\nstay calm and speak clearly to the 911 dispatcher.\nthe dispatcher will guide you through the process, and may ask you for:\n\nyour exact location - give the full address, including apartment number, floor, or any access instructions. if you're unsure of the address, describe nearby landmarks or cross streets.\nthe nature of the emergency - briefly describe what happened and the person's current condition.\nthe patient's condition - report whether the person is conscious, breathing, and responsive. describe visible injuries or symptoms.\nyour relationship to the patient - state whether you are family, a friend, or a bystander.\nyour contact information - provide a phone number where responders can reach you.\n\ndo not hang up until the dispatcher tells you to.\nthe dispatcher may tell you how to provide care while you wait for help to arrive.\nif the situation changes while you wait, call 911 again immediately to update them.\nstay with the patient until help arrives, if it is safe for you to do so.\nchoose someone to watch for the ambulance and to guide responders to the location.\nemergency rooms\nthere are four emergency rooms in slo county:\n\narroyo grande community hospital (arroyo grande)\nadventist health sierra vista (slo)\nfrench hospital medical center (slo)\nadventist health twin cities (templeton)\n\nthese emergency rooms are open all day, every day.\ndo not worry if your medi-cal paperwork is not yet in order.\nunder the \"hospital presumptive eligibility\" program, in an emergency, hospitals will treat you as though you have medi-cal for up to two months while they work with you to determine your eligibility, if the following conditions hold:\n\nyou are uninsured and not receiving medi-cal.\nyou have a low monthly income.\nyou live in california.\nyou have not used the \"hospital presumptive eligibility\" program more than once in the past 12 months (more than twice for children).\n\nu.s. citizenship is not required. \nall four emergency rooms participate in the \"hospital presumptive eligibility\" program. \nurgent care options\nvisit an urgent care center when you have a medical problem that needs prompt attention but is not life-threatening.\nurgent care centers treat conditions that are too serious to wait for a doctor's appointment but that do not require emergency room services.\nthe wait is usually shorter than emergency rooms, and the cost is typically lower for non-emergency conditions.\nmost urgent care centers accept walk-ins, and some also allow appointments.\nbring your insurance card, identification, and a list of medications you take.\n\n\n\n\nurgent care location\nmedicare\nmedi-cal\n\n\n\ncommunity health centers of the central coast (arroyo grande)\nyes\nyes\n\n\ndignity health urgent care (atascadero)\nyes\nyes\n\n\ncarbon health urgent care (atascadero)\nyes\nno\n\n\nurgent care of atascadero\nyes\nno\n\n\nurgent care of morro bay\nyes\nno\n\n\ncarbon health urgent care (paso robles)\nyes\nno\n\n\ncommunity health centers of the central coast (paso robles)\nyes\nyes\n\n\nnorth county care minor emergency services (paso robles)\n?\n?\n\n\ndignity health urgent care (pismo beach)\nyes\nyes\n\n\nurgent care pismo beach\nyes\nno\n\n\ncottage urgent care (slo)\nyes\nyes\n\n\nfamily and industrial medical center (slo)\nyes\nno\n\n\nmedstop (slo)\nyes\nno\n\n\ncommunity health centers of the central coast (templeton - las tablas)\nyes\nyes\n\n\nhealth insurance\nmedi-cal (medicaid)\nmedi-cal, california's medicaid program, is a health insurance program for low-income people who meet certain eligibility requirements. \ncencal administers medi-cal in slo county. \nyou can search a list of local cencal health care providers at cencalhealth.org/members/provider-directory-for-members/.\nhomeless slo county residents who are enrolled in cencal health qualify for enhanced care management. \nthis helps you coordinate the care you need across multiple healthcare providers. \ncontact them if you want to apply or you want more details. \nyou can also apply in-person (walk-ins ok) at capslo's outreach and engagement services center. \nhow to apply for medi-cal\nyou can apply for medi-cal at www.coveredca.com or benefitscal.com. \nyou can get help applying from the slo county department of social services \nor catholic charities. \nto get help in indigenous mexican languages, call 805-483-1166, or visit mixteco.org/indigenous-interpreter-services/. \nif you are a patient of adventist health, you can get help from them by calling 844-827-5047. \nif you are a farm laborer, you may also be able to get help applying for medi-cal from the civil assistance program of the california farmworker foundation. \nprescription medication\nfor information about obtaining prescription medicine through medi-cal, contact medi-cal rx.\nto find a medi-cal rx pharmacy, visit medi-calrx.dhcs.ca.gov/home/find-a-pharmacy.\ndentists\ndentists are not provided through cencal but through medi-cal dental.\nfor information about dental benefits, contact med-cal dental.\nto find a medi-cal dental provider, see one of these resources:\n\ndenti-cal dental care dentist referral (800-322-6384)\n\"find a dentist\" at smile california\n\nmedicare and hicap\nmedicare is a government-provided health insurance program for people over age 65 and for people with long-term disabilities.\nlearn if you qualify for medicare by asking the social security administration.\nsee ssa.gov: \"check eligibility for social security benefits\" or visit in person.\nmedicare's many options can be confusing.\nhealth insurance counseling & advocacy program (\"hicap\") offers free and unbiased information about medicare and its options.\nhicap can help you:\n\nfind the best prescription drug plan\nfind and use prescription drug discount programs\nfile medicare denial appeals\nunderstand long-term care insurance options\n\nto use the local hicap program you must be eligible for medicare and you must be a resident of slo or santa barbara counties. \nthe hicap program is free. \nyou can also submit questions to them via a web form and get answers by email: \"ask a medicare question\"\ncovered california / obamacare\ncovered california is a free service that helps you to apply for affordable medical insurance in california.\nthis includes medi-cal/cencal but also a variety of other brand-name health insurance plans, which may be available to you for free or at a very low cost depending on your income and circumstances.\nvisit coveredca.com or call 800-300-1506 to learn more.\nva health care\nmilitary veterans may qualify for va health care.\nto learn if you qualify, how to apply, and details about your medical benefits package, call 877-222-8387, or visit va.gov: \"about va health benefits.\"\nsee also slo vet center, veterans administration outpatient clinic, and veterans services (slo county).\ncrowdfunding medical expenses\nif you expect to have high medical expenses that you cannot afford, you might try to raise the money through donations from others.\nthe help hope live program can help you establish a \"crowdfunding\" campaign to raise money this way.\nemergency funding\nif you need immediate funds to pay for a specific medical expense and you are not eligible for medi-cal or any other health insurance, consider the medically indigent services program.\ncall them to start the application process. \nif you are a patient of adventist health, you may qualify for their financial assistance program.\nask them in person for an application or contact them at 844-827-5047  or ahfinasst@ah.org.\n\nsee also the emergency financial needs section of this guide.\n\ntransportation to medical appointments\n\nsee transportation to medical appointments in the transportation section\n\nmedical and assistive devices\naccess central coast helps you find and afford assistive devices like wheelchairs, canes, walkers, scooters, modified telephones, and speech-generating devices. \nalliance for pharmaceutical access helps you get low-cost diabetic supplies (glucose test strips and meters, insulin syringes, etc.). \natascadero senior center, \nmorro bay senior center, \nand nipomo senior center \nhave free lending libraries of mobility aids and some other medical equipment.\nthe boyd bristol medical equipment program helps veterans and their family members get free loans of medical equipment like walkers, canes, scooters, and crutches. \nthey can also deliver these devices to you. \ncambria's anonymous neighbors (can) provides loans of medical equipment including wheelchairs, walkers, canes, grab bars, and life alert devices to people on the north coast. \ncalifornia connect can loan you, for free, assistive telecommunications equipment that helps if you have functional limitations of hearing, vision, mobility, speech, and/or interpretation of information. \nthe california department of rehabilitation can give you a free speech-generating device if you have difficulty speaking. \n\n\nthe central coast assistive technology center allows you to try, and helps you learn to use, assistive technologies including vision/hearing technologies and ergonomics. \nthey also help you access a no-cost lending library of assistive technology devices (myatprogram.org).\n\n\npathpoint has a lending library of assistive technology devices for people with developmental disabilities. \nslo noor foundation helps uninsured people get low-cost diabetes monitoring and treatment supplies. \nsouth bay seniors people helping people can loan you assistive technology like walkers and wheelchairs. \ncall them or visit their office for details. \nprescription medicines\ndrug discount plans allow you to get prescriptions at reduced prices.\nyou can get help finding the best discount plans for you from alliance for pharmaceutical access, \nhealth insurance counseling & advocacy program (\"hicap\"), \nneedymeds, \nor united way. \nfor answers about medi-cal/cencal prescription benefits, contact medi-cal rx.\nto find a medi-cal rx pharmacy, visit medi-calrx.dhcs.ca.gov: \"find a pharmacy\".\nthe healthcare for the homeless program dispenses some medications directly, without you having to visit a pharmacy. \nslo noor foundation helps people who are uninsured (or whose insurance does not cover prescriptions) get free or low-cost prescription medications. \ncuesta college students can get over-the-counter and some prescription medicines (many free of charge) from student health services. \ndental care\ncentral coast dental society maintains a list of dentists who offer reduced rates for people in financial hardship.\ncommunity health centers offers dental care at its offices in nipomo, oceano, templeton (las tablas), and at 40 prado in slo. \nslo noor foundation has a dental clinic. \n\nsee medi-cal: dentists above to learn how to find a medi-cal dental provider.\n\nvision care\nthe community health centers offices in nipomo, paso robles, and at 260 station way in arroyo grande specialize in optometry. \neyecare america offers a free eye exam and follow-up ophthalmology treatment to uninsured and underinsured adults. \nslo noor foundation has a vision care clinic. \neyeglasses\nthe american academy of ophthalmology maintains a list of sources of free and low-cost eyeglasses.\nyou can find a list of medi-cal opticians at provdir.cencalhealth.org.\nmental health\nyou can get 24-hour mental health support from slo hotline (805-783-0607, or text 741741).\n\nfor mental health emergencies, see emergency care and emergency contacts.\n\nthe mental health evaluation team / mobile crisis team and mobile crisis unit respond to acute mental health needs.\nsan luis obispo counseling service at cal poly and community counseling center offer low- or no-cost mental health counseling.\na community health centers primary care physician can refer you to chc-provided mental health counseling or psychiatry, which happens over the phone or through internet videoconferencing. \ncuesta college students can get mental health therapy through student health services. \nadult mental health outpatient treatment (via slo county mental health services) \nand transitions mental health association \nand its homeless outreach full service partnership \noffer mental health evaluation & treatment, including programs specifically for homeless people.\nthe healthcare for the homeless program at capslo's 40 prado homeless services center includes mental health counseling and treatment. \nslo hub offers weekly mental health therapy sessions to its clients. \nlife steps foundation \nand pathpoint \nhave some services for people with mental health disorders and/or developmental disabilities.\ntri-county glad offers some mental health services to people who are deaf or hard of hearing. \nthe veterans administration outpatient clinic offers mental health care to qualifying u.s. military veterans.\nthey say: \"all va health care facilities offer same-day help. you may qualify even without enrolling in va health care.\" \nand slo vet center offers confidential counseling and other mental health care to combat veterans (and certain other veterans) and to victims of military sexual trauma. \nreproductive health\nthe center for health and prevention offers contraception, std testing and treatment, uti/yeast infection testing and treatment, genital exams, pap smears, and menopausal services. \ncuesta college students can get reproductive/sexual healthcare and referrals (for example for birth control, emergency contraception, and sti testing) from student health services. \nthe healthcare for the homeless program offers contraceptives, hiv screening and education, ob/gyn services, and std testing. \nplanned parenthood offers abortion, birth control, emergency contraception, hiv/std testing and treatment, help with various sexual and reproductive concerns, and no-cost family planning services. \nthe slo county public health department offers std testing and birth control. \npregnancy, childbirth, lactation\nadventist health (805-434-4644) \nand french hospital (805-541-2229) \neach offer free breastfeeding support by phone.\nthe center for health and prevention offers pregnancy testing and counseling. \ncommunity health centers of the central coast's 1057 e. grand ave. (arroyo grande), 1551 bishop st. (slo), and 292 posada ln. (templeton) locations offer the wellness pregnancy program / comprehensive perinatal services program. \n\n\nplanned parenthood offers pregnancy testing and planning, and prenatal and postpartum services. \npregnancy & parenting support offers maternity clothes, nursing supplies, diapers, formula, and referrals. \nthe women, infants, and children (wic) program offers breastfeeding support. \nchiropractic treatment\nthe community health centers of the central coast offices in arroyo grande (260 station way and 1205 e. grand ave.), atascadero, cambria, nipomo, oceano, paso robles, san miguel, templeton (las tablas), and slo (77 casa st. and 1551 bishop st.) offer chiropractic treatment. \nsurgery\nthe csf medical non profit foundation helps medically uninsured people obtain life-saving surgical procedures. \nthe recuperative care program gives you a place to recover from surgery if your health would be compromised by an unstable living situation. \nask your doctor to refer you to that program. \nmedical resources for specific populations\nchildren\ncalifornia children's services pays for and helps arrange doctor visits, hospital stays, surgery, physical therapy, tests, medical equipment, etc. for children and youths whose parents otherwise could not afford it. \nthe community health centers offices at 260 station way in arroyo grande, in nipomo, oceano, paso robles, templeton (las tablas), and at 77 casa st. in slo offer pediatric services. \nthe healthcare for the homeless program offers pediatric care and well child check-ups. \ninfantsee helps you get a free eye/vision test for infants. \ntolosa children's dental center (805-592-2445) accepts medi-cal \nor sliding-scale cash payments. \nunitedhealthcare children's foundation helps pay for medical expenses that are not covered by a child's family's commercial health insurance. \nthe child must be 16 or younger, with a u.s. social security number. \nthe need must be documented by a physician, and the child must be covered by commercial health insurance. \nthe women, infants, and children (wic) program gives food benefits to low-income women who have recently given birth. \npeople with diabetes\nalliance for pharmaceutical access\nand slo noor foundation \ncan help you get low-cost diabetes supplies.\ndignity health leads a free diabetes support group on zoom (internet video conferencing) and in-person every three months. \ncall 805-597-6780 or email angela.fissell@commonspirit.org for details. \nthe healthcare for the homeless program offers diabetes testing and care. \nslo noor foundation offers nutrition education & lifestyle coaching for uninsured people with diabetes or prediabetes. \npeople with disabilities\ncalifornia connect can loan you, for free, assistive telecommunications equipment that helps if you have functional limitations of hearing, vision, mobility, speech, and/or interpretation of information. \nthe california department of rehabilitation helps people with disabilities find or keep employment and live independently. \nthey can help you navigate disability and benefits programs, obtain assistive technologies, and get help with childcare and transportation.\ndisability rights california helps you understand and defend your legal rights as a disabled person. \nthe life steps foundation has resources for people with cerebral palsy, mild intellectual disability, mental health disorders, traumatic brain injury, down syndrome, and spectrum disorders. \npathpoint also has services for people with developmental disabilities. \nif you use american sign language, lifesigns can provide an interpreter to accompany you at your medical appointments. \ntri-county glad can help with telephone call interpreting. \npeople with hiv or hepatitis-c\nthe access support network has a variety of services for people impacted by hiv and hep-c. \nthese include testing, treatment, benefits counseling, help with insurance, harm reduction (including narcan and suboxone), infection prevention, and wound care. \nthe center for health & prevention offers hiv/hep-c testing. \nseniors\n\n\nthe central coast commission for senior citizens offers a variety of services for seniors, including senior connection (an information and referral service), the central coast aging & disability resource center, and the health insurance counseling & advocacy program.\nthey can help you with nutrition and meal services, transportation, and care management.\nteens and youth\ncommunity action partnership san luis obispo (capslo)'s teen wellness program includes health coaching, strength classes, mindfulness workshops, and reproductive health education. \nwomen\nthe center for health & prevention offers breast exams, referrals for free mammograms, pap smears, and menopausal services. \nthe community health centers offices at 1057 e. grand ave. in arroyo grande, in nipomo, at 1551 bishop st. in slo, and at 292 posada ln. in templeton specialize in women's health. \n\n\nslo noor foundation has a women's mobile health unit. \npoison oak\npoison oak is a common plant in slo county and grows everywhere from shaded wet creek beds to dry sunny hillsides. \nit is a shrub or vine and sometimes also climbs trees and so can appear to be tree branches. \nits leaves appear in groups of three, but they can have a variety of shapes and colors (dark to pale green, pale orange, bright red). \nthe plants sometimes also display clusters of tiny green, pale, or brown fruits. \n\n\n\n\n\n\n\nthe plant exudes an oil that causes a skin rash in people who touch it. \nyou do not have to touch the plant to be affected: you just need to touch the oil, which can rub off onto clothing, pet fur, or other items and may remain poisonous for years. \nif you have been near a fire in which poison oak plants were burned, you may be exposed to the oil through the smoke. \nyou can prevent the rash by washing your skin thoroughly as soon as possible after exposure and by washing any clothing or other items that may be carrying the oil. \nrubbing alcohol or detergent soaps can be helpful in removing oils. \nthe rash typically appears 12-48 hours, or even several days after exposure. \nit is typically very itchy, and sometimes blisters.\nyou can treat the rash with over-the-counter steroid (such as hydrocortisone) creams, calamine lotion, or antihistamines. \nif you have trouble breathing or swallowing, you may have inhaled some oils (for example from smoke) and you may be experiencing severe respiratory irritation. \nin such a case you should seek medical attention.\nsunburn\nsunburn is painful. \nit also can make you fatigued and more susceptible to infection. \nin the long run it can put you at higher risk of developing skin cancer. \nhomeless people are more prone to sunburn because they have fewer options to escape the mid-day sun.\nyou can reduce your risk of sunburn by finding shady places to rest during the day, by wearing more thoroughly-covering clothing like long-sleeved shirts and broad-brimmed hats, and by applying sunscreen. \nask homeless service providers if they have any sunscreen they can give you. sometimes they do.\n\nsee the clothing section of this guide for some tips on where to find free or low-cost clothing.\n\nif you develop a sunburn, you can get some relief with over-the-counter salves and creams, or just by keeping the area moist (perhaps with a dampened cloth). \nif you have blisters that break, keep the area clean and covered with a bandage. \nif you notice increasing redness that spreads beyond the area of the burn, or pus, or if you develop a fever, seek medical care as this may indicate an infection. \n\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "emergency-care",
+    "title": "Emergency Care",
+    "content": "when and how to call 911\ncall 911 immediately when someone needs emergency medical care that cannot wait.\nthis includes when a person:\n\ncannot breathe or struggles severely to breathe\nhas no pulse or appears unconscious and unresponsive\nbleeds heavily and cannot stop the bleeding\nshows signs of stroke (sudden face drooping, arm weakness, or speech difficulty)\nexperiences chest pain that might indicate a heart attack\nhas a severe allergic reaction with swelling or breathing problems\nsuffers a serious injury\ntakes a dangerous overdose of a drug or poison\nhas a seizure (especially if it lasts longer than five minutes or if the person has never had a seizure before)\nhas a severe mental health crisis in which they are an immediate danger to themselves or others\n\nstay calm and speak clearly to the 911 dispatcher.\nthe dispatcher will guide you through the process, and may ask you for:\n\nyour exact location - give the full address, including apartment number, floor, or any access instructions. if you're unsure of the address, describe nearby landmarks or cross streets.\nthe nature of the emergency - briefly describe what happened and the person's current condition.\nthe patient's condition - report whether the person is conscious, breathing, and responsive. describe visible injuries or symptoms.\nyour relationship to the patient - state whether you are family, a friend, or a bystander.\nyour contact information - provide a phone number where responders can reach you.\n\ndo not hang up until the dispatcher tells you to.\nthe dispatcher may tell you how to provide care while you wait for help to arrive.\nif the situation changes while you wait, call 911 again immediately to update them.\nstay with the patient until help arrives, if it is safe for you to do so.\nchoose someone to watch for the ambulance and to guide responders to the location.\nemergency rooms\nthere are four emergency rooms in slo county:\n\narroyo grande community hospital (arroyo grande)\nadventist health sierra vista (slo)\nfrench hospital medical center (slo)\nadventist health twin cities (templeton)\n\nthese emergency rooms are open all day, every day.\ndo not worry if your medi-cal paperwork is not yet in order.\nunder the \"hospital presumptive eligibility\" program, in an emergency, hospitals will treat you as though you have medi-cal for up to two months while they work with you to determine your eligibility, if the following conditions hold:\n\nyou are uninsured and not receiving medi-cal.\nyou have a low monthly income.\nyou live in california.\nyou have not used the \"hospital presumptive eligibility\" program more than once in the past 12 months (more than twice for children).\n\nu.s. citizenship is not required. \nall four emergency rooms participate in the \"hospital presumptive eligibility\" program. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "urgent-care",
+    "title": "Urgent Care Options",
+    "content": "visit an urgent care center when you have a medical problem that needs prompt attention but is not life-threatening.\nurgent care centers treat conditions that are too serious to wait for a doctor's appointment but that do not require emergency room services.\nthe wait is usually shorter than emergency rooms, and the cost is typically lower for non-emergency conditions.\nmost urgent care centers accept walk-ins, and some also allow appointments.\nbring your insurance card, identification, and a list of medications you take.\n\n\n\n\nurgent care location\nmedicare\nmedi-cal\n\n\n\ncommunity health centers of the central coast (arroyo grande)\nyes\nyes\n\n\ndignity health urgent care (atascadero)\nyes\nyes\n\n\ncarbon health urgent care (atascadero)\nyes\nno\n\n\nurgent care of atascadero\nyes\nno\n\n\nurgent care of morro bay\nyes\nno\n\n\ncarbon health urgent care (paso robles)\nyes\nno\n\n\ncommunity health centers of the central coast (paso robles)\nyes\nyes\n\n\nnorth county care minor emergency services (paso robles)\n?\n?\n\n\ndignity health urgent care (pismo beach)\nyes\nyes\n\n\nurgent care pismo beach\nyes\nno\n\n\ncottage urgent care (slo)\nyes\nyes\n\n\nfamily and industrial medical center (slo)\nyes\nno\n\n\nmedstop (slo)\nyes\nno\n\n\ncommunity health centers of the central coast (templeton - las tablas)\nyes\nyes\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "health-insurance",
+    "title": "Health Insurance",
+    "content": "medi-cal (medicaid)\nmedi-cal, california's medicaid program, is a health insurance program for low-income people who meet certain eligibility requirements. \ncencal administers medi-cal in slo county. \nyou can search a list of local cencal health care providers at cencalhealth.org/members/provider-directory-for-members/.\nhomeless slo county residents who are enrolled in cencal health qualify for enhanced care management. \nthis helps you coordinate the care you need across multiple healthcare providers. \ncontact them if you want to apply or you want more details. \nyou can also apply in-person (walk-ins ok) at capslo's outreach and engagement services center. \nhow to apply for medi-cal\nyou can apply for medi-cal at www.coveredca.com or benefitscal.com. \nyou can get help applying from the slo county department of social services \nor catholic charities. \nto get help in indigenous mexican languages, call 805-483-1166, or visit mixteco.org/indigenous-interpreter-services/. \nif you are a patient of adventist health, you can get help from them by calling 844-827-5047. \nif you are a farm laborer, you may also be able to get help applying for medi-cal from the civil assistance program of the california farmworker foundation. \nprescription medication\nfor information about obtaining prescription medicine through medi-cal, contact medi-cal rx.\nto find a medi-cal rx pharmacy, visit medi-calrx.dhcs.ca.gov/home/find-a-pharmacy.\ndentists\ndentists are not provided through cencal but through medi-cal dental.\nfor information about dental benefits, contact med-cal dental.\nto find a medi-cal dental provider, see one of these resources:\n\ndenti-cal dental care dentist referral (800-322-6384)\n\"find a dentist\" at smile california\n\nmedicare and hicap\nmedicare is a government-provided health insurance program for people over age 65 and for people with long-term disabilities.\nlearn if you qualify for medicare by asking the social security administration.\nsee ssa.gov: \"check eligibility for social security benefits\" or visit in person.\nmedicare's many options can be confusing.\nhealth insurance counseling & advocacy program (\"hicap\") offers free and unbiased information about medicare and its options.\nhicap can help you:\n\nfind the best prescription drug plan\nfind and use prescription drug discount programs\nfile medicare denial appeals\nunderstand long-term care insurance options\n\nto use the local hicap program you must be eligible for medicare and you must be a resident of slo or santa barbara counties. \nthe hicap program is free. \nyou can also submit questions to them via a web form and get answers by email: \"ask a medicare question\"\ncovered california / obamacare\ncovered california is a free service that helps you to apply for affordable medical insurance in california.\nthis includes medi-cal/cencal but also a variety of other brand-name health insurance plans, which may be available to you for free or at a very low cost depending on your income and circumstances.\nvisit coveredca.com or call 800-300-1506 to learn more.\nva health care\nmilitary veterans may qualify for va health care.\nto learn if you qualify, how to apply, and details about your medical benefits package, call 877-222-8387, or visit va.gov: \"about va health benefits.\"\nsee also slo vet center, veterans administration outpatient clinic, and veterans services (slo county).\ncrowdfunding medical expenses\nif you expect to have high medical expenses that you cannot afford, you might try to raise the money through donations from others.\nthe help hope live program can help you establish a \"crowdfunding\" campaign to raise money this way.\nemergency funding\nif you need immediate funds to pay for a specific medical expense and you are not eligible for medi-cal or any other health insurance, consider the medically indigent services program.\ncall them to start the application process. \nif you are a patient of adventist health, you may qualify for their financial assistance program.\nask them in person for an application or contact them at 844-827-5047  or ahfinasst@ah.org.\n\nsee also the emergency financial needs section of this guide.\n\ntransportation to medical appointments\n\nsee transportation to medical appointments in the transportation section\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "medical-and-assistive-devices",
+    "title": "Medical and Assistive Devices",
+    "content": "access central coast helps you find and afford assistive devices like wheelchairs, canes, walkers, scooters, modified telephones, and speech-generating devices. \nalliance for pharmaceutical access helps you get low-cost diabetic supplies (glucose test strips and meters, insulin syringes, etc.). \natascadero senior center, \nmorro bay senior center, \nand nipomo senior center \nhave free lending libraries of mobility aids and some other medical equipment.\nthe boyd bristol medical equipment program helps veterans and their family members get free loans of medical equipment like walkers, canes, scooters, and crutches. \nthey can also deliver these devices to you. \ncambria's anonymous neighbors (can) provides loans of medical equipment including wheelchairs, walkers, canes, grab bars, and life alert devices to people on the north coast. \ncalifornia connect can loan you, for free, assistive telecommunications equipment that helps if you have functional limitations of hearing, vision, mobility, speech, and/or interpretation of information. \nthe california department of rehabilitation can give you a free speech-generating device if you have difficulty speaking. \n\n\nthe central coast assistive technology center allows you to try, and helps you learn to use, assistive technologies including vision/hearing technologies and ergonomics. \nthey also help you access a no-cost lending library of assistive technology devices (myatprogram.org).\n\n\npathpoint has a lending library of assistive technology devices for people with developmental disabilities. \nslo noor foundation helps uninsured people get low-cost diabetes monitoring and treatment supplies. \nsouth bay seniors people helping people can loan you assistive technology like walkers and wheelchairs. \ncall them or visit their office for details. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "prescription-medicines",
+    "title": "Prescription Medicines",
+    "content": "drug discount plans allow you to get prescriptions at reduced prices.\nyou can get help finding the best discount plans for you from alliance for pharmaceutical access, \nhealth insurance counseling & advocacy program (\"hicap\"), \nneedymeds, \nor united way. \nfor answers about medi-cal/cencal prescription benefits, contact medi-cal rx.\nto find a medi-cal rx pharmacy, visit medi-calrx.dhcs.ca.gov: \"find a pharmacy\".\nthe healthcare for the homeless program dispenses some medications directly, without you having to visit a pharmacy. \nslo noor foundation helps people who are uninsured (or whose insurance does not cover prescriptions) get free or low-cost prescription medications. \ncuesta college students can get over-the-counter and some prescription medicines (many free of charge) from student health services. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "dental-care",
+    "title": "Dental Care",
+    "content": "central coast dental society maintains a list of dentists who offer reduced rates for people in financial hardship.\ncommunity health centers offers dental care at its offices in nipomo, oceano, templeton (las tablas), and at 40 prado in slo. \nslo noor foundation has a dental clinic. \n\nsee medi-cal: dentists above to learn how to find a medi-cal dental provider.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "vision-care",
+    "title": "Vision Care",
+    "content": "the community health centers offices in nipomo, paso robles, and at 260 station way in arroyo grande specialize in optometry. \neyecare america offers a free eye exam and follow-up ophthalmology treatment to uninsured and underinsured adults. \nslo noor foundation has a vision care clinic. \neyeglasses\nthe american academy of ophthalmology maintains a list of sources of free and low-cost eyeglasses.\nyou can find a list of medi-cal opticians at provdir.cencalhealth.org.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "mental-health",
+    "title": "Mental Health",
+    "content": "you can get 24-hour mental health support from slo hotline (805-783-0607, or text 741741).\n\nfor mental health emergencies, see emergency care and emergency contacts.\n\nthe mental health evaluation team / mobile crisis team and mobile crisis unit respond to acute mental health needs.\nsan luis obispo counseling service at cal poly and community counseling center offer low- or no-cost mental health counseling.\na community health centers primary care physician can refer you to chc-provided mental health counseling or psychiatry, which happens over the phone or through internet videoconferencing. \ncuesta college students can get mental health therapy through student health services. \nadult mental health outpatient treatment (via slo county mental health services) \nand transitions mental health association \nand its homeless outreach full service partnership \noffer mental health evaluation & treatment, including programs specifically for homeless people.\nthe healthcare for the homeless program at capslo's 40 prado homeless services center includes mental health counseling and treatment. \nslo hub offers weekly mental health therapy sessions to its clients. \nlife steps foundation \nand pathpoint \nhave some services for people with mental health disorders and/or developmental disabilities.\ntri-county glad offers some mental health services to people who are deaf or hard of hearing. \nthe veterans administration outpatient clinic offers mental health care to qualifying u.s. military veterans.\nthey say: \"all va health care facilities offer same-day help. you may qualify even without enrolling in va health care.\" \nand slo vet center offers confidential counseling and other mental health care to combat veterans (and certain other veterans) and to victims of military sexual trauma. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "reproductive-health",
+    "title": "Reproductive Health",
+    "content": "the center for health and prevention offers contraception, std testing and treatment, uti/yeast infection testing and treatment, genital exams, pap smears, and menopausal services. \ncuesta college students can get reproductive/sexual healthcare and referrals (for example for birth control, emergency contraception, and sti testing) from student health services. \nthe healthcare for the homeless program offers contraceptives, hiv screening and education, ob/gyn services, and std testing. \nplanned parenthood offers abortion, birth control, emergency contraception, hiv/std testing and treatment, help with various sexual and reproductive concerns, and no-cost family planning services. \nthe slo county public health department offers std testing and birth control. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "pregnancy-childbirth-lactation",
+    "title": "Pregnancy, Childbirth, Lactation",
+    "content": "adventist health (805-434-4644) \nand french hospital (805-541-2229) \neach offer free breastfeeding support by phone.\nthe center for health and prevention offers pregnancy testing and counseling. \ncommunity health centers of the central coast's 1057 e. grand ave. (arroyo grande), 1551 bishop st. (slo), and 292 posada ln. (templeton) locations offer the wellness pregnancy program / comprehensive perinatal services program. \n\n\nplanned parenthood offers pregnancy testing and planning, and prenatal and postpartum services. \npregnancy & parenting support offers maternity clothes, nursing supplies, diapers, formula, and referrals. \nthe women, infants, and children (wic) program offers breastfeeding support. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "chiropractic-treatment",
+    "title": "Chiropractic Treatment",
+    "content": "the community health centers of the central coast offices in arroyo grande (260 station way and 1205 e. grand ave.), atascadero, cambria, nipomo, oceano, paso robles, san miguel, templeton (las tablas), and slo (77 casa st. and 1551 bishop st.) offer chiropractic treatment. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "surgery",
+    "title": "Surgery",
+    "content": "the csf medical non profit foundation helps medically uninsured people obtain life-saving surgical procedures. \nthe recuperative care program gives you a place to recover from surgery if your health would be compromised by an unstable living situation. \nask your doctor to refer you to that program. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "medical-resources-specific-populations",
+    "title": "Medical Resources for Specific Populations",
+    "content": "children\ncalifornia children's services pays for and helps arrange doctor visits, hospital stays, surgery, physical therapy, tests, medical equipment, etc. for children and youths whose parents otherwise could not afford it. \nthe community health centers offices at 260 station way in arroyo grande, in nipomo, oceano, paso robles, templeton (las tablas), and at 77 casa st. in slo offer pediatric services. \nthe healthcare for the homeless program offers pediatric care and well child check-ups. \ninfantsee helps you get a free eye/vision test for infants. \ntolosa children's dental center (805-592-2445) accepts medi-cal \nor sliding-scale cash payments. \nunitedhealthcare children's foundation helps pay for medical expenses that are not covered by a child's family's commercial health insurance. \nthe child must be 16 or younger, with a u.s. social security number. \nthe need must be documented by a physician, and the child must be covered by commercial health insurance. \nthe women, infants, and children (wic) program gives food benefits to low-income women who have recently given birth. \npeople with diabetes\nalliance for pharmaceutical access\nand slo noor foundation \ncan help you get low-cost diabetes supplies.\ndignity health leads a free diabetes support group on zoom (internet video conferencing) and in-person every three months. \ncall 805-597-6780 or email angela.fissell@commonspirit.org for details. \nthe healthcare for the homeless program offers diabetes testing and care. \nslo noor foundation offers nutrition education & lifestyle coaching for uninsured people with diabetes or prediabetes. \npeople with disabilities\ncalifornia connect can loan you, for free, assistive telecommunications equipment that helps if you have functional limitations of hearing, vision, mobility, speech, and/or interpretation of information. \nthe california department of rehabilitation helps people with disabilities find or keep employment and live independently. \nthey can help you navigate disability and benefits programs, obtain assistive technologies, and get help with childcare and transportation.\ndisability rights california helps you understand and defend your legal rights as a disabled person. \nthe life steps foundation has resources for people with cerebral palsy, mild intellectual disability, mental health disorders, traumatic brain injury, down syndrome, and spectrum disorders. \npathpoint also has services for people with developmental disabilities. \nif you use american sign language, lifesigns can provide an interpreter to accompany you at your medical appointments. \ntri-county glad can help with telephone call interpreting. \npeople with hiv or hepatitis-c\nthe access support network has a variety of services for people impacted by hiv and hep-c. \nthese include testing, treatment, benefits counseling, help with insurance, harm reduction (including narcan and suboxone), infection prevention, and wound care. \nthe center for health & prevention offers hiv/hep-c testing. \nseniors\n\n\nthe central coast commission for senior citizens offers a variety of services for seniors, including senior connection (an information and referral service), the central coast aging & disability resource center, and the health insurance counseling & advocacy program.\nthey can help you with nutrition and meal services, transportation, and care management.\nteens and youth\ncommunity action partnership san luis obispo (capslo)'s teen wellness program includes health coaching, strength classes, mindfulness workshops, and reproductive health education. \nwomen\nthe center for health & prevention offers breast exams, referrals for free mammograms, pap smears, and menopausal services. \nthe community health centers offices at 1057 e. grand ave. in arroyo grande, in nipomo, at 1551 bishop st. in slo, and at 292 posada ln. in templeton specialize in women's health. \n\n\nslo noor foundation has a women's mobile health unit. \n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "poison-oak",
+    "title": "Poison Oak",
+    "content": "poison oak is a common plant in slo county and grows everywhere from shaded wet creek beds to dry sunny hillsides. \nit is a shrub or vine and sometimes also climbs trees and so can appear to be tree branches. \nits leaves appear in groups of three, but they can have a variety of shapes and colors (dark to pale green, pale orange, bright red). \nthe plants sometimes also display clusters of tiny green, pale, or brown fruits. \n\n\n\n\n\n\n\nthe plant exudes an oil that causes a skin rash in people who touch it. \nyou do not have to touch the plant to be affected: you just need to touch the oil, which can rub off onto clothing, pet fur, or other items and may remain poisonous for years. \nif you have been near a fire in which poison oak plants were burned, you may be exposed to the oil through the smoke. \nyou can prevent the rash by washing your skin thoroughly as soon as possible after exposure and by washing any clothing or other items that may be carrying the oil. \nrubbing alcohol or detergent soaps can be helpful in removing oils. \nthe rash typically appears 12-48 hours, or even several days after exposure. \nit is typically very itchy, and sometimes blisters.\nyou can treat the rash with over-the-counter steroid (such as hydrocortisone) creams, calamine lotion, or antihistamines. \nif you have trouble breathing or swallowing, you may have inhaled some oils (for example from smoke) and you may be experiencing severe respiratory irritation. \nin such a case you should seek medical attention.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "sunburn",
+    "title": "Sunburn",
+    "content": "sunburn is painful. \nit also can make you fatigued and more susceptible to infection. \nin the long run it can put you at higher risk of developing skin cancer. \nhomeless people are more prone to sunburn because they have fewer options to escape the mid-day sun.\nyou can reduce your risk of sunburn by finding shady places to rest during the day, by wearing more thoroughly-covering clothing like long-sleeved shirts and broad-brimmed hats, and by applying sunscreen. \nask homeless service providers if they have any sunscreen they can give you. sometimes they do.\n\nsee the clothing section of this guide for some tips on where to find free or low-cost clothing.\n\nif you develop a sunburn, you can get some relief with over-the-counter salves and creams, or just by keeping the area moist (perhaps with a dampened cloth). \nif you have blisters that break, keep the area clean and covered with a bandage. \nif you notice increasing redness that spreads beyond the area of the burn, or pus, or if you develop a fever, seek medical care as this may indicate an infection. \n\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "drug-use-and-recovery",
+    "title": "Drug Use, Recovery, and Harm Reduction",
+    "content": "in this section:\n\nnaloxone / narcan\ntobacco / nicotine\n12-step and similar recovery programs\n\n\nnote: the somewhat confusing term \"behavioral health\" often describes programs for people who use addictive or harmful drugs and want help.\n\naccess support network offers suboxone (buprenorphine) treatment and opioid overdose prevention training. \naegis treatment centers is an opioid treatment program (otp) offering medication-assisted treatment that uses methadone, suboxone, and similar medicines. \nthey provide specialized services for pregnant women, for veterans, for people with low incomes and for people with mental health disorders. \n\nthey accept medi-cal, medicare, and most commercial insurance. \naspire counseling services runs inpatient (partial hospitalization) and intensive outpatient treatment programs for people trying to beat addiction. \nthey accept medicare and most private insurance plans. \nthe community health centers offices at 260 station way in arroyo grande, in atascadero, cambria, nipomo, oceano, paso robles,\nat 77 casa st. in slo, and in templeton (las tablas), specialize in behavioral health. \ntheir healthcare for the homeless program at the 40 prado homeless services center offers substance abuse treatment and needle exchange.\ngood samaritan shelter in santa maria has a detox program and apparently accepts referrals from 5 cities homeless coalition in slo county.\nslo bangers runs a needle exchange program, can give you overdose prevention training, and distributes narcan.\nslo county mental health services include drug & alcohol walk-in clinics, detox (medically-assisted treatment), and referral to residential treatment options.\nslo county drug and alcohol services offers medically-assisted treatment, recovery services, and outpatient care.\nsome of their services are available on a walk-in basis.\nthey charge a sliding fee depending on ability to pay.\nthey operate the slo sobering center for sobering up, detox, and medically-assisted drug withdrawal.\nfrench hospital medical center and arroyo grande community hospital offer walk-in suboxone treatment at their emergency rooms.\ntransitions mental health association has substance use support groups for people who also have other mental health needs.\nthe veterans administration outpatient clinic offers substance abuse treatment to qualifying u.s. military veterans.\nthe county veterans services offices can also refer veterans to alcohol and drug dependency treatment programs.\nyou can search for other rehab / addiction / detox programs in slo county at websites like addictions.com, recovery.com, or rehabs.org.\nsubstance abuse and mental health services administration (samhsa) is a u.s. government agency.\nit has a free phone service (800-662-help; tty: 800-487-4889; text: 435748) that can help you find substance abuse treatment options near you that match your needs. \nnaloxone / narcan\nnaloxone is an easy-to-administer medication that can save the life of someone who is experiencing an overdose of an opiate such as fentanyl or heroin.\nyou can get naloxone from access support network, slo bangers, slo county drug and alcohol services, and french hospital medical center and arroyo grande community hospital emergency rooms.\nyou can also get free naloxone any time from these \"naloxboxes\":\n\n\n🗺️ view all locations on an interactive map\nnorth coast:\n\nbaywood-los osos: community park, 2180 palisades ave.\ncambria: shamel park, 5455 windsor blvd.\ncambria: slo county public libraries (cambria branch), 1043 main st.\ncayucos: paul andrew park, n. 3rd st.\nmorro bay: public health facility, 760 morro bay blvd.\n\nnorth county:\n\natascadero: slo county department of social services, 9630 el camino real\natascadero: slo county public libraries (atascadero branch), 6555 capistrano ave.\npaso robles: slo county behavioral health, 805 4th st.\npaso robles: city library, 1000 spring st.\npaso robles: echo (paso home key), 1134 black oak dr.\npaso robles: cuesta college student health center map\nsan miguel: community park, 1325 k st.\nsanta margarita: community park, 2210 h st.\nshandon: slo county public libraries (shandon branch), 195 n. 2nd st.\n\nslo city:\n\nslo county animal services, 885 oklahoma ave.\nslo county behavioral health prevention & outreach, 277 south st. #t\nthe center for health & prevention (capslo clinic), 705 grand ave.\ncuesta canyon park, 2400 loomis st.\nel chorro regional park campground, state hwy 1 @ dairy creek rd.\nmaxine lewis grove, 732 orcutt rd.\nslo county department of social services, 3433 s. higuera st.\nslo county public health department (health campus), 2180 johnson ave.\nslo county public libraries (slo branch), 995 palm st.\nsun street centers, 34 prado rd.\nthe anderson, 965 monterey st.\ncuesta college student health center map\n\nsouth county:\n\narroyo grande: lopez lake recreation area, 6800 lopez dr.\narroyo grande: the center for health & prevention (capslo clinic), 1152 e. grand ave.\ngrover beach: public health, 286 s. 16th st. bldg a\nnipomo: slo county public libraries (nipomo branch), 918 w. tefft st.\noceano: coastal dunes rv park & campground, 1001 pacific blvd.\noceano: slo county public libraries (oceano branch), 1511 19th st.\noceano: oceano campground (county campground), 494 air park dr.\n\ntobacco / nicotine\nthe \"kick it california\" program can help you stop smoking (kickitca.org at 800-300-8086 or smokefree.gov at 800-784-8669).\nthe healthcare for the homeless program and the slo county public health department also offer tobacco cessation help.\n12-step and similar recovery programs\nalcoholics anonymous is a peer-led sobriety and recovery program.\nrecovery dharma, hosted by aspire counseling services, is a similar, buddhist-oriented program.\nnarcotics anonymous is similar and helps you stop using other addictive drugs.\nmarijuana anonymous is for marijuana specifically.\naa & na meet in many locations throughout the county, every day of the week.\nthe alano club and the cambria connection, for example, host aa or na meetings several times a day.\nsober living homes and residential treatment options\n\nsee shelter & housing: sober living homes\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "naloxone-narcan",
+    "title": "Naloxone / Narcan",
+    "content": "naloxone is an easy-to-administer medication that can save the life of someone who is experiencing an overdose of an opiate such as fentanyl or heroin.\nyou can get naloxone from access support network, slo bangers, slo county drug and alcohol services, and french hospital medical center and arroyo grande community hospital emergency rooms.\nyou can also get free naloxone any time from these \"naloxboxes\":\n\n\n🗺️ view all locations on an interactive map\nnorth coast:\n\nbaywood-los osos: community park, 2180 palisades ave.\ncambria: shamel park, 5455 windsor blvd.\ncambria: slo county public libraries (cambria branch), 1043 main st.\ncayucos: paul andrew park, n. 3rd st.\nmorro bay: public health facility, 760 morro bay blvd.\n\nnorth county:\n\natascadero: slo county department of social services, 9630 el camino real\natascadero: slo county public libraries (atascadero branch), 6555 capistrano ave.\npaso robles: slo county behavioral health, 805 4th st.\npaso robles: city library, 1000 spring st.\npaso robles: echo (paso home key), 1134 black oak dr.\npaso robles: cuesta college student health center map\nsan miguel: community park, 1325 k st.\nsanta margarita: community park, 2210 h st.\nshandon: slo county public libraries (shandon branch), 195 n. 2nd st.\n\nslo city:\n\nslo county animal services, 885 oklahoma ave.\nslo county behavioral health prevention & outreach, 277 south st. #t\nthe center for health & prevention (capslo clinic), 705 grand ave.\ncuesta canyon park, 2400 loomis st.\nel chorro regional park campground, state hwy 1 @ dairy creek rd.\nmaxine lewis grove, 732 orcutt rd.\nslo county department of social services, 3433 s. higuera st.\nslo county public health department (health campus), 2180 johnson ave.\nslo county public libraries (slo branch), 995 palm st.\nsun street centers, 34 prado rd.\nthe anderson, 965 monterey st.\ncuesta college student health center map\n\nsouth county:\n\narroyo grande: lopez lake recreation area, 6800 lopez dr.\narroyo grande: the center for health & prevention (capslo clinic), 1152 e. grand ave.\ngrover beach: public health, 286 s. 16th st. bldg a\nnipomo: slo county public libraries (nipomo branch), 918 w. tefft st.\noceano: coastal dunes rv park & campground, 1001 pacific blvd.\noceano: slo county public libraries (oceano branch), 1511 19th st.\noceano: oceano campground (county campground), 494 air park dr.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "tobacco-nicotine",
+    "title": "Tobacco / Nicotine",
+    "content": "the \"kick it california\" program can help you stop smoking (kickitca.org at 800-300-8086 or smokefree.gov at 800-784-8669).\nthe healthcare for the homeless program and the slo county public health department also offer tobacco cessation help.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "twelve-step",
+    "title": "12-Step and Similar Recovery Programs",
+    "content": "alcoholics anonymous is a peer-led sobriety and recovery program.\nrecovery dharma, hosted by aspire counseling services, is a similar, buddhist-oriented program.\nnarcotics anonymous is similar and helps you stop using other addictive drugs.\nmarijuana anonymous is for marijuana specifically.\naa & na meet in many locations throughout the county, every day of the week.\nthe alano club and the cambria connection, for example, host aa or na meetings several times a day.\nsober living homes and residential treatment options\n\nsee shelter & housing: sober living homes\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "tattoo-removal",
+    "title": "Tattoo Removal",
+    "content": "there are programs available that will erase your tattoos.\nthis can help you if you have tattoos that interfere with your ability to get a job or that are suggestive of gang or hate group affiliation.\ntattoo removal can help you get a fresh start, unburdened by regretful decisions from your past.\nthe process of laser tattoo removal takes time.\ntypically you undergo between five and twelve visits, each one lasting about five minutes, over several months.\nin each visit a laser breaks ink particles in your tattoo so that your immune system can remove them.\nthe tattooed area will become red and swollen soon after treatment, but this eventually settles down.\nsometimes there is some blistering and scabbing.\nyou will need to take some care to keep the area of the tattoo clean, and to apply some ointments that assist healing.\nthe liberty tattoo removal program offers laser tattoo removal of gang-related, anti-social, or economically limiting tattoos.\nyou are required to do some hours of community service (or an equivalent financial donation) before each treatment, but there is otherwise no cost.\nyou must agree to remain clean and sober, and to get no more tattoos, during the treatment.\nthis service is offered to people in slo county and the treatments happen in slo city.\ncatholic charities has a low-cost tattoo removal program ($20-90 per session, on a sliding scale based on ability to pay).\nyou must also complete 20 hours of community service before beginning treatment.\nthey prioritize the removal of offensive or gang-related tattoos, and will remove both visible-and-obvious tattoos (e.g. the face, the back of the hands) and more discreet ones.\ncall them to begin the process.\nthe removery ink-nitiative program offers free removal of tattoos, if those tattoos are in visible areas (face, hands, arms) or suggest gang or hate group affiliation, to people who have been incarcerated, are former gang members, or are survivors of domestic abuse or human trafficking.\napply on their website.\nthe jails to jobs website lists hundreds of other free or low-cost tattoo removal programs throughout the country.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "end-of-life-help",
+    "title": "End-of-Life Care, Advance Directives, Hospice",
+    "content": "in this section:\n\nhospice and palliative care services\nadvance directives\n\nhospice and palliative care services\npalliative care is medical treatment that aims to relieve pain and suffering, perhaps alongside medical treatment that hopes to cure or treat some health problem.\nhospice care is meant to make the process of dying less uncomfortable, and is meant for people who do not have realistic hopes of being cured and living long.\ntypically this means they are in their last six months of life.\nhospice slo includes non-medical volunteer support, grief counseling, support groups, in-home respite care, care management, and end-of-life companion support.\nall services are provided at no charge (they rely entirely on community donations).\nthese services are open to san luis obispo county residents grieving a death, coping with life-limiting illness, or facing end of life.\nthe medically fragile homeless program provides shelter to terminally ill people who need housing so that they can die in the dignity and stability of housing with the care of hospice.\naevum home health offers palliative care, and accepts medicare and medi-cal. they also have a hospice program.\ncentral coast home health and hospice includes hospice nurse availability, nursing services, spiritual care, dietitian services, social work services, bereavement services, home health aides, trained volunteers, support groups, and musicians.\nthey accept medicare; contact them directly to ask about whether medi-cal will cover their services.\ndignity health french hospital medical center home health and hospice includes team-oriented medical care, symptom and pain management, and emotional and spiritual support tailored to patient needs.\nthey accept medicare and medi-cal.\nthey also have financial assistance programs that make hospice treatment free for people below 250% of the federal poverty level, and discounted for people below 400% of the federal poverty level (call 888-488-7667 or 805-542-6321 for details).\ndignity health also has a home health and hospice program in atascadero that includes skilled nursing, hospice care, and palliative care.\nthey accept medicare and medi-cal.\nthey also have financial assistance programs that make hospice treatment free for people below 250% of the federal poverty level, and discounted for people below 400% of the federal poverty level (call 888-488-7667 or 805-542-6321 for details).\nthey are located at 4555 el camino real #a, are open m-f 8am-5pm, and can be reached by phone at 805-434-1427 or 800-549-9609.\nmedi-cal (cencal) recipients who have a life expectancy of six months or less can choose to receive medi-cal covered hospice care in lieu of ordinary medical coverage.\nmedi-cal (cencal) also covers palliative care as part of its ordinary medical coverage.\nhospice care is part of the veterans health administration (vha)'s standard medical benefits package.\nif you are a veteran who is enrolled with the vha, and you have a clinical need for end-of-life hospice care, you can get this without a copay through the vha.\ncontact the local veterans administration outpatient clinic or call the national department of veterans affairs at 800-827-1000.\nadvance directives\nadvance health care directives are legal documents that let you communicate your health care wishes in advance, in case you become unable to speak for yourself.\nsometimes people call these \"living wills.\"\nthese documents include:\n\nadvance health care directives: specifies which medical treatments you would or would not want if you become terminally ill or are in a persistent vegetative state\nhealthcare power of attorney: designates a trusted person to make medical decisions for you when you cannot\nphysician orders for life-sustaining treatment: you can use this to tell physicians how much they should intervene to try to extend your life\ndo not resuscitate (dnr) orders: expresses your desire to refuse resuscitation efforts in particular\norgan donation authorization: you give or withhold permission for your organs, tissues, or body parts to be donated when you die, or put conditions on how they can be used\n\nthese documents help to ensure that your healthcare wishes are respected even if you are incapacitated and cannot express them yourself.\nthey usually must be signed by you and by certain witnesses to be effective.\nit is a good idea to create such documents before you need them, as when you need them you will be preoccupied or unable.\ngive these documents to your healthcare providers so they know to respect your specific preferences.\nthe free websites prepare for your care and the conversation project can help you create advance directive documents that match your needs and your preferences.\nthe california advance directive form website has several varieties of advance directive forms in pdf format that you can review or print.\nsenior legal services project, california rural legal assistance (crla), and slo legal assistance foundation (slolaf) can give you free help to make your advance directive documents clear and legally binding.\nhospice slo offers advanced directive assistance either in-person at its offices, or by phone or internet conferencing.\nyour healthcare provider or hospice can help you complete a physician orders for life-sustaining treatment (polst) form.\nit instructs medical care providers whether they should try to extend your life however they can, or whether they should avoid certain types of burdensome treatments like cpr, feeding tubes, or a mechanical breathing apparatus.\na polst form only works if you or your legally-recognized decision-maker signs it and your physician, nurse practitioner, or physician assistant also signs it.\nyou can change your mind after you submit such a form and can change it or discontinue it.\nyou can learn more about the form and review one online, in several languages, at capolst.org.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "hospice-and-palliative-care",
+    "title": "Hospice and Palliative Care Services",
+    "content": "palliative care is medical treatment that aims to relieve pain and suffering, perhaps alongside medical treatment that hopes to cure or treat some health problem.\nhospice care is meant to make the process of dying less uncomfortable, and is meant for people who do not have realistic hopes of being cured and living long.\ntypically this means they are in their last six months of life.\nhospice slo includes non-medical volunteer support, grief counseling, support groups, in-home respite care, care management, and end-of-life companion support.\nall services are provided at no charge (they rely entirely on community donations).\nthese services are open to san luis obispo county residents grieving a death, coping with life-limiting illness, or facing end of life.\nthe medically fragile homeless program provides shelter to terminally ill people who need housing so that they can die in the dignity and stability of housing with the care of hospice.\naevum home health offers palliative care, and accepts medicare and medi-cal. they also have a hospice program.\ncentral coast home health and hospice includes hospice nurse availability, nursing services, spiritual care, dietitian services, social work services, bereavement services, home health aides, trained volunteers, support groups, and musicians.\nthey accept medicare; contact them directly to ask about whether medi-cal will cover their services.\ndignity health french hospital medical center home health and hospice includes team-oriented medical care, symptom and pain management, and emotional and spiritual support tailored to patient needs.\nthey accept medicare and medi-cal.\nthey also have financial assistance programs that make hospice treatment free for people below 250% of the federal poverty level, and discounted for people below 400% of the federal poverty level (call 888-488-7667 or 805-542-6321 for details).\ndignity health also has a home health and hospice program in atascadero that includes skilled nursing, hospice care, and palliative care.\nthey accept medicare and medi-cal.\nthey also have financial assistance programs that make hospice treatment free for people below 250% of the federal poverty level, and discounted for people below 400% of the federal poverty level (call 888-488-7667 or 805-542-6321 for details).\nthey are located at 4555 el camino real #a, are open m-f 8am-5pm, and can be reached by phone at 805-434-1427 or 800-549-9609.\nmedi-cal (cencal) recipients who have a life expectancy of six months or less can choose to receive medi-cal covered hospice care in lieu of ordinary medical coverage.\nmedi-cal (cencal) also covers palliative care as part of its ordinary medical coverage.\nhospice care is part of the veterans health administration (vha)'s standard medical benefits package.\nif you are a veteran who is enrolled with the vha, and you have a clinical need for end-of-life hospice care, you can get this without a copay through the vha.\ncontact the local veterans administration outpatient clinic or call the national department of veterans affairs at 800-827-1000.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "advance-directives",
+    "title": "Advance Directives",
+    "content": "advance health care directives are legal documents that let you communicate your health care wishes in advance, in case you become unable to speak for yourself.\nsometimes people call these \"living wills.\"\nthese documents include:\n\nadvance health care directives: specifies which medical treatments you would or would not want if you become terminally ill or are in a persistent vegetative state\nhealthcare power of attorney: designates a trusted person to make medical decisions for you when you cannot\nphysician orders for life-sustaining treatment: you can use this to tell physicians how much they should intervene to try to extend your life\ndo not resuscitate (dnr) orders: expresses your desire to refuse resuscitation efforts in particular\norgan donation authorization: you give or withhold permission for your organs, tissues, or body parts to be donated when you die, or put conditions on how they can be used\n\nthese documents help to ensure that your healthcare wishes are respected even if you are incapacitated and cannot express them yourself.\nthey usually must be signed by you and by certain witnesses to be effective.\nit is a good idea to create such documents before you need them, as when you need them you will be preoccupied or unable.\ngive these documents to your healthcare providers so they know to respect your specific preferences.\nthe free websites prepare for your care and the conversation project can help you create advance directive documents that match your needs and your preferences.\nthe california advance directive form website has several varieties of advance directive forms in pdf format that you can review or print.\nsenior legal services project, california rural legal assistance (crla), and slo legal assistance foundation (slolaf) can give you free help to make your advance directive documents clear and legally binding.\nhospice slo offers advanced directive assistance either in-person at its offices, or by phone or internet conferencing.\nyour healthcare provider or hospice can help you complete a physician orders for life-sustaining treatment (polst) form.\nit instructs medical care providers whether they should try to extend your life however they can, or whether they should avoid certain types of burdensome treatments like cpr, feeding tubes, or a mechanical breathing apparatus.\na polst form only works if you or your legally-recognized decision-maker signs it and your physician, nurse practitioner, or physician assistant also signs it.\nyou can change your mind after you submit such a form and can change it or discontinue it.\nyou can learn more about the form and review one online, in several languages, at capolst.org.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "personal-safety",
+    "title": "Personal Safety, Deescalation, Self-Defense",
+    "content": "in this section:\n\nself-defense classes and martial arts\npersonal safety tips\n\nself-defense classes and martial arts\nsometimes relatively inexpensive self-defense or martial arts classes are offered through the \"community programs\" at cuesta college (see the \"martial arts\" section of their website) or san luis coastal adult school (see the \"community programs\" section of their website).\n\n\n\npersonal safety tips\nto stay safe on the streets, stay aware of your surroundings.\nbe alert when you walk alone, and avoid distractions like phones or headphones.\ntrust your instincts-if a situation feels unsafe, go somewhere safer.\nwalk with confidence: keep your eyes forward, and maintain a steady pace.\nthese simple behaviors can make you less vulnerable to potential threats.\nlearning to identify trustworthy people is one of the most important street skills you can develop, though it takes time and experience.\nbe cautious when forming new relationships-sometimes people experiencing homelessness are victimized by people who say they want to help.\nwatch for \"red flags\" like people who try to exploit your vulnerabilities, who offer deals that seem too good to be true, or who pressure you into uncomfortable or vulnerable situations.\nconnect with peers who understand your situation, as these relationships often provide both safety and emotional support.\nremember that developing good judgment about people is a gradual process, not something you can master immediately.\nwhenever possible, travel with trusted companions rather than going places alone.\nhaving someone you trust with you provides both practical safety and moral support.\nbuild a network of friends who protect each other.\nsuch connections improve your physical safety and also your overall well-being and security.\nif you use emergency shelters, address your security concerns with the staff before you settle in.\n(for example, if you see someone at the shelter who has been threatening to you in the past, or if you are not sure your possessions will be secure where you have been told to leave them.)\nsome people choose to sleep on the streets rather than in shelters because of safety concerns.\nif you do stay outside, you need to balance the risks of harassment in public places against the risk of assault in more secluded areas.\nstay vigilant even in places that are supposed to be safe.\nif you find yourself in a dangerous situation, your primary goal should be to escape and get help rather than to fight.\nthe best approach to self-defense is to avoid physical violence through awareness and de-escalation.\nif you do need to defend yourself, learn a few simple techniques that can make an attacker reconsider and give you time to get away.\nwhen possible, take formal self-defense classes to learn proper techniques from trained instructors.\nsources:\n\n\"basic street safety for women\"\n\"capacity for survival: exploring strengths of homeless street youth\"\n\"personal security & safety when living in a homeless shelter\"\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "self-defense-classes",
+    "title": "Self-Defense Classes and Martial Arts",
+    "content": "sometimes relatively inexpensive self-defense or martial arts classes are offered through the \"community programs\" at cuesta college (see the \"martial arts\" section of their website) or san luis coastal adult school (see the \"community programs\" section of their website).\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "womens-self-defense",
+    "title": "Women’s Self-Defense Programs",
+    "content": "\nmodel mugging of slo\navailable evidence suggests this is defunct or on ice\ntheir facebook account's most recent post is from 2021 and says \"classes are not being held at this time\"\n\n\nsource: modelmugging.org\nnote: website might not load if you're on a vpn\nthe page says it's about mm classes in slo, but if you try to register it redirects you to \"los angeles / orange county\" classes\n\n\n\n\nakido of slo\nhas a women's self defense page on their website: aikidosanluisobispo.com/?page_id=1109\nbut it says \"upcoming classes tba\" and may be the same as the model mugging classes that were last offered some time around or before 2021\n\n\ncuesta college women's self defense workshop\nformat: hands-on, comprehensive workshop in safe, supportive environment\ncontent: self-defense mindset, managing unknown persons, striking and combative skills\ninstructor: qualified martial arts instructor\nfinancial aid: scholarships and family discounts available\nlocations/phone/email: see cuesta college in the directory\nsource: cuesta.edu\n\ntry cuesta.edu/communityprograms/community-recreation/martial-arts/index.html\n\n\n\n\n\n\nlumina alliance: no indication from their website that they offer self-defense training\n-->\n\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "personal-safety-tips",
+    "title": "Personal Safety Tips",
+    "content": "to stay safe on the streets, stay aware of your surroundings.\nbe alert when you walk alone, and avoid distractions like phones or headphones.\ntrust your instincts-if a situation feels unsafe, go somewhere safer.\nwalk with confidence: keep your eyes forward, and maintain a steady pace.\nthese simple behaviors can make you less vulnerable to potential threats.\nlearning to identify trustworthy people is one of the most important street skills you can develop, though it takes time and experience.\nbe cautious when forming new relationships-sometimes people experiencing homelessness are victimized by people who say they want to help.\nwatch for \"red flags\" like people who try to exploit your vulnerabilities, who offer deals that seem too good to be true, or who pressure you into uncomfortable or vulnerable situations.\nconnect with peers who understand your situation, as these relationships often provide both safety and emotional support.\nremember that developing good judgment about people is a gradual process, not something you can master immediately.\nwhenever possible, travel with trusted companions rather than going places alone.\nhaving someone you trust with you provides both practical safety and moral support.\nbuild a network of friends who protect each other.\nsuch connections improve your physical safety and also your overall well-being and security.\nif you use emergency shelters, address your security concerns with the staff before you settle in.\n(for example, if you see someone at the shelter who has been threatening to you in the past, or if you are not sure your possessions will be secure where you have been told to leave them.)\nsome people choose to sleep on the streets rather than in shelters because of safety concerns.\nif you do stay outside, you need to balance the risks of harassment in public places against the risk of assault in more secluded areas.\nstay vigilant even in places that are supposed to be safe.\nif you find yourself in a dangerous situation, your primary goal should be to escape and get help rather than to fight.\nthe best approach to self-defense is to avoid physical violence through awareness and de-escalation.\nif you do need to defend yourself, learn a few simple techniques that can make an attacker reconsider and give you time to get away.\nwhen possible, take formal self-defense classes to learn proper techniques from trained instructors.\nsources:\n\n\"basic street safety for women\"\n\"capacity for survival: exploring strengths of homeless street youth\"\n\"personal security & safety when living in a homeless shelter\"\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "legal-help",
+    "title": "Legal Help & Crime Victim Protection",
+    "content": "in this section:\n\nhelp for defendants, convicts, parolees, probationers\nlegal help regarding housing (discrimination, landlord disputes, etc.)\nhelp with benefits, wrangling with health insurers, et cetera\nconsumer protection\nvictims of crime, abuse\nlegal self-help / law libraries\nlegal consultation\nfamily law / child support\nimmigration law\nsenior legal services\ntax disputes\nmiscellany\n\nhelp for defendants, convicts, parolees, probationers\nif you are being taken to court and accused of a serious crime by the government, you have the right to have a lawyer who is trained in the law to help defend you against the charges.\nyou have a right to a lawyer even if you do not have enough money to pay one.\nif you cannot afford to hire a lawyer, tell the judge so when you first appear in court, and the judge will assign a public defender to you.\nslo public defenders is the primary public defenders' office in slo county.\nyou must wait until the judge assigns a particular public defender to you before you can discuss your case with them.\nif you have been in jail or prison and are reentering the community after doing your time or being released on parole, restorative partners can help make your reentry successful.\nthey can give you housing assistance including clean & sober living homes, and help returning to the workforce.\ncall or email them to learn more.\nif you have a criminal record that makes it difficult for you to find employment or housing, you may be able to clean that record.\nthe \"clean slate clinic\" is a joint project of people's justice project, california rural legal assistance, and slo college of law legal clinic.\ncontact them at 805-902-2752 or 805-242-6691 to schedule an appointment.\nu.s. military veterans who enter the criminal justice system may be able to get services from \"veterans treatment court\" if the activity they were arrested or prosecuted for is attributed to conditions like post-traumatic stress disorder, traumatic brain injury, sexual trauma, or other causes related to military service.\nveterans treatment court is a rigorous 12-18 month program of supervised probation customized for the needs of traumatized veterans which includes treatment, counseling, and regular court appearances.\ncontact county veterans services for help getting into this program.\nlegal help regarding housing (discrimination, landlord disputes, etc.)\ncalifornia rural legal assistance provides free civil legal assistance to low-income people.\nthis includes cases concerning foreclosures, evictions & lockouts, section 8 and public housing, and housing discrimination.\nslo legal assistance foundation (slolaf) helps low-income people in slo county with legal support.\namong the issues they help with are eviction defense for tenants, landlord/tenant conflicts, habitability/repair issues, accessibility for people with disabilities, fair housing and discrimination, section 8 housing, unlawful rent increases, and mobile home law.\nthe california civil rights department can help you understand your rights to be protected from illegal housing discrimination and can also help you investigate and file formal discrimination complaints.\nthe california advocacy organization tenants together (info@tenantstogether.org) has a tenants' rights hotline at 888-495-8020 (text 650-600-7821).\nthey also have an on-line self-help tenant defense toolkit to help you understand your rights as a renter and how to enforce those rights.\nthe california department of real estate published a california tenants' guide (español) which gives a detailed explanation of california law concerning tenants of rental properties.\nslo city has a tenants union (805-779-1639).\nthe slo branch of democratic socialists of america have a housing justice guide for tenants in san luis obispo.\nit tries to explain how you can best assert and defend your legal rights as a renter.\nthe long term care ombudsman can help you fight for your rights if you are being improperly evicted from a long term care facility.\nu.s. military veterans who have low incomes and who are homeless or at risk of homelessness can get help from supportive services for veteran families.\nthis help includes temporary financial assistance for rent, deposits, and utilities, legal assistance, rental agreement education, and landlord-tenant mediation.\nyou must have a dd214 with discharge other than dishonorable.\nhelp with benefits, wrangling with health insurers, etc.\n\nsee the navigating social security / ssdi / ssi / survivors benefits section for advice specific to those programs.\n\nhealth insurance counseling & advocacy program (\"hicap\") offers free and unbiased information about medicare and its options.\nhicap can also help you file medicare denial appeals or make medicare fraud referrals.\nto use the local hicap program you must be eligible for medicare and you must be a resident of slo or santa barbara counties.\nhicap is free.\ncentral california legal services' health consumer center program (800-464-3111) helps people enroll and stay enrolled in health insurance programs, helps make sure those programs cover the medical care you need, and helps people who are improperly billed or subject to improper collections actions because of medical treatment.\nif you are a u.s. military veteran, you can get help learning about, applying for, and receiving government benefits you are entitled to from the county veterans services offices.\n\n\nconsumer protection\nto report a consumer complaint directly to the slo district attorney, you can use the consumer complaint form on their website.\nidentity theft is when someone else pretends to be you-for example by using your name, identification, or credit card number-to commit fraud or to put the blame on you for something they have done.\nyou can report identity theft with the federal trade commission at identitytheft.gov or 877-438-4338 and they can help you take steps to protect yourself.\nif you believe you have been defrauded by an automotive repair shop, you can get help from the bureau of automotive repairs (800-952-5210 or barenforcement@dca.ca.gov).\nthe california department of motor vehicles has an investigations division that enforces laws relating to new and used vehicle dealers.\nif you are the victim of fraud or other illegal action by a vehicle dealer, you can file a complaint online.\nif you are the victim of fraud or other illegal action concerning a bank account, credit card, debt collector, money transfer, payday loan, or something like that, you may be able to get help from the consumer financial protection bureau (855-411-2372).\nthe long term care ombudsman can help you fight for your rights if you are being mistreated by or improperly evicted from a long term care facility.\nmany service providers are licensed by the state of california (for example, health care providers, accountants, security guards, social workers, etc.).\nif you believe you have been treated unfairly or improperly by a licensed service provider, you can file a complaint with the california department of consumer affairs (800-952-5210/tty:800-735-2929, dca@dca.ca.gov).\nvictims of crime, abuse\nvictims of crime have certain legal rights, and they may be asked to participate in crime investigations or to testify in criminal cases.\nthe victim witness assistance program helps crime victims who are navigating this process.\nit can help you understand your rights, obtain support services, get help with court appearances, apply for restitution, and get notifications about important updates concerning the criminal case against your victimizer(s).\nif you have been the victim of a violent crime, the california victim compensation board (800-777-9229) can help you get financial restitution, medical treatment, mental health counseling, and other help.\nif you are the victim of sexual assault or intimate partner violence, lumina alliance can help you advocate for your rights and can accompany you through the legal process.\ncasa (court appointed special advocates) helps to advocate on behalf of abused or neglected children in the court system.\ncasa advocates are court-appointed; you cannot request their services directly.\n\n\nlegal self-help / law libraries\n\n\nif you need to research the law, legal precedents, and legal processes, you can visit the slo county law library, a free research library.\nthe library has thousands of print volumes and also has publicly-accessible computers at which you can access westlaw, ceb onlaw, nolo guides, bell's compendium, and other electronic legal databases.\nit also has tools with which you can create documents that conform to the standards of local courts.\nif you are filing a small claims case (a civil dispute involving less than $10,000, in which the parties are not represented in court by lawyers), a family law case (for example divorce, child support, child custody), a request for a restraining order, or certain other matters you can get free help from slo court self-help services.\nslo superior court also has some guides on:\n\nimmigration resources\nhow to obtain gun violence, civil harassment, and domestic violence restraining orders\nthe process of going to court for child custody and support, divorce, legal separation, and annulment, and other family law matters\nthe processes of legal name changes and gender changes\n\nthe state of california's small claims in california web page is also a good introduction to the small claims process.\nthe slo law line (805-548-8884) gives free basic legal advice to people who cannot afford an attorney, and can help you find additional legal assistance.\ncall to make an appointment for a telephone consultation.\nu.s. military veterans can get help from the statesidelegal website, which has information about how to file benefits claims and denial appeals, how to defend civil rights claims, and other legal matters.\nlegal consultation in general\nif you need to confer with a lawyer or other legal consultant, you have several options.\nthe slo county bar association's attorney referral service can help you find a lawyer who is most appropriate to your case.\nthis service is free for personal injury, worker's compensation, and criminal law cases, but costs $50 otherwise.\nthe slo legal assistance foundation (slolaf) provides free legal assistance on civil law and family law (not criminal law) matters to low-income people in slo county.\ncalifornia rural legal assistance (crla) provides free civil law (not criminal law) services to low-income people in slo county.\npeople's justice project is a non-profit law firm that can provide affordable legal representation to people with low- or moderate-income in criminal law or civil rights cases.\nu.s. military veterans can use the statesidelegal website's veterans legal help navigator to find legal representatives that best match the needs of your case.\naclu of southern california can provide limited legal advice in civil liberties and civil rights cases.\nit has limited resources and typically focuses on specific cases which it hopes to use to force systemic changes.\nit does not accept walk-ins.\nit offers several free know your rights guides, but note that these can be more reflective of what the aclu believes your legal rights are on paper than what the law enforcement system actually respects.\nfamily law / child support\nchild support services can help you locate parents who may owe child support, establish parentage, obtain and enforce support orders, and collect payments.\nif you are filing a family law case, you can get free help from slo court self-help services.\nslo superior court has some guides on the process of going to court for child custody and support, divorce, legal separation, and annulment, and other family law matters.\nimmigration law\n\n\nslo county undocusupport has a list of legal assistance services that includes a chart of which local legal aid groups provide which specific immigration-related legal services.\ncatholic charities has an immigration and citizenship program to help people with issues such as u.s citizenship applications, immigration status changes, daca, u-visas, vawa-visas, and consular visa processes.\nunitarian universalists san luis obispo hosts the unitarian universalist refugee and immigrant services education (uurise) program, which offers free or low-cost immigration legal services.\nimmigrant hope arroyo grande is an immigration legal services center that can help you with naturalization, consular processing, immigration status changes, temporary protective status, daca, green card renewals, and visas.\nslo college of law holds immigration clinics by telephone or zoom on mondays between 4pm and 6pm.\nthey can help you with daca renewal, visas, naturalization/citizenship, and green cards.\nthis costs $15.\nschedule an appointment at their website or by calling 831-582-3600.\nslo superior court also has some free immigration resources.\ncentral coast coalition for undocumented student success operates dream (or monarch) centers at local colleges (cal poly, cuesta, and allan hancock).\nthese centers help students with (among other things) daca application assistance and other legal help:\n\ncuesta college provides free immigration legal services to students, faculty, and staff.\nmake an appointment to talk to an advisor here or call 805-246-3867 or 805-546-3109\ncal poly's dream center provides free and confidential immigrant legal defense to cal poly students, recent graduates, employees, and immediate family members.\nthis includes deportation defense (detained and non-detained), daca applications and renewals, family-based immigration petitions, u & t visa applications, vawa cases, asylum claims, lawful permanent resident status, and citizenship applications\nthe allan hancock college aim to dream center offers free immigration legal services to all students, faculty, and staff.\nthis includes daca, citizenship, family petitions, adjustments of status, among other things.\n\nif you call the rapid response hotline at 805-870-8855, you can get know-your-rights information and referrals to trusted attorneys (nonprofit, private, or public) from the \"805 immigrant rapid response network.\"\nthe immigrant legal resource center and the immigrant defense project can also help you with know-your-rights information and with finding legal help.\nsenior legal services\nthe senior legal services project offers free legal help for people in slo county who are age 60 and up.\nthey can help you navigate the legal issues around benefits rights assistance, consumer protection, housing discrimination and eviction prevention, advance medical directives and durable power of attorney, will preparation, and protective/restraining orders.\nthey often hold by-appointment clinics at local senior centers, or you can contact their office directly via the slo legal assistance foundation (slolaf).\ntax disputes\nthe orfalea college of business at cal poly operates a low income taxpayer clinic at cal poly's slo campus, building 3, room 107, m-th 9am-5pm and f 9am-1pm.\nthey represent low-income clients for free in tax controversies before the i.r.s. and the u.s. tax court.\ntheir help is available in english and spanish.\nthis service is only available to you if the amount the irs says you owe is $50,000 per tax year or less, and your household's total income does not exceed 250 percent of the federal poverty guidelines.\nto use this service, complete an intake form which is available on their website, or call them at 877-318-6772 (español: 805-756-5725)\nyou can also ask for more information by email at litc@calpoly.edu.\nmiscellany\n\nsee the advance directives section of this guide for help on how to make legally-binding advance directives such as advance care directives, healthcare power of attorney, physician orders for life-sustaining treatment (polst), do not resuscitate (dnr) orders, and organ donation authorizations.\n\nthe california civil rights department enforces california's laws against certain forms of discrimination in employment, housing, business, and services, and against hate crimes and human trafficking.\nif you believe you have been treated illegally in ways like these, you can file a discrimination complaint, report a hate crime with them and request that they investigate.\nthe americans with disabilities act protects people who have disabilities from discrimination.\nthe ada.gov website explains this act and how you can enforce your rights under it.\nthat site also shows you how to file an official complaint.\nyou can also reach the u.s. department of justice's americans with disabilities act section at 800-514-0301 (tty: 833-610-1264) or disability.outreach@usdoj.gov.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "defendants-and-convicts",
+    "title": "Help for Defendants, Convicts, Parolees, Probationers",
+    "content": "if you are being taken to court and accused of a serious crime by the government, you have the right to have a lawyer who is trained in the law to help defend you against the charges.\nyou have a right to a lawyer even if you do not have enough money to pay one.\nif you cannot afford to hire a lawyer, tell the judge so when you first appear in court, and the judge will assign a public defender to you.\nslo public defenders is the primary public defenders' office in slo county.\nyou must wait until the judge assigns a particular public defender to you before you can discuss your case with them.\nif you have been in jail or prison and are reentering the community after doing your time or being released on parole, restorative partners can help make your reentry successful.\nthey can give you housing assistance including clean & sober living homes, and help returning to the workforce.\ncall or email them to learn more.\nif you have a criminal record that makes it difficult for you to find employment or housing, you may be able to clean that record.\nthe \"clean slate clinic\" is a joint project of people's justice project, california rural legal assistance, and slo college of law legal clinic.\ncontact them at 805-902-2752 or 805-242-6691 to schedule an appointment.\nu.s. military veterans who enter the criminal justice system may be able to get services from \"veterans treatment court\" if the activity they were arrested or prosecuted for is attributed to conditions like post-traumatic stress disorder, traumatic brain injury, sexual trauma, or other causes related to military service.\nveterans treatment court is a rigorous 12-18 month program of supervised probation customized for the needs of traumatized veterans which includes treatment, counseling, and regular court appearances.\ncontact county veterans services for help getting into this program.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "housing-legal",
+    "title": "Legal Help Regarding Housing (Discrimination, Landlord Disputes, etc.)",
+    "content": "california rural legal assistance provides free civil legal assistance to low-income people.\nthis includes cases concerning foreclosures, evictions & lockouts, section 8 and public housing, and housing discrimination.\nslo legal assistance foundation (slolaf) helps low-income people in slo county with legal support.\namong the issues they help with are eviction defense for tenants, landlord/tenant conflicts, habitability/repair issues, accessibility for people with disabilities, fair housing and discrimination, section 8 housing, unlawful rent increases, and mobile home law.\nthe california civil rights department can help you understand your rights to be protected from illegal housing discrimination and can also help you investigate and file formal discrimination complaints.\nthe california advocacy organization tenants together (info@tenantstogether.org) has a tenants' rights hotline at 888-495-8020 (text 650-600-7821).\nthey also have an on-line self-help tenant defense toolkit to help you understand your rights as a renter and how to enforce those rights.\nthe california department of real estate published a california tenants' guide (español) which gives a detailed explanation of california law concerning tenants of rental properties.\nslo city has a tenants union (805-779-1639).\nthe slo branch of democratic socialists of america have a housing justice guide for tenants in san luis obispo.\nit tries to explain how you can best assert and defend your legal rights as a renter.\nthe long term care ombudsman can help you fight for your rights if you are being improperly evicted from a long term care facility.\nu.s. military veterans who have low incomes and who are homeless or at risk of homelessness can get help from supportive services for veteran families.\nthis help includes temporary financial assistance for rent, deposits, and utilities, legal assistance, rental agreement education, and landlord-tenant mediation.\nyou must have a dd214 with discharge other than dishonorable.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "benefits-legal",
+    "title": "Help with Benefits, Wrangling with Health Insurers, etc.",
+    "content": "\nsee the navigating social security / ssdi / ssi / survivors benefits section for advice specific to those programs.\n\nhealth insurance counseling & advocacy program (\"hicap\") offers free and unbiased information about medicare and its options.\nhicap can also help you file medicare denial appeals or make medicare fraud referrals.\nto use the local hicap program you must be eligible for medicare and you must be a resident of slo or santa barbara counties.\nhicap is free.\ncentral california legal services' health consumer center program (800-464-3111) helps people enroll and stay enrolled in health insurance programs, helps make sure those programs cover the medical care you need, and helps people who are improperly billed or subject to improper collections actions because of medical treatment.\nif you are a u.s. military veteran, you can get help learning about, applying for, and receiving government benefits you are entitled to from the county veterans services offices.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "liability-law",
+    "title": "Injury Liability / Workers’ Compensation",
+    "content": "\nnote: local injury liability and workers' compensation attorneys not yet researched. for current resources, contact slo county bar association referral service or search for contingency fee attorneys who handle cases without upfront costs.\n-->\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "consumer-protection",
+    "title": "Consumer Protection",
+    "content": "to report a consumer complaint directly to the slo district attorney, you can use the consumer complaint form on their website.\nidentity theft is when someone else pretends to be you-for example by using your name, identification, or credit card number-to commit fraud or to put the blame on you for something they have done.\nyou can report identity theft with the federal trade commission at identitytheft.gov or 877-438-4338 and they can help you take steps to protect yourself.\nif you believe you have been defrauded by an automotive repair shop, you can get help from the bureau of automotive repairs (800-952-5210 or barenforcement@dca.ca.gov).\nthe california department of motor vehicles has an investigations division that enforces laws relating to new and used vehicle dealers.\nif you are the victim of fraud or other illegal action by a vehicle dealer, you can file a complaint online.\nif you are the victim of fraud or other illegal action concerning a bank account, credit card, debt collector, money transfer, payday loan, or something like that, you may be able to get help from the consumer financial protection bureau (855-411-2372).\nthe long term care ombudsman can help you fight for your rights if you are being mistreated by or improperly evicted from a long term care facility.\nmany service providers are licensed by the state of california (for example, health care providers, accountants, security guards, social workers, etc.).\nif you believe you have been treated unfairly or improperly by a licensed service provider, you can file a complaint with the california department of consumer affairs (800-952-5210/tty:800-735-2929, dca@dca.ca.gov).\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "crime-victims",
+    "title": "Victims of Crime, Abuse",
+    "content": "victims of crime have certain legal rights, and they may be asked to participate in crime investigations or to testify in criminal cases.\nthe victim witness assistance program helps crime victims who are navigating this process.\nit can help you understand your rights, obtain support services, get help with court appearances, apply for restitution, and get notifications about important updates concerning the criminal case against your victimizer(s).\nif you have been the victim of a violent crime, the california victim compensation board (800-777-9229) can help you get financial restitution, medical treatment, mental health counseling, and other help.\nif you are the victim of sexual assault or intimate partner violence, lumina alliance can help you advocate for your rights and can accompany you through the legal process.\ncasa (court appointed special advocates) helps to advocate on behalf of abused or neglected children in the court system.\ncasa advocates are court-appointed; you cannot request their services directly.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "mediation",
+    "title": "Mediation",
+    "content": "if you have a dispute with someone else, mediation is a way to resolve that dispute without having to go to court.\nthis doesn't always work, but when it does it can be much less costly and cumbersome than filing a lawsuit.\nmediators are professionals who help people in conflict to resolve their dispute.\nyou can use mediation for many types of conflicts, including those that have to do with family, employment, housing, neighbors, relationship, contracting, or consumer disputes.\ncreative mediation is a non-profit mediation service that offers free services to slo county residents.\nwhen creative mediation receives your request for their mediation assistance, they will contact you for more information.\nthen they will contact the person you are having a dispute with.\nif that person agrees to handle your dispute by means of mediation, a mediation session will be scheduled at a time that works for you.\na neutral mediator will be assigned to your case to help you resolve it.\n-->\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "legal-self-help",
+    "title": "Legal Self-Help / Law Libraries",
+    "content": "if you need to research the law, legal precedents, and legal processes, you can visit the slo county law library, a free research library.\nthe library has thousands of print volumes and also has publicly-accessible computers at which you can access westlaw, ceb onlaw, nolo guides, bell's compendium, and other electronic legal databases.\nit also has tools with which you can create documents that conform to the standards of local courts.\nif you are filing a small claims case (a civil dispute involving less than $10,000, in which the parties are not represented in court by lawyers), a family law case (for example divorce, child support, child custody), a request for a restraining order, or certain other matters you can get free help from slo court self-help services.\nslo superior court also has some guides on:\n\nimmigration resources\nhow to obtain gun violence, civil harassment, and domestic violence restraining orders\nthe process of going to court for child custody and support, divorce, legal separation, and annulment, and other family law matters\nthe processes of legal name changes and gender changes\n\nthe state of california's small claims in california web page is also a good introduction to the small claims process.\nthe slo law line (805-548-8884) gives free basic legal advice to people who cannot afford an attorney, and can help you find additional legal assistance.\ncall to make an appointment for a telephone consultation.\nu.s. military veterans can get help from the statesidelegal website, which has information about how to file benefits claims and denial appeals, how to defend civil rights claims, and other legal matters.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "legal-consultation",
+    "title": "Legal Consultation in General",
+    "content": "if you need to confer with a lawyer or other legal consultant, you have several options.\nthe slo county bar association's attorney referral service can help you find a lawyer who is most appropriate to your case.\nthis service is free for personal injury, worker's compensation, and criminal law cases, but costs $50 otherwise.\nthe slo legal assistance foundation (slolaf) provides free legal assistance on civil law and family law (not criminal law) matters to low-income people in slo county.\ncalifornia rural legal assistance (crla) provides free civil law (not criminal law) services to low-income people in slo county.\npeople's justice project is a non-profit law firm that can provide affordable legal representation to people with low- or moderate-income in criminal law or civil rights cases.\nu.s. military veterans can use the statesidelegal website's veterans legal help navigator to find legal representatives that best match the needs of your case.\naclu of southern california can provide limited legal advice in civil liberties and civil rights cases.\nit has limited resources and typically focuses on specific cases which it hopes to use to force systemic changes.\nit does not accept walk-ins.\nit offers several free know your rights guides, but note that these can be more reflective of what the aclu believes your legal rights are on paper than what the law enforcement system actually respects.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "family-law",
+    "title": "Family Law / Child Support",
+    "content": "child support services can help you locate parents who may owe child support, establish parentage, obtain and enforce support orders, and collect payments.\nif you are filing a family law case, you can get free help from slo court self-help services.\nslo superior court has some guides on the process of going to court for child custody and support, divorce, legal separation, and annulment, and other family law matters.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "immigration-law",
+    "title": "Immigration Law",
+    "content": "slo county undocusupport has a list of legal assistance services that includes a chart of which local legal aid groups provide which specific immigration-related legal services.\ncatholic charities has an immigration and citizenship program to help people with issues such as u.s citizenship applications, immigration status changes, daca, u-visas, vawa-visas, and consular visa processes.\nunitarian universalists san luis obispo hosts the unitarian universalist refugee and immigrant services education (uurise) program, which offers free or low-cost immigration legal services.\nimmigrant hope arroyo grande is an immigration legal services center that can help you with naturalization, consular processing, immigration status changes, temporary protective status, daca, green card renewals, and visas.\nslo college of law holds immigration clinics by telephone or zoom on mondays between 4pm and 6pm.\nthey can help you with daca renewal, visas, naturalization/citizenship, and green cards.\nthis costs $15.\nschedule an appointment at their website or by calling 831-582-3600.\nslo superior court also has some free immigration resources.\ncentral coast coalition for undocumented student success operates dream (or monarch) centers at local colleges (cal poly, cuesta, and allan hancock).\nthese centers help students with (among other things) daca application assistance and other legal help:\n\ncuesta college provides free immigration legal services to students, faculty, and staff.\nmake an appointment to talk to an advisor here or call 805-246-3867 or 805-546-3109\ncal poly's dream center provides free and confidential immigrant legal defense to cal poly students, recent graduates, employees, and immediate family members.\nthis includes deportation defense (detained and non-detained), daca applications and renewals, family-based immigration petitions, u & t visa applications, vawa cases, asylum claims, lawful permanent resident status, and citizenship applications\nthe allan hancock college aim to dream center offers free immigration legal services to all students, faculty, and staff.\nthis includes daca, citizenship, family petitions, adjustments of status, among other things.\n\nif you call the rapid response hotline at 805-870-8855, you can get know-your-rights information and referrals to trusted attorneys (nonprofit, private, or public) from the \"805 immigrant rapid response network.\"\nthe immigrant legal resource center and the immigrant defense project can also help you with know-your-rights information and with finding legal help.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "senior-legal-services",
+    "title": "Senior Legal Services",
+    "content": "the senior legal services project offers free legal help for people in slo county who are age 60 and up.\nthey can help you navigate the legal issues around benefits rights assistance, consumer protection, housing discrimination and eviction prevention, advance medical directives and durable power of attorney, will preparation, and protective/restraining orders.\nthey often hold by-appointment clinics at local senior centers, or you can contact their office directly via the slo legal assistance foundation (slolaf).\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "tax-disputes",
+    "title": "Tax Disputes",
+    "content": "the orfalea college of business at cal poly operates a low income taxpayer clinic at cal poly's slo campus, building 3, room 107, m-th 9am-5pm and f 9am-1pm.\nthey represent low-income clients for free in tax controversies before the i.r.s. and the u.s. tax court.\ntheir help is available in english and spanish.\nthis service is only available to you if the amount the irs says you owe is $50,000 per tax year or less, and your household's total income does not exceed 250 percent of the federal poverty guidelines.\nto use this service, complete an intake form which is available on their website, or call them at 877-318-6772 (español: 805-756-5725)\nyou can also ask for more information by email at litc@calpoly.edu.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "legal-miscellany",
+    "title": "Miscellany",
+    "content": "\nsee the advance directives section of this guide for help on how to make legally-binding advance directives such as advance care directives, healthcare power of attorney, physician orders for life-sustaining treatment (polst), do not resuscitate (dnr) orders, and organ donation authorizations.\n\nthe california civil rights department enforces california's laws against certain forms of discrimination in employment, housing, business, and services, and against hate crimes and human trafficking.\nif you believe you have been treated illegally in ways like these, you can file a discrimination complaint, report a hate crime with them and request that they investigate.\nthe americans with disabilities act protects people who have disabilities from discrimination.\nthe ada.gov website explains this act and how you can enforce your rights under it.\nthat site also shows you how to file an official complaint.\nyou can also reach the u.s. department of justice's americans with disabilities act section at 800-514-0301 (tty: 833-610-1264) or disability.outreach@usdoj.gov.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "ids-and-other-documents",
+    "title": "IDs and Other Documents",
+    "content": " (how to obtain, replace, secure)\noften, agencies and programs will ask you to produce certain documents, like a government identification card (such as a driver's license), a social security card, a birth certificate, and so forth.\nif you have lost such documents, or have never obtained them, this can be an obstacle to working with those agencies and programs.\nthis section of the guide shows you how to obtain or replace documents like these.\nin this section:\n\nsocial security numbers or cards\nid cards and driver's licenses\nbirth, death, and marriage certificates\ncivil case documents\npassports\ntips\n\nsocial security numbers or cards\nyou do not often need your social security card, but you do often need your social security number.\nthe social security administration can help you get a new social security card.\nif you have an account or can create an on-line account at ssa.gov/myaccount, you can request a social security card on-line and it will be mailed to you.\nyou can get help with this process by calling 800-772-1213 (tty: 800-325-0778).\n\nsee mail drops, post office boxes, etc. for ways to get mail if you do not have a stable mailing address.\n\nif you are unable to complete this on-line process, you can visit the local social security administration office to get a new card.\nit will go more smoothly if you can bring some alternative form of identification like a driver's license or passport.\nin the absence of those, a military id, employee id, school id, or health insurance card might be helpful.\nid cards and driver's licenses\na state-issued \"real id,\" or a california driver's license which is also a real id, is a useful form of government-issued photo identification card that is widely accepted by a variety of programs, businesses, and service providers.\nyou get such an identification card from the california dmv.\nyou must visit the california dmv office to have your photo taken and to submit your paperwork.\nyou typically first need to already have another identification document (such as a certified birth certificate, a passport, a permanent resident card, a certificate of naturalization or citizenship, or a permanent resident card) as well as documents that demonstrate your california residency (such as a utility bill, tax return, bank statement, or rental agreement that contains your name and address).\nthere are also fees you typically must pay to obtain either a real id or a driver's license that operates as a real id.\nhowever, if you are homeless, you may be able to get a waiver for fees (a \"no-fee id card\"), and you may be able to use the address of a homeless shelter or other homeless services agency as your california residency address.\nthis is true even if you are only temporarily homeless because you are fleeing domestic violence or a similar dangerous situation.\nyou can only get a simple real id (\"california identification card\") with the no-fee method, not a driver's license.\nhomeless services providers like 40 prado homeless services center, the 5cities homeless coalition (5chc), or the el camino homeless organization (echo) can help you with this process.\nif you have previously received a real id or california driver's license, but you have lost the card and need to replace it, you can begin this process by visiting www.edl.dmv.ca.gov/apply or the california dmv office.\nbirth, death, and marriage certificates\nif you were born in slo county, you can obtain a copy of your birth certificate from the slo county clerk-recorder.\nyou will need to show valid identification (typically, a government-issued photo id like a driver's license or passport).\nthere is also a $32 fee.\nhowever, if you are homeless, you can request an \"affidavit of homeless status for fee exempt certified copy of birth certificate.\"\nyou need to sign this and you also need to get a signature from a \"homeless services provider.\"\nthis exempts you from having to pay the $32 fee.\nhomeless services providers like 40 prado homeless services center, the 5cities homeless coalition (5chc), or the el camino homeless organization (echo) can help you with this process.\nyou can obtain a \"certified copy\" of a birth certificate for yourself or your child or other close relative.\na certified copy allows you to establish your identity.\notherwise you can obtain an \"informational\" copy, which is not valid for establishing identity.\nyou should understand ahead of time whether or not you need a certified copy, and, if so, you should be sure to ask for one specifically when you order your copy.\nyou can also use the vitalchek website to order an informational copy of your birth certificate on-line without visiting the slo county clerk-recorder office.\n(you may need to provide a notarized, sworn statement if you want to order a \"certified copy\" this way, in which case it is probably just as easy to visit the slo county clerk-recorder office.)\nthat may cost a bit more.\ndeath records for deaths that occurred in slo county can also be obtained from the slo county clerk-recorder ($24) or from vitalchek.\nagain, there is a difference between \"certified\" and \"informational\" copies of death certificates, and you should check which one you need before you order it.\nyou can typically only get a \"certified\" copy for a close relative, and you may have to provide additional documentation.\nyou can also get a copy of a marriage certificate that was issued in slo county from the slo county clerk-recorder office ($17) or from vitalchek.\nagain, there is a difference between \"certified\" and \"informational\" copies, and you should check which one you need before you order it.\nyou can typically only get a \"certified\" copy for yourself or a close relative, and you may have to provide additional documentation.\nthere is no homeless fee exemption program for death and marriage certificates the way there is for birth certificates.\nif you need a birth, death, or marriage certificate from another county in california, try the california department of public health's \"vital records\" web page.\nif you need such records from elsewhere in the u.s. outside california, visit the national center for health statistics web page.\nthe vitalchek website can often also get you these records from other areas.\ncivil case documents\nto get copies of slo superior court documents in civil cases to which you are a party, first go to the court offices in san luis obispo or in paso robles.\nthose offices have a publicly-accessible computer at which you can find your case number.\ncourt staff can help you with this process.\nthen review the documents associated with that case, choose which documents you want, and request them.\nyou must pay 50¢ per page to get printouts of these documents.\nif you cannot go to the court offices, you can follow the procedure described on this web page to order documents by mail.\nif you have a lawyer, that lawyer may be able to search for these documents on-line themselves.\n\nsee the legal help & crime victim protection section for some tips on getting help from a lawyer.\n\npassports\na u.s. passport is required for international travel to most countries outside the united states.\nyou need a passport to travel by air, land, or sea to most international destinations.\ngetting a passport for the first time\nto apply for your first u.s. passport, you must apply in person at an authorized passport acceptance facility.\nyou cannot apply by mail for a first-time passport.\nit costs $165 total ($130 application fee + $35 execution fee) to apply for an adult passport.\nyou must bring the following documents:\n\nproof of u.s. citizenship (certified u.s. birth certificate with official seal, or certificate of naturalization, or certificate of citizenship, or consular report of birth abroad, or a previous u.s. passport)\nnote: digital or mobile birth certificates are not accepted; you must bring a physical birth certificate\n\n\na photo identification with your picture (driver's license, government employee id, u.s. military id, or certificate of naturalization or citizenship)\nnote: digital or photocopied documents are not accepted; you must bring the original document\nyou must also submit photocopies of the front and back of your id\n\n\na recent passport photo that meets official requirements\na completed form ds-11 (do not it sign until you are instructed to do so by the passport agent)\n\nyou also must provide an address where you can receive your passport by mail.\nif you do not have a stable address, consider using a mail drop service (see the mail drops section of this guide).\nyou can apply for a passport at the post office.\ncall them to make an appointment:\n\n\n\ncity\npost office address\nphone\n\n\n\natascadero\n9800 el camino real\n805-461-6161\n\n\ncayucos\n97 ash st.\n805-995-3479\n\n\ngrover beach\n917 w. grand ave.\n805-489-5138\n\n\nguadalupe\n1030 guadalupe st.\n805-353-4061\n\n\noceano\n1800 beach st.\n805-489-6515\n\n\npismo beach\n100 crest dr.\n805-481-5971\n\n\nsan luis obispo\n1655 dalidio dr.\n805-543-2605\n\n\nif you are applying for a new passport, if your passport expired more than five years ago and you need a new one, or if your passport was lost or damaged and you need a new one, you can also apply for a passport at certain slo county public libraries branches. \ncall them to make an appointment:\n\natascadero library\nnipomo library\nslo city library\n\nrenewing your passport\nyou can renew your passport by mail if all of the following are true:\n\nyou have your most recent passport with you\nyour passport is not damaged or mutilated\nyour passport was issued when you were age 16 or older\nyour passport was issued in the last 15 years\nyour passport is in your current name (or you can document a legal name change)\n\nif you meet these requirements, you can renew by mail using form ds-82.\nthis costs $130 for adults.\nyou can also renew online at travel.state.gov if you meet additional eligibility requirements.\nif you cannot renew by mail (for example, if your passport is lost, stolen, damaged, or expired more than five years), you must apply in person using the same process as for a first-time passport.\nreplacing a lost or stolen passport\nif your passport is lost or stolen, follow these steps to get a new one:\n\nreport it immediately:\n  report your passport lost or stolen as soon as possible.\n  this protects you from identity theft.\n  you can report online using form ds-64, by calling 877-487-2778 (tty 888-874-7793), or in person when you apply for a replacement.\n  note that if you report your passport lost or stolen, you can no longer use it for travel even if you find it later.\n\napply for a replacement:\n  to replace a lost or stolen passport, apply in person at an authorized passport acceptance facility.\n  the process and requirements are the same as for a first-time passport application (see above).\n  reporting your passport lost or stolen does not replace it; to get a replacement you must also apply for a new passport.\n  this costs $165.\n\n\npassports from other countries\nif you are a citizen of another country and you need to obtain or renew a passport from your home country, contact your country's embassy or consulate.\nthe nearest consulates for many countries are located in los angeles or san francisco.\nyou can find contact information for embassies and consulates at embassy.goabroad.com or by searching online for your country's embassy or consulate in the united states.\ntips\ndocument storage and security\nhere are some tips for handling important documents:\n\nuse your phone camera to take photos of important documents, and save those photos \"in the cloud\" (icloud for iphone, google photos for android) so still have access to your photos if your phone is lost or stolen.\nmake copies of important documents, and store the copies separately from the originals.\nthat way if you lose one set, you are less likely to lose all of them.\nsome homeless services centers offer document storage for their clients.\nask your case worker if they can store your important documents in your file at those agencies.\nif you have enough money, consider storing especially important or difficult-to-replace documents in a safety deposit box at a bank.\nthese can be rented for $30-50 per year.\n\nif you have no identification documents\nif you are completely without identifying documentation, you may need help establishing your identity so that you can access programs and services that require identifying documentation.\nyou may want to begin by contacting the social security administration who can assist you in verifying your identity through their records.\nslo court self-help services can help you through california's affidavit processes, with which you can establish your identity when you lack identity documentation.\nthis way you can get a california photo id card, which helps you get access to many programs and services.\nthere is an expensive filing fee for this process, but ask about a fee waiver that is available to people with low incomes.\nif you have a case manager, ask them if they can help you with this process.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "social-security-numbers-or-cards",
+    "title": "Social Security Numbers or Cards",
+    "content": "you do not often need your social security card, but you do often need your social security number.\nthe social security administration can help you get a new social security card.\nif you have an account or can create an on-line account at ssa.gov/myaccount, you can request a social security card on-line and it will be mailed to you.\nyou can get help with this process by calling 800-772-1213 (tty: 800-325-0778).\n\nsee mail drops, post office boxes, etc. for ways to get mail if you do not have a stable mailing address.\n\nif you are unable to complete this on-line process, you can visit the local social security administration office to get a new card.\nit will go more smoothly if you can bring some alternative form of identification like a driver's license or passport.\nin the absence of those, a military id, employee id, school id, or health insurance card might be helpful.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "id-cards-drivers-licenses",
+    "title": "ID Cards and Driver’s Licenses",
+    "content": "a state-issued \"real id,\" or a california driver's license which is also a real id, is a useful form of government-issued photo identification card that is widely accepted by a variety of programs, businesses, and service providers.\nyou get such an identification card from the california dmv.\nyou must visit the california dmv office to have your photo taken and to submit your paperwork.\nyou typically first need to already have another identification document (such as a certified birth certificate, a passport, a permanent resident card, a certificate of naturalization or citizenship, or a permanent resident card) as well as documents that demonstrate your california residency (such as a utility bill, tax return, bank statement, or rental agreement that contains your name and address).\nthere are also fees you typically must pay to obtain either a real id or a driver's license that operates as a real id.\nhowever, if you are homeless, you may be able to get a waiver for fees (a \"no-fee id card\"), and you may be able to use the address of a homeless shelter or other homeless services agency as your california residency address.\nthis is true even if you are only temporarily homeless because you are fleeing domestic violence or a similar dangerous situation.\nyou can only get a simple real id (\"california identification card\") with the no-fee method, not a driver's license.\nhomeless services providers like 40 prado homeless services center, the 5cities homeless coalition (5chc), or the el camino homeless organization (echo) can help you with this process.\nif you have previously received a real id or california driver's license, but you have lost the card and need to replace it, you can begin this process by visiting www.edl.dmv.ca.gov/apply or the california dmv office.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "birth-death-marriage-certificates",
+    "title": "Birth, Death, and Marriage Certificates",
+    "content": "if you were born in slo county, you can obtain a copy of your birth certificate from the slo county clerk-recorder.\nyou will need to show valid identification (typically, a government-issued photo id like a driver's license or passport).\nthere is also a $32 fee.\nhowever, if you are homeless, you can request an \"affidavit of homeless status for fee exempt certified copy of birth certificate.\"\nyou need to sign this and you also need to get a signature from a \"homeless services provider.\"\nthis exempts you from having to pay the $32 fee.\nhomeless services providers like 40 prado homeless services center, the 5cities homeless coalition (5chc), or the el camino homeless organization (echo) can help you with this process.\nyou can obtain a \"certified copy\" of a birth certificate for yourself or your child or other close relative.\na certified copy allows you to establish your identity.\notherwise you can obtain an \"informational\" copy, which is not valid for establishing identity.\nyou should understand ahead of time whether or not you need a certified copy, and, if so, you should be sure to ask for one specifically when you order your copy.\nyou can also use the vitalchek website to order an informational copy of your birth certificate on-line without visiting the slo county clerk-recorder office.\n(you may need to provide a notarized, sworn statement if you want to order a \"certified copy\" this way, in which case it is probably just as easy to visit the slo county clerk-recorder office.)\nthat may cost a bit more.\ndeath records for deaths that occurred in slo county can also be obtained from the slo county clerk-recorder ($24) or from vitalchek.\nagain, there is a difference between \"certified\" and \"informational\" copies of death certificates, and you should check which one you need before you order it.\nyou can typically only get a \"certified\" copy for a close relative, and you may have to provide additional documentation.\nyou can also get a copy of a marriage certificate that was issued in slo county from the slo county clerk-recorder office ($17) or from vitalchek.\nagain, there is a difference between \"certified\" and \"informational\" copies, and you should check which one you need before you order it.\nyou can typically only get a \"certified\" copy for yourself or a close relative, and you may have to provide additional documentation.\nthere is no homeless fee exemption program for death and marriage certificates the way there is for birth certificates.\nif you need a birth, death, or marriage certificate from another county in california, try the california department of public health's \"vital records\" web page.\nif you need such records from elsewhere in the u.s. outside california, visit the national center for health statistics web page.\nthe vitalchek website can often also get you these records from other areas.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "civil-case-documents",
+    "title": "Civil Case Documents",
+    "content": "to get copies of slo superior court documents in civil cases to which you are a party, first go to the court offices in san luis obispo or in paso robles.\nthose offices have a publicly-accessible computer at which you can find your case number.\ncourt staff can help you with this process.\nthen review the documents associated with that case, choose which documents you want, and request them.\nyou must pay 50¢ per page to get printouts of these documents.\nif you cannot go to the court offices, you can follow the procedure described on this web page to order documents by mail.\nif you have a lawyer, that lawyer may be able to search for these documents on-line themselves.\n\nsee the legal help & crime victim protection section for some tips on getting help from a lawyer.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "passports",
+    "title": "Passports",
+    "content": "a u.s. passport is required for international travel to most countries outside the united states.\nyou need a passport to travel by air, land, or sea to most international destinations.\ngetting a passport for the first time\nto apply for your first u.s. passport, you must apply in person at an authorized passport acceptance facility.\nyou cannot apply by mail for a first-time passport.\nit costs $165 total ($130 application fee + $35 execution fee) to apply for an adult passport.\nyou must bring the following documents:\n\nproof of u.s. citizenship (certified u.s. birth certificate with official seal, or certificate of naturalization, or certificate of citizenship, or consular report of birth abroad, or a previous u.s. passport)\nnote: digital or mobile birth certificates are not accepted; you must bring a physical birth certificate\n\n\na photo identification with your picture (driver's license, government employee id, u.s. military id, or certificate of naturalization or citizenship)\nnote: digital or photocopied documents are not accepted; you must bring the original document\nyou must also submit photocopies of the front and back of your id\n\n\na recent passport photo that meets official requirements\na completed form ds-11 (do not it sign until you are instructed to do so by the passport agent)\n\nyou also must provide an address where you can receive your passport by mail.\nif you do not have a stable address, consider using a mail drop service (see the mail drops section of this guide).\nyou can apply for a passport at the post office.\ncall them to make an appointment:\n\n\n\ncity\npost office address\nphone\n\n\n\natascadero\n9800 el camino real\n805-461-6161\n\n\ncayucos\n97 ash st.\n805-995-3479\n\n\ngrover beach\n917 w. grand ave.\n805-489-5138\n\n\nguadalupe\n1030 guadalupe st.\n805-353-4061\n\n\noceano\n1800 beach st.\n805-489-6515\n\n\npismo beach\n100 crest dr.\n805-481-5971\n\n\nsan luis obispo\n1655 dalidio dr.\n805-543-2605\n\n\nif you are applying for a new passport, if your passport expired more than five years ago and you need a new one, or if your passport was lost or damaged and you need a new one, you can also apply for a passport at certain slo county public libraries branches. \ncall them to make an appointment:\n\natascadero library\nnipomo library\nslo city library\n\nrenewing your passport\nyou can renew your passport by mail if all of the following are true:\n\nyou have your most recent passport with you\nyour passport is not damaged or mutilated\nyour passport was issued when you were age 16 or older\nyour passport was issued in the last 15 years\nyour passport is in your current name (or you can document a legal name change)\n\nif you meet these requirements, you can renew by mail using form ds-82.\nthis costs $130 for adults.\nyou can also renew online at travel.state.gov if you meet additional eligibility requirements.\nif you cannot renew by mail (for example, if your passport is lost, stolen, damaged, or expired more than five years), you must apply in person using the same process as for a first-time passport.\nreplacing a lost or stolen passport\nif your passport is lost or stolen, follow these steps to get a new one:\n\nreport it immediately:\n  report your passport lost or stolen as soon as possible.\n  this protects you from identity theft.\n  you can report online using form ds-64, by calling 877-487-2778 (tty 888-874-7793), or in person when you apply for a replacement.\n  note that if you report your passport lost or stolen, you can no longer use it for travel even if you find it later.\n\napply for a replacement:\n  to replace a lost or stolen passport, apply in person at an authorized passport acceptance facility.\n  the process and requirements are the same as for a first-time passport application (see above).\n  reporting your passport lost or stolen does not replace it; to get a replacement you must also apply for a new passport.\n  this costs $165.\n\n\npassports from other countries\nif you are a citizen of another country and you need to obtain or renew a passport from your home country, contact your country's embassy or consulate.\nthe nearest consulates for many countries are located in los angeles or san francisco.\nyou can find contact information for embassies and consulates at embassy.goabroad.com or by searching online for your country's embassy or consulate in the united states.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "document-tips",
+    "title": "Tips",
+    "content": "document storage and security\nhere are some tips for handling important documents:\n\nuse your phone camera to take photos of important documents, and save those photos \"in the cloud\" (icloud for iphone, google photos for android) so still have access to your photos if your phone is lost or stolen.\nmake copies of important documents, and store the copies separately from the originals.\nthat way if you lose one set, you are less likely to lose all of them.\nsome homeless services centers offer document storage for their clients.\nask your case worker if they can store your important documents in your file at those agencies.\nif you have enough money, consider storing especially important or difficult-to-replace documents in a safety deposit box at a bank.\nthese can be rented for $30-50 per year.\n\nif you have no identification documents\nif you are completely without identifying documentation, you may need help establishing your identity so that you can access programs and services that require identifying documentation.\nyou may want to begin by contacting the social security administration who can assist you in verifying your identity through their records.\nslo court self-help services can help you through california's affidavit processes, with which you can establish your identity when you lack identity documentation.\nthis way you can get a california photo id card, which helps you get access to many programs and services.\nthere is an expensive filing fee for this process, but ask about a fee waiver that is available to people with low incomes.\nif you have a case manager, ask them if they can help you with this process.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "mail-drops-post-office-boxes",
+    "title": "Mail Drops, Post Office Boxes, Etc.",
+    "content": "if you are homeless, you may be at a loss when asked for your mailing address.\nthere are various ways to establish a reliable mailing address even if you do not have a stable living address.\nthe 5cities homeless coalition and 40 prado homeless services center offices permit clients of their services to use these offices as mailing addresses, and will hold your incoming mail there for you. \nask them for details.\nyou can rent mail boxes from ups stores and from the u.s. postal service.\nthe postal service option is the most affordable of the two.\nbut sometimes, a \"p.o. box\" address (which is what you get from the postal service) is not adequate for your needs, and one advantage of the ups store option is that it appears as a regular street address (e.g. \"1241 johnson avenue #1234, san luis obispo\").\nups store locations with mailbox rental services are available throughout slo county including:\n\n\n\ncity\nups store location\nphone\n\n\n\narroyo grande\n1375 e. grand ave. #103\n805-904-6480\n\n\natascadero\n7343 el camino real\n805-466-9015\n\n\nmorro bay\n630 quintana rd.\n805-772-9284\n\n\nnipomo\n110 south mary ave. #2\n805-929-0055\n\n\npaso robles\n179 niblick rd.\n805-237-8727\n\n\npismo beach\n567 five cities dr.\n805-295-6581\n\n\nslo\n3940 broad st.\n805-549-0200\n\n\nslo\n793 foothill blvd.\n805-541-9333\n\n\nslo\n1241 johnson ave.\n805-541-1334\n\n\nanother option is to ask people to send you mail addressed to \"general delivery\":\n\nyour name\ngeneral delivery\ncity name, ca zip-code‒9999\n\nyou can collect mail that is sent to you via general delivery from the post office.\nhere are some general delivery zip codes for slo county:\n\n\n\npost office\npick-up address\nzip code\n\n\n\narroyo grande\n160 station way\n93420‒9999\n\n\natascadero\n9800 el camino real\n93422‒9999\n\n\ncambria\n4100 bridge st.\n93428‒9999\n\n\ncayucos\n97 ash ave.\n93430‒9999\n\n\ngrover beach\n917 w. grand ave.\n93433‒9999\n\n\nlos osos\n1189 los osos valley rd.\n93402‒9999\n\n\nmorro bay\n898 napa ave.\n93442‒9999\n\n\nnipomo\n630 w. tefft st.\n93444‒9999\n\n\noceano\n1800 beach st.\n93445‒9999\n\n\npaso robles\n800 6th st.\n93446‒9999\n\n\npismo beach\n100 crest dr.\n93449‒9999\n\n\nsan luis obispo\n1655 dalidio dr. (main)\n93401‒9999\n\n\nsan simeon\n250 san simeon ave. ste 7\n93452‒9999\n\n\nsanta margarita\n22360 el camino real\n93453‒9999\n\n\ntempleton\n101 n. main st.\n93465‒9999\n\n\nnote: in cities with multiple post office locations, general delivery is typically handled at only one facility (usually the main post office). for example, san luis obispo has two post offices, but general delivery is handled at the main location on dalidio dr.\nto confirm which location handles general delivery in your area, call 800-275-8777 and request \"customer service,\" or use the usps zip code lookup tool by entering \"general delivery\" as the address line.\n\n\nyou should speak with the postmaster at the post office where you want to receive general delivery mail beforehand.\nthe post office will hold general delivery mail for you for 30 days.\nyou must have a valid photo id to collect your mail at the post office.\nthis service is free.\nhowever, this is not a long-term solution; it is meant for temporary use (for instance by travelers passing through town).\nthe post office may stop accepting general delivery mail for you if you try to use this method for a long time or if you get too much mail.\n\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "banking-and-money-management",
+    "title": "Banking and Money Management",
+    "content": "in this section:\n\nbanks and credit unions\nfinancial literacy classes and 1-on-1 assistance\ndebt consolidation\n\nbanks and credit unions\ncredit unions are like banks, but are nonprofit organizations that tend to be locally-focused.\nthey can often be more accommodating than banks to people with low incomes and to homeless people.\ncredit unions in slo county include:\n\ncoasthills credit union\ngolden 1 credit union\nsesloc credit union\nslo credit union\n\nsome ordinary banks offer \"bank on certified accounts\" which are savings or checking accounts that are more affordable, have small minimum balances, and have no overdraft fees.\nyou can search for banks that offer such accounts at joinbankon.org.\n\nsee the mail drops, post office boxes, etc. section of this guide if you do not have a stable address and you need an address you can use while establishing a bank account.\n\n\nsee the ids and other documents section of this guide for information on how to obtain required identification and other documentation.\n\ntips for how to succeed in establishing a bank account:\n\ncall ahead: contact banks before you visit and ask about their specific requirements\nbring multiple documents: have as much identification and address verification as possible\nask about special programs: specifically inquire about programs for people without permanent addresses\nconsider credit unions first: they are often more flexible and community-focused than large banks\nuse service organization support: have case workers or service providers help advocate and provide verification if needed\n\nfinancial literacy classes and 1-on-1 assistance\nsesloc credit union offers online webinars on topics like debt management and the psychology of spending.\nthese webinars are free to the public.\nthey also offer free one-on-one, professional financial counseling to sesloc members.\ngoodwill central coast has a free \"opportunity platform\" that includes one-on-one financial coaching services to help you achieve your personal money goals.\ndebt consolidation\nmoney management international (866-889-9347) and national foundation for credit counseling (800-388-2227) are nonprofit groups that can help you manage credit card or other debt.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "banks-and-credit-unions",
+    "title": "Banks and Credit Unions",
+    "content": "credit unions are like banks, but are nonprofit organizations that tend to be locally-focused.\nthey can often be more accommodating than banks to people with low incomes and to homeless people.\ncredit unions in slo county include:\n\ncoasthills credit union\ngolden 1 credit union\nsesloc credit union\nslo credit union\n\nsome ordinary banks offer \"bank on certified accounts\" which are savings or checking accounts that are more affordable, have small minimum balances, and have no overdraft fees.\nyou can search for banks that offer such accounts at joinbankon.org.\n\nsee the mail drops, post office boxes, etc. section of this guide if you do not have a stable address and you need an address you can use while establishing a bank account.\n\n\nsee the ids and other documents section of this guide for information on how to obtain required identification and other documentation.\n\ntips for how to succeed in establishing a bank account:\n\ncall ahead: contact banks before you visit and ask about their specific requirements\nbring multiple documents: have as much identification and address verification as possible\nask about special programs: specifically inquire about programs for people without permanent addresses\nconsider credit unions first: they are often more flexible and community-focused than large banks\nuse service organization support: have case workers or service providers help advocate and provide verification if needed\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "financial-literacy",
+    "title": "Financial Literacy Classes and 1-on-1 Assistance",
+    "content": "sesloc credit union offers online webinars on topics like debt management and the psychology of spending.\nthese webinars are free to the public.\nthey also offer free one-on-one, professional financial counseling to sesloc members.\ngoodwill central coast has a free \"opportunity platform\" that includes one-on-one financial coaching services to help you achieve your personal money goals.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "debt-consolidation",
+    "title": "Debt Consolidation",
+    "content": "money management international (866-889-9347) and national foundation for credit counseling (800-388-2227) are nonprofit groups that can help you manage credit card or other debt.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "tax-preparation",
+    "title": "Tax Preparation",
+    "content": "there are several programs that can give you free assistance in completing and filing your annual tax returns.\nfree tax assistance programs are usually available in the february-through-april period.\neven if you do not think you owe any taxes because your income is very low, it can be to your advantage to file a tax return.\nthis is for a few reasons:\n\nyou may qualify for certain refundable tax credits that can put money in your pocket, even if you did not pay taxes all year.\nsome programs for low-income people require those people to show their most recent tax return to prove that they qualify.\nfiling a tax return, even if it is of no practical effect, can be a gesture of compliance with the law that can be helpful, for example if you are engaged in the u.s. immigration process.\n\navoid using commercial tax preparers that charge high fees, or that offer \"refund anticipation loans.\"\nsome of these give poor-quality tax advice, and most of them are bad bargains compared to the free services.\nif you are due a tax refund, you will get that refund more quickly if you have a bank account that accepts direct deposit.\nthe u.s. internal revenue service stopped issuing paper tax refund checks in 2025.\n\nsee the banking and money management section of this guide for help in establishing a bank account.\n\nthe national volunteer income tax assistance (vita) program allows low- and moderate-income people to get free help in preparing and filing their federal and state tax returns.\nunited way of slo county coordinates the local vita program through various partner organizations, including cal poly and aarp.\nthe aarp tax-aide program is especially for people over age 50.\nuse united way's 211 service to find a vita location near you and make an appointment.\nthe united way also has an on-line program with which you can upload your tax documents and get free help from tax preparation volunteers over the internet.\nthere are also free options that allow you to file your federal income taxes yourself by using guided tax preparation software or by filling in on-line forms and filing them electronically.\nsee irs.gov/freefile for details.\n\n\n\nsee the internet access / email / digital access assistance section of this guide for ways to get access to a computer and the internet.\n\nhomeless people can use the address of a friend, relative, or trusted service provider as their filing address.\n\nsee the mail drops, post office boxes, etc. section of this guide for more options for establishing a mailing address.\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "emergency-financial-help",
+    "title": "Emergency Financial Help",
+    "content": "in this section:\n\nyou can apply yourself\nyou must apply through some referring agency\ngovernment assistance programs\nutility assistance programs\n\nif you need to pay a bill or make a purchase and you have no money, there are some programs available that may be able to help you.\nfor some of these, you can apply directly to the agency running the program to ask for their help.\nfor others, you can only apply through some other agency (your case manager, doctor, or social worker may be able to do this for you if you ask).\nsome of these programs are specific to certain regions or to certain sorts of financial needs.\nmany do not give you money directly, but help you purchase goods or pay bills.\n\nsee the banking and money management section of this guide for financial literacy and credit counseling resources that can help you reduce your debt or save money for when you need it.\n\nyou can apply yourself\n5cities homeless coalition has an immediate needs program that can help low-income families and individuals in need in the five cities area with limited funds to pay for bills, or for goods or services to address their immediate needs such as utilities, transportation, auto repairs, clothing, and employment readiness.\nno funds are given directly to the individual applicant; rather bills are paid or goods are purchased on their behalf.\nunitarian universalists san luis obispo has a \"minister's discretionary fund\" with which it can pay for emergency needs like vehicle registration, repair, payments, or impound fees; property storage fees; travel for healthcare; phones and phone service; or supplies for living outdoors.\nemail minister.uuslo@gmail.com if you need such help.\ngreen pastures, operated by the first presbyterian church in slo city, offers micro-grants for financial needs such as utility bills and medical bills, with a focus on helping people stay in their homes.\nsee their website for details on how and when to apply for these grants.\nst. patrick's church in arroyo grande has limited discretionary funds for specific emergency needs such as utility payments or partial rent.\nthe auntie isabell foundation gives financial assistance (grants and business development microloans) to \"underrepresented individuals\" in paso robles.\ngrants can be for needs like education, housing, transportation, job preparation, addressing life challenges, and child care. \nyou must be aged 18-30 to qualify for a grant. \nyou can apply for grants or loans by completing a form on their website. \nthe society of st. vincent de paul can help with an emergency such as a threatened utility cut-off or a housing eviction notice, or a job-threatening transportation issue.\nthey may also be able to help you with a rental deposit.\nsalvation army provides some rent and utility assistance, when funds are available, from its slo city and arroyo grande service centers.\ncall to make an appointment.\nloaves & fishes (paso robles) can help people of limited means with groceries and other services.\nuse the contact form on their website to request an appointment.\nthe los osos cares resource center can give immediate needs assistance to people in los osos, baywood park, morro bay, cayucos, cambria, and that general region.\njewish family services offers once-per-year pre-paid gas card assistance for people in slo county who need help with transportation costs.\nsubmit an application on their website.\ncatholic charities operates a one-time \"emergency rental assistance\" program.\nit is only available sometimes.\ncheck this web page to see if the program is currently in effect and if so, how to apply for it.\nthey also operate a \"financial stability services\" program which can provide financial resources to low-income people in financial crisis.\nto apply for these programs, first call their main or paso robles number to make an appointment.\nwhen applying for help, bring your identification, proof of income, and proof of need.\nif you are applying for help to pay the rent, also bring your rental agreement.\nif you are applying for help to pay utility bills, bring those bills.\nthe local facebook group helpslo invites people to post requests for needs they have, such as for new tires for their car, or school clothing for their children, or other things like that.\nhowever, you cannot ask for cash.\nthe group is informal, and your need will be met (if it is) by the individual generosity of another group member.\nthe national group modest needs crowdfunds requests for financial assistance for low-income workers who are living paycheck-to-paycheck and who encounter an unexpected or emergency expense they cannot afford, or who become unable to pay their bills.\nthey do not give money to applicants directly, but can help them to pay bills.\nsee their website for instructions on how to apply for a grant.\nif you are a cuesta college student, you can get help with food, housing, health and well-being, transportation, textbooks, parking passes, technology, and other basic needs from the basic needs office.\nyou must apply through some referring agency\nnorth county neighboraid (managed by center for family strengthening) gives cash assistance and gifts of goods to needy people in northern slo county. \nexamples include gas cards for parents traveling to distant children's hospitals, groceries following crises, rental assistance, baby supplies, summer camp fees, and utility payments. \navailability depends on the financial health of the organization (funding fluctuates). \nyou typically cannot apply directly to this program but must be referred to it by a service provider.\nwomenade buys goods and pays bills for people in need.\nwomenade slo helps people in the city of slo; womenade south county helps people in the five cities area and nearby; womenade estero bay helps people in the los osos area.\nyou cannot apply directly for help from womenade, but you must apply through another service provider.\njewish family services has a micro-grant program for people who need one-time emergency financial assistance for needs like rent assistance, vehicle needs, transportation, or food.\nyou cannot apply for this yourself, but must have a case worker apply on your behalf.\nchristian fund for the disabled will match with its own money the grant given by a church or other christian organization to a disabled person who has particular financial needs associated with their disability (such as the need for assistive equipment or rehabilitative therapy).\nyour application to this fund must include documentation from that church or christian organization, among other things.\n\n\ngovernment assistance programs\nslo county department of social services (dss) operates the general assistance cash aid program which provides money and vouchers to people.\nit is for needy people without dependent children who live in slo county who are not eligible for any other cash aid program.\napply for this program at a dss office.\nif you qualify for this program, you must also do an in-person interview at the slo city dss office.\nyou can also apply for calworks cash aid at any dss office, or online at benefitscal.\ncalworks is california's version of the temporary assistance to needy families (tanf) federal program.\nto qualify, you must have a \"qualifying child\" at least one parent of whom is \"deceased, absent from the home, disabled, or unemployed\" and you must be below a certain maximum income/assets limit.\nyou must participate in an in-person interview, and you may need to provide some documentation to verify your eligibility.\nto receive benefits, you may be required to participate in the welfare-to-work program, which helps you prepare for, find, and maintain employment.\nif you are a refugee or an immigrant from cuba or haiti who is not eligible for calworks, you may be able to get benefits from the refugee cash assistance (rca) or entrant cash assistance (eca) programs.\nif you are also a victim of human trafficking, domestic violence, or other serious crime, you may also qualify for trafficking & crime victims assistance program (tcvap).\nfor any of these programs, you can apply in person at a slo county department of social services office.\nbring proof of income and assets and documentation about your refugee or entry status, including your sponsor's information if you have a sponsor.\nfor tcvap, you can also apply online at benefitscal.\nrefugees can also get help applying for these programs from slo for home.\nif you become unemployed, you may be able to apply for unemployment insurance benefits.\nthis temporarily pays you part of the salary you earned while you were working.\nto qualify, you must have a social security number, be authorized to work in the united states, and earn some minimum amount of reported wages or salary during the previous 18 months.\nyou must have become totally or partially unemployed, and through no fault of your own.\nyou must also be able to work, looking for paid work, and able to accept paid work.\nyou can apply for unemployment benefits from california's employment development department (edd) through the myedd website or by phone (800-300-5616, tty: 800-815-9387).\nif you have questions, you can also email wsbsanluisobispoinfo@edd.ca.gov.\nif you are a u.s. military veteran, you can get help learning about, applying for, and receiving government benefits you are entitled to from the county veterans services offices.\nif you are a farm laborer, you may be able to get some help applying for benefits from the civil assistance program of the california farmworker foundation.\nutility assistance programs\n\n\nsome local utilities have or participate in programs to make it easier for people with limited means to pay their utility bills.\nthe pg&e care program gives a discount of at least 20% on gas and electric bills to people with low incomes or who are enrolled in public assistance programs such as medi-cal, calfresh, or ssi.\nif you do not qualify for that program, you may still qualify for family electric rate assistance which can give you a 18% discount on your electric bill.\napply for either program online at energyinsight.pge.com/carefera\nif you have questions, contact them at careandfera@pge.com or 877-660-6789.\npg&e also has a relief for energy assistance through community help (reach) program.\nit can help people who are threatened with energy bill shutoff during times of crisis by giving them a credit for the amount due on their bill.\nto apply, complete the dollar energy fund application form on-line, or call 888-282-6816.\ncapslo operates the low income home energy assistance program (also known as heap or liheap).\nthis program helps low-income households in slo county with one-time assistance to pay their gas, propane, or electric bill.\nit has limited funding, so is only able to offer help while funding is available.\nthe city of slo has customer assistance programs that can reduce your water, sewer, trash, and recycling bills.\nfor details on how to apply, contact the utility billing department at 805-781-7133 or ub@slocity.org.\nlow-income households in los osos who qualify for in pg&e's care program (see above) can also get up to 50% off of their sewer bill by applying for los osos low income financial assistance program.\ncontact the county department of public works at publicworks@co.slo.ca.us or 805-781-5252 for details.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "financial-aid-apply-yourself",
+    "title": "You Can Apply Yourself",
+    "content": "5cities homeless coalition has an immediate needs program that can help low-income families and individuals in need in the five cities area with limited funds to pay for bills, or for goods or services to address their immediate needs such as utilities, transportation, auto repairs, clothing, and employment readiness.\nno funds are given directly to the individual applicant; rather bills are paid or goods are purchased on their behalf.\nunitarian universalists san luis obispo has a \"minister's discretionary fund\" with which it can pay for emergency needs like vehicle registration, repair, payments, or impound fees; property storage fees; travel for healthcare; phones and phone service; or supplies for living outdoors.\nemail minister.uuslo@gmail.com if you need such help.\ngreen pastures, operated by the first presbyterian church in slo city, offers micro-grants for financial needs such as utility bills and medical bills, with a focus on helping people stay in their homes.\nsee their website for details on how and when to apply for these grants.\nst. patrick's church in arroyo grande has limited discretionary funds for specific emergency needs such as utility payments or partial rent.\nthe auntie isabell foundation gives financial assistance (grants and business development microloans) to \"underrepresented individuals\" in paso robles.\ngrants can be for needs like education, housing, transportation, job preparation, addressing life challenges, and child care. \nyou must be aged 18-30 to qualify for a grant. \nyou can apply for grants or loans by completing a form on their website. \nthe society of st. vincent de paul can help with an emergency such as a threatened utility cut-off or a housing eviction notice, or a job-threatening transportation issue.\nthey may also be able to help you with a rental deposit.\nsalvation army provides some rent and utility assistance, when funds are available, from its slo city and arroyo grande service centers.\ncall to make an appointment.\nloaves & fishes (paso robles) can help people of limited means with groceries and other services.\nuse the contact form on their website to request an appointment.\nthe los osos cares resource center can give immediate needs assistance to people in los osos, baywood park, morro bay, cayucos, cambria, and that general region.\njewish family services offers once-per-year pre-paid gas card assistance for people in slo county who need help with transportation costs.\nsubmit an application on their website.\ncatholic charities operates a one-time \"emergency rental assistance\" program.\nit is only available sometimes.\ncheck this web page to see if the program is currently in effect and if so, how to apply for it.\nthey also operate a \"financial stability services\" program which can provide financial resources to low-income people in financial crisis.\nto apply for these programs, first call their main or paso robles number to make an appointment.\nwhen applying for help, bring your identification, proof of income, and proof of need.\nif you are applying for help to pay the rent, also bring your rental agreement.\nif you are applying for help to pay utility bills, bring those bills.\nthe local facebook group helpslo invites people to post requests for needs they have, such as for new tires for their car, or school clothing for their children, or other things like that.\nhowever, you cannot ask for cash.\nthe group is informal, and your need will be met (if it is) by the individual generosity of another group member.\nthe national group modest needs crowdfunds requests for financial assistance for low-income workers who are living paycheck-to-paycheck and who encounter an unexpected or emergency expense they cannot afford, or who become unable to pay their bills.\nthey do not give money to applicants directly, but can help them to pay bills.\nsee their website for instructions on how to apply for a grant.\nif you are a cuesta college student, you can get help with food, housing, health and well-being, transportation, textbooks, parking passes, technology, and other basic needs from the basic needs office.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "financial-aid-get-referral",
+    "title": "You Must Apply through Some Referring Agency",
+    "content": "north county neighboraid (managed by center for family strengthening) gives cash assistance and gifts of goods to needy people in northern slo county. \nexamples include gas cards for parents traveling to distant children's hospitals, groceries following crises, rental assistance, baby supplies, summer camp fees, and utility payments. \navailability depends on the financial health of the organization (funding fluctuates). \nyou typically cannot apply directly to this program but must be referred to it by a service provider.\nwomenade buys goods and pays bills for people in need.\nwomenade slo helps people in the city of slo; womenade south county helps people in the five cities area and nearby; womenade estero bay helps people in the los osos area.\nyou cannot apply directly for help from womenade, but you must apply through another service provider.\njewish family services has a micro-grant program for people who need one-time emergency financial assistance for needs like rent assistance, vehicle needs, transportation, or food.\nyou cannot apply for this yourself, but must have a case worker apply on your behalf.\nchristian fund for the disabled will match with its own money the grant given by a church or other christian organization to a disabled person who has particular financial needs associated with their disability (such as the need for assistive equipment or rehabilitative therapy).\nyour application to this fund must include documentation from that church or christian organization, among other things.\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "government-assistance-programs",
+    "title": "Government Assistance Programs",
+    "content": "slo county department of social services (dss) operates the general assistance cash aid program which provides money and vouchers to people.\nit is for needy people without dependent children who live in slo county who are not eligible for any other cash aid program.\napply for this program at a dss office.\nif you qualify for this program, you must also do an in-person interview at the slo city dss office.\nyou can also apply for calworks cash aid at any dss office, or online at benefitscal.\ncalworks is california's version of the temporary assistance to needy families (tanf) federal program.\nto qualify, you must have a \"qualifying child\" at least one parent of whom is \"deceased, absent from the home, disabled, or unemployed\" and you must be below a certain maximum income/assets limit.\nyou must participate in an in-person interview, and you may need to provide some documentation to verify your eligibility.\nto receive benefits, you may be required to participate in the welfare-to-work program, which helps you prepare for, find, and maintain employment.\nif you are a refugee or an immigrant from cuba or haiti who is not eligible for calworks, you may be able to get benefits from the refugee cash assistance (rca) or entrant cash assistance (eca) programs.\nif you are also a victim of human trafficking, domestic violence, or other serious crime, you may also qualify for trafficking & crime victims assistance program (tcvap).\nfor any of these programs, you can apply in person at a slo county department of social services office.\nbring proof of income and assets and documentation about your refugee or entry status, including your sponsor's information if you have a sponsor.\nfor tcvap, you can also apply online at benefitscal.\nrefugees can also get help applying for these programs from slo for home.\nif you become unemployed, you may be able to apply for unemployment insurance benefits.\nthis temporarily pays you part of the salary you earned while you were working.\nto qualify, you must have a social security number, be authorized to work in the united states, and earn some minimum amount of reported wages or salary during the previous 18 months.\nyou must have become totally or partially unemployed, and through no fault of your own.\nyou must also be able to work, looking for paid work, and able to accept paid work.\nyou can apply for unemployment benefits from california's employment development department (edd) through the myedd website or by phone (800-300-5616, tty: 800-815-9387).\nif you have questions, you can also email wsbsanluisobispoinfo@edd.ca.gov.\nif you are a u.s. military veteran, you can get help learning about, applying for, and receiving government benefits you are entitled to from the county veterans services offices.\nif you are a farm laborer, you may be able to get some help applying for benefits from the civil assistance program of the california farmworker foundation.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "utility-assistance-programs",
+    "title": "Utility Assistance Programs",
+    "content": "some local utilities have or participate in programs to make it easier for people with limited means to pay their utility bills.\nthe pg&e care program gives a discount of at least 20% on gas and electric bills to people with low incomes or who are enrolled in public assistance programs such as medi-cal, calfresh, or ssi.\nif you do not qualify for that program, you may still qualify for family electric rate assistance which can give you a 18% discount on your electric bill.\napply for either program online at energyinsight.pge.com/carefera\nif you have questions, contact them at careandfera@pge.com or 877-660-6789.\npg&e also has a relief for energy assistance through community help (reach) program.\nit can help people who are threatened with energy bill shutoff during times of crisis by giving them a credit for the amount due on their bill.\nto apply, complete the dollar energy fund application form on-line, or call 888-282-6816.\ncapslo operates the low income home energy assistance program (also known as heap or liheap).\nthis program helps low-income households in slo county with one-time assistance to pay their gas, propane, or electric bill.\nit has limited funding, so is only able to offer help while funding is available.\nthe city of slo has customer assistance programs that can reduce your water, sewer, trash, and recycling bills.\nfor details on how to apply, contact the utility billing department at 805-781-7133 or ub@slocity.org.\nlow-income households in los osos who qualify for in pg&e's care program (see above) can also get up to 50% off of their sewer bill by applying for los osos low income financial assistance program.\ncontact the county department of public works at publicworks@co.slo.ca.us or 805-781-5252 for details.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "navigating-social-security",
+    "title": "Navigating Social Security / SSDI / SSI / Survivors Benefits / CAPI",
+    "content": "\nsee the social security numbers or cards section of this guide to learn how to get a social security number or to get or replace a social security card.\n\nnote: in 2025, social security stopped issuing paper checks.\nnow they use direct deposit to bank accounts or issue a \"direct express\" prepaid debit card.\n\nsee the banks and credit unions section of this guide for information on how to establish a bank account.\n\nthere are a number of programs operated by the social security administration, including:\n\nsocial security - monthly payments from the government to people who reach retirement age, and who paid into the social security system while they were working\nsocial security disability insurance (ssdi) - monthly payments from the government to people who cannot work because they are disabled, and who paid into the social security system while they were working\nsupplemental security income (ssi) - monthly payments from the government to disabled people and to seniors with limited means\n\nhomeless people have the same rights as anyone else to apply for these payments.\nyou do not have to have a permanent address to receive benefits.\nyou may be entitled to certain benefits even if you did not pay into the social security system, if your spouse or ex-spouse did.\nyou may need to appear at the social security administration office in person to apply for such spousal or survivors benefits.\n\nsee the mail drops section of this guide for information on establishing a mailing address.\n\nyou can apply for these benefits through the local social security administration office either in person or by phone.\nyou can also apply on-line at the social security administration's website.\nif you have a case worker, ask them if they can help you through the process or refer you to someone who can.\nto make the application process go smoothly, learn what documentation you need and have that documentation with you when you apply.\nif you do not have a stable mailing address, establish one ahead of time.\nif you are applying for disability, bring your relevant medical records, treatment history, and medical provider contact information.\npay stubs and tax records can help to establish your work history, especially if you were paid under-the-table or as a contractor rather than an employee.\nbe patient, as the process of applying for benefits can be time-consuming and the bureaucracy can move slowly.\nif you are denied benefits, learn about the appeals process and consider appealing the decision.\nif you are denied ssi benefits solely because of your immigration status, you may be able to get benefits instead from the california assistance program for immigrants (capi).\napply from the slo county department of social services.\nif you have a disability and are applying for social security disability insurance, you may be able to get some immediate financial help from the slo county department of social services' \"general assistance disabled program\" while you wait for your application to be processed.\nthey may also be able to assign you a \"benefits arch advocate\" who can help you apply for ssi and ssdi.\n\n\nthe government encourages you to seek work and to return to work without losing disability benefits.\nthe ticket to work program is a free, voluntary program for people aged 18-64 who are receiving ssdi or ssi benefits.\nit can give you free career counseling, vocational rehabilitation, and job placement and training.\ncall 866-968-7842 (tty: 866-833-2967) to learn how to apply.\nif you are a u.s. military veteran, you may also qualify for a variety of other benefits.\nyou can get help learning about, applying for, and receiving government benefits you are entitled to from the county veterans services offices.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "employment-job-boards",
+    "title": "Employment, Job Boards, Etc.",
+    "content": "in this section:\n\nfinding steady work\nmaking ends meet: recycling\nmaking ends meet: gig jobs\n\nfinding steady work\nthe slo cal careers center offers free employment and training, can help you improve your résumé and your interviewing skills, and can help you find job openings.\nthey offer specialized services for young people, for veterans, and for people with disabilities.\neckerd connects workforce development can help you explore career possibilities, get training and credentialing to help you qualify for more jobs, and find employment.\napply on-line at their website.\ncaljobs is a job listing and resume listing web site.\nyou can search for open employment positions on the site, and you can add your resume so that employers can search for you.\nthe state employment development department (edd) offers many job seeker services such as free job training programs and job fairs.\nthe employment development department (edd) has a migrant seasonal farmworker program that includes no-cost job search assistance, labor market info, vocational training, and information about your legal rights and labor law protections.\ngoodwill central coast has a free \"opportunity platform\" that includes job search, resume building, digital literacy, and job readiness programs.\nslo county public libraries brainfuse helpnow elearning program can help you prepare for a variety of standardized tests, learn professional skills, and polish your resume.\nits ebscolearning platform can help you prepare a good resume and cover letter, can improve your job search technique, and can better prepare you for a job interview.\nrecent refugees from other countries can also get help finding employment from slo for home.\n\n\nfor college students\ncuesta college students, graduates, and staff can get help finding a job or an internship from cuesta college career services (careerservices@cuesta.edu, 805-546-3252 slo, 805-546-3232 paso robles).\ncall to make an appointment.\ncal poly (slo) students, graduates, and staff can get help from cal poly career services (careerservices@calpoly.edu, 805-756-1111, student services building, room 114).\nthis includes career counseling, career and professional development certificates, interview clothes, and career fairs.\nthey also conduct workshops on topics like job searching, building your resume, interview skills, and how to use linkedin.\nfor people with disabilities\nif you are currently receiving ssdi or ssi benefits and you are between the ages of 18 and 64, the ticket to work program can give you free career counseling, vocational rehabilitation, and job placement and training, and can help you return to work without losing your benefits.\ncall 866-968-7842 (tty: 866-833-2967) to learn how to apply.\npathpoint helps people with intellectual or developmental disabilities to find jobs that are good matches for them, trains them in job skills, and helps them to maintain employment.\ntransitions mental health association (tmha) has work programs to help people with mental illnesses find and maintain meaningful employment.\nthey operate the growing grounds farm, nursery, and downtown slo retail store, which employ tmha clients and give them vocational training.\ntmha also operates a \"supported employment program\" which helps people with mental illnesses find and keep jobs.\nto use that program, you first must get a referral from california department of rehabilitation, slo county behavioral health, or slo county mental health services.\ncalifornia department of rehabilitation offers vocational rehabilitation services for people with disabilities, including job training, placement assistance, assistive technology, and education support.\nfor people released from jail or prison\nrestorative partners can help you build job experience after you are released from jail or prison.\nthey operate \"the bridge cafe\" which can give you paid employment while training you for certification by cuesta college's culinary arts program.\nafter you complete that program, they will also help you find a job in that field.\ncontact restorative partners to inquire about participating in this program.\nfor u.s. military veterans\nif you were not dishonorably discharged and if you have a service-connected disability rating of at least 10% from the department of veterans affairs, you may be eligible for the veteran readiness & employment (vr&e) program.\nvr&e can help you with with job training, education, employment accommodations, resume development, and job seeking skills coaching.\nyou can apply for this program by submitting a form 28-1900.\nyou can also get help from veterans services.\nthe employment development department (edd) has a veterans services program.\nto apply, register & post a resume in caljobs, then meet with a veterans service navigator at the edd for an initial assessment.\nmaking ends meet: recycling\nthere are a few places in slo county that specialize in purchasing aluminum and glass for recycling:\n\nags recycling (arroyo grande and morro bay)\ncambria recycling center (cambria)\nsteve's recycling (los osos)\nrecycle 101 (oceano)\n\nmany stores also will pay crv (california redemption value) refunds for up to fifty returned beverage containers at a time.\nto find such a store near you, use the search form at the calrecycle website.\nmaking ends meet: gig jobs\nthere are some ways to earn small amounts of money by doing various tasks on the internet, such as taking surveys, watching videos, or testing apps.\nsome of these are scams, and most do not pay very much, but they can be ways to make a few bucks here and there if you are unable to find or commit to steady work.\nthe \"beermoney\" subreddit maintains a curated list of such opportunities.\nthat site also includes feedback from participants on their experiences.\nthe site flexjobs is another way to find remote jobs with flexible hours.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "finding-steady-work",
+    "title": "Finding Steady Work",
+    "content": "the slo cal careers center offers free employment and training, can help you improve your résumé and your interviewing skills, and can help you find job openings.\nthey offer specialized services for young people, for veterans, and for people with disabilities.\neckerd connects workforce development can help you explore career possibilities, get training and credentialing to help you qualify for more jobs, and find employment.\napply on-line at their website.\ncaljobs is a job listing and resume listing web site.\nyou can search for open employment positions on the site, and you can add your resume so that employers can search for you.\nthe state employment development department (edd) offers many job seeker services such as free job training programs and job fairs.\nthe employment development department (edd) has a migrant seasonal farmworker program that includes no-cost job search assistance, labor market info, vocational training, and information about your legal rights and labor law protections.\ngoodwill central coast has a free \"opportunity platform\" that includes job search, resume building, digital literacy, and job readiness programs.\nslo county public libraries brainfuse helpnow elearning program can help you prepare for a variety of standardized tests, learn professional skills, and polish your resume.\nits ebscolearning platform can help you prepare a good resume and cover letter, can improve your job search technique, and can better prepare you for a job interview.\nrecent refugees from other countries can also get help finding employment from slo for home.\n\n\nfor college students\ncuesta college students, graduates, and staff can get help finding a job or an internship from cuesta college career services (careerservices@cuesta.edu, 805-546-3252 slo, 805-546-3232 paso robles).\ncall to make an appointment.\ncal poly (slo) students, graduates, and staff can get help from cal poly career services (careerservices@calpoly.edu, 805-756-1111, student services building, room 114).\nthis includes career counseling, career and professional development certificates, interview clothes, and career fairs.\nthey also conduct workshops on topics like job searching, building your resume, interview skills, and how to use linkedin.\nfor people with disabilities\nif you are currently receiving ssdi or ssi benefits and you are between the ages of 18 and 64, the ticket to work program can give you free career counseling, vocational rehabilitation, and job placement and training, and can help you return to work without losing your benefits.\ncall 866-968-7842 (tty: 866-833-2967) to learn how to apply.\npathpoint helps people with intellectual or developmental disabilities to find jobs that are good matches for them, trains them in job skills, and helps them to maintain employment.\ntransitions mental health association (tmha) has work programs to help people with mental illnesses find and maintain meaningful employment.\nthey operate the growing grounds farm, nursery, and downtown slo retail store, which employ tmha clients and give them vocational training.\ntmha also operates a \"supported employment program\" which helps people with mental illnesses find and keep jobs.\nto use that program, you first must get a referral from california department of rehabilitation, slo county behavioral health, or slo county mental health services.\ncalifornia department of rehabilitation offers vocational rehabilitation services for people with disabilities, including job training, placement assistance, assistive technology, and education support.\nfor people released from jail or prison\nrestorative partners can help you build job experience after you are released from jail or prison.\nthey operate \"the bridge cafe\" which can give you paid employment while training you for certification by cuesta college's culinary arts program.\nafter you complete that program, they will also help you find a job in that field.\ncontact restorative partners to inquire about participating in this program.\nfor u.s. military veterans\nif you were not dishonorably discharged and if you have a service-connected disability rating of at least 10% from the department of veterans affairs, you may be eligible for the veteran readiness & employment (vr&e) program.\nvr&e can help you with with job training, education, employment accommodations, resume development, and job seeking skills coaching.\nyou can apply for this program by submitting a form 28-1900.\nyou can also get help from veterans services.\nthe employment development department (edd) has a veterans services program.\nto apply, register & post a resume in caljobs, then meet with a veterans service navigator at the edd for an initial assessment.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "recycling",
+    "title": "Making Ends Meet: Recycling",
+    "content": "there are a few places in slo county that specialize in purchasing aluminum and glass for recycling:\n\nags recycling (arroyo grande and morro bay)\ncambria recycling center (cambria)\nsteve's recycling (los osos)\nrecycle 101 (oceano)\n\nmany stores also will pay crv (california redemption value) refunds for up to fifty returned beverage containers at a time.\nto find such a store near you, use the search form at the calrecycle website.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "gig-jobs",
+    "title": "Making Ends Meet: Gig Jobs",
+    "content": "there are some ways to earn small amounts of money by doing various tasks on the internet, such as taking surveys, watching videos, or testing apps.\nsome of these are scams, and most do not pay very much, but they can be ways to make a few bucks here and there if you are unable to find or commit to steady work.\nthe \"beermoney\" subreddit maintains a curated list of such opportunities.\nthat site also includes feedback from participants on their experiences.\nthe site flexjobs is another way to find remote jobs with flexible hours.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "education-job-skills-training",
+    "title": "Education, Job Skills Training, Certification, Tutoring, Literacy",
+    "content": "in this section:\n\nadult education\ndigital literacy: how to use computers and the internet\nlibraries\ncitizenship studies\nliteracy\nhigh school diplomas and their equivalents (ged or hiset)\nenglish as a second language (esl)\nfor people with disabilities\nfor u.s. military veterans\n\nadult education\ncuesta college's continuing education program is open to the general community (you do not have to be enrolled at cuesta college).\nclasses themselves are free, but some have additional costs that have to do with supplies, prerequisite documentation and tests, and other things that take place outside the classroom.\namong their programs are classes to prepare you for a california commercial learning permit so you can become a commercial truck driver.\nthey also offer miscellaneous adult education classes on topics of a recreational or curiosity-satisfying nature.\nslo partners programs include bootcamps to learn in-demand skills in fields like dental assistant, hospitality, and manufacturing.\nthere is a financial assistance program to help you pay for tuition.\nsan luis coastal adult school offers a free food services program that can prepare you for a career in the culinary industry.\nslo county public libraries offers skill-building, professional development, and college prep courses, at its learningexpress library.\nalison.com offers free online courses in several fields of study, including vocational training and \"soft skills.\"\nyou can get a certificate and/or diploma after completing a course of study, but this sometimes costs money (the course itself is free).\nnote that alison.com is accredited in the united kingdom, not the united states, which may affect how much these certificates and diplomas are respected by employers or colleges here.\nlifelong learners of the central coast offers low-cost classes and seminars on a variety of topics.\nyou can also become an annual member for a $25 fee, and this gives you substantial discounts on all classes throughout the year.\ncontact them at lifelearnerscentralcoast@gmail.com for details.\n\n\ntoastmasters is a peer-led course of practical exercises that improve your public speaking skills.\nclubs typically meet for one hour once per week and members practice public speaking exercises together and provide critiques and advice.\nthey welcome guests to participate.\nit is not free.\nthere is a $60 membership fee every six months, and some individual groups also charge small membership fees of their own.\ntoastmasters in slo county groups include:\n\n\n\nclub\nmeeting time\nlocation\n\n\n\nslo toastmasters club 83\nth 6:30-7:30am\n872 higuera st., slo\n\n\nslo noontime toastmasters club (5204)\ntu noon-1pm\nmt. carmel lutheran church, 1701 fredericks st., slo\n\n\nslo motion toastmasters club\nm noon-1pm\nslo city/county library, 995 palm st., slo\n\n\ncal poly toastmasters\nw noon-1pm\nbldg. 70 (facilities), room 110 on the cal poly san luis obispo campus\n\n\nspeakeasy toastmasters club\nth 12:10-1:15pm\nvarious locations around paso robles\n\n\nthe local university of california cooperative extension offers courses in gardening, food preservation, and rangeland and watershed management.\nmany programs are free or low-cost.\ndigital literacy: how to use computers and the internet\nlucia mar adult education offers a digital literacy class designed to teach you basic to intermediate computer skills with a focus on communication and productivity using google's free suite of apps.\ncomputers are provided for use in class.\nto register, submit this online form.\nslo county public libraries offers free basic computer skills courses and courses in amazon web services tools at its learningexpress library.\nthey also have a set of video tutorials that include basic computer skills as well as guides to how to use several popular computer tools (like gmail, facebook, microsoft office, and instagram).\ngoodwill central coast offers a variety of digital literacy classes.\ncontact them at digitalliteracy@ccgoodwill.org for details.\npaso robles senior center has two computers you can use on-site, and they offer free assistance and one-on-one tutoring sessions. \natascadero senior center periodically has \"tech help\" sessions at which an expert is available to help with your technical challenges or to teach you a new skill.\nlibraries\nthe slo county public libraries has not only books, but online research databases, computers with internet access, english conversation practice sessions, and several online learning programs.\ncal poly's robert e. kennedy library is a resource not just for cal poly students and faculty but for the inhabitants of the central coast in general. \nthe library supports the principle of open access to its collections by the community and region. \nmembers of the community can come to the library during main library opening hours and can access most databases while on the premises by bringing their own device and signing onto cal poly guest wireless. \nsmaller libraries with more eclectic collections include the lending library at the paso robles senior center and \"little free libraries.\"\nlittle free libraries are boxes in public areas (for example adjacent to sidewalks) where people leave books they are giving away.\nanyone is free to take books for their own use from little free libraries.\nthere is no check-out/check-in procedure. just take what you want to read, or leave what you're finished reading.\nthey are typically open 24-hours a day, every day.\nsee little free libraries in the directory for a list of dozens of them in slo county.\nthe slo county law library gives you free access to law- and court-related books and databases.\ncitizenship studies\nlucia mar adult education offers a u.s. citizenship class that teaches the process of establishing u.s. citizenship and prepares you to pass the naturalization interview & test.\nthe course is every thursday from 5-8pm at the oceano learning center, and you can begin the course any thursday.\nyou must be able to read and understand basic english.\nregister online or call them for more information.\nslo county public libraries gives you access to the procitizen citizenship prep course, covering the civics, reading, and writing parts of the u.s. citizenship exam.\nits brainfuse helpnow elearning program and ebscolearning program also include some u.s. citizenship test preparation.\nif you are a refugee from another country, you may be able to get some help with your education from slo for home.\nliteracy\nlucia mar adult education offers basic english literary course that takes place all year at its oceano learning center location.\nthe course is every tuesday from 5-8pm and you can begin the course any tuesday.\nregister online or call them for more information.\nthe literacy connection is a free, volunteer-based, one-on-one tutoring program that helps adults improve their literacy skills.\nhigh school diplomas and their equivalents (ged or hiset)\nif you did not earn a high school diploma, you can instead get a certificate that demonstrates that you have high-school-graduate-level competency.\nthis can help you apply for jobs or for higher education.\nto get such a certificate, you must pass a test: either the ged test or the hiset test.\nyou can also take such a test to earn such a certificate if you are still in high school but you want to leave school early rather than continue to graduation.\ncuesta college's continuing education program includes free, non-credit courses that are designed to help you build the schools you need to pass the california high school equivalency (ged) exam.\ncourses are offered in english and in spanish.\nthey also offer free tutoring, and free access to software programs to help you study.\nlucia mar adult education offers free high school diploma classes to adults.\nthis will enable you to earn an actual high school diploma, but these classes can also prepare you to take and pass the ged or hiset.\nregister on their website.\nwhen you get your high school diploma or hiset equivalency credential, you can also get a referral to cuesta or hancock colleges if you want to continue your education there.\ntempleton adult school offers free high school diploma classes to adults on a flexible schedule.\ncall them or email clondon@templetonusd.org to begin the process of enrollment.\nsan luis coastal adult school offers free high school diploma / equivalency classes in san luis obispo, morro bay, and at the san luis obispo jail.\nslo county public libraries offers on-line lessons, practice tests, and other learning tools, in english and spanish, at its high school equivalency center.\nthe cal-learn program helps pregnant or parenting teens finish high school or get an equivalent certificate. \nit helps with child care, transportation, educational expenses, and will even give you cash bonuses for getting good grades or for graduating. \napply for this program through the slo county department of social services or contact cal-learn@dss.ca.gov if you have questions. \nthe slo county office of education's \"homeless and foster youth services coordinating program\" can help homeless and foster youth manage their enrollment in school, including choosing which school to attend, getting their records transferred from previous schools, and finding resources that will be useful to them.\nto access this program, contact the liaison for your school district or contact the county office of education at 805-782-7268 or jthomas@slocoe.org.\nenglish as a second language (esl)\nenglish as a second language (esl) classes are for learners who already have another native or \"mother\" language, and they want to learn english as well.\nsan luis coastal adult school offers free esl classes in morro bay and san luis obispo.\nlucia mar adult education offers free esl classes at its nipomo and oceano learning centers\ncuesta college offers free esl classes in arroyo grande, paso robles, and san luis obispo.\nthe literacy connection offers free esl tutoring and on-line conversation practice groups.\nto apply, complete the form on their website or call 805-781-5077.\nrecent refugees from other countries can also get esl help from slo for home.\nfor people with disabilities\ncuesta college's continuing education program has an adults with disabilities program of specialized courses that develop independent living & employment skills of people with intellectual disabilities.\nfor u.s. military veterans\nas a u.s. military veteran, you may qualify for \"gi bill\" education benefits that can help you pay for school and cover expenses while you're training for a job.\nyou can apply for these benefits online at the veterans affairs website or by phone at 888-442-4551.\nif you were not dishonorably discharged and if you have a service-connected disability rating of at least 10% from the department of veterans affairs, you may be eligible for the veteran readiness & employment (vr&e) program.\nvr&e can help you with with job training, education, and job seeking skills coaching.\nyou can apply for this program by submitting a form 28-1900.\nyou can also get help from veterans services.\npeople in the u.s. military, u.s. military veterans, and their spouses, adult children, and caregivers can also take free, online training courses in fields like data analytics, cybersecurity, artificial intelligence (ai), cloud computing, and information technology (it) support through the ibm skillsbuild program\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "adult-education",
+    "title": "Adult Education",
+    "content": "cuesta college's continuing education program is open to the general community (you do not have to be enrolled at cuesta college).\nclasses themselves are free, but some have additional costs that have to do with supplies, prerequisite documentation and tests, and other things that take place outside the classroom.\namong their programs are classes to prepare you for a california commercial learning permit so you can become a commercial truck driver.\nthey also offer miscellaneous adult education classes on topics of a recreational or curiosity-satisfying nature.\nslo partners programs include bootcamps to learn in-demand skills in fields like dental assistant, hospitality, and manufacturing.\nthere is a financial assistance program to help you pay for tuition.\nsan luis coastal adult school offers a free food services program that can prepare you for a career in the culinary industry.\nslo county public libraries offers skill-building, professional development, and college prep courses, at its learningexpress library.\nalison.com offers free online courses in several fields of study, including vocational training and \"soft skills.\"\nyou can get a certificate and/or diploma after completing a course of study, but this sometimes costs money (the course itself is free).\nnote that alison.com is accredited in the united kingdom, not the united states, which may affect how much these certificates and diplomas are respected by employers or colleges here.\nlifelong learners of the central coast offers low-cost classes and seminars on a variety of topics.\nyou can also become an annual member for a $25 fee, and this gives you substantial discounts on all classes throughout the year.\ncontact them at lifelearnerscentralcoast@gmail.com for details.\n\n\ntoastmasters is a peer-led course of practical exercises that improve your public speaking skills.\nclubs typically meet for one hour once per week and members practice public speaking exercises together and provide critiques and advice.\nthey welcome guests to participate.\nit is not free.\nthere is a $60 membership fee every six months, and some individual groups also charge small membership fees of their own.\ntoastmasters in slo county groups include:\n\n\n\nclub\nmeeting time\nlocation\n\n\n\nslo toastmasters club 83\nth 6:30-7:30am\n872 higuera st., slo\n\n\nslo noontime toastmasters club (5204)\ntu noon-1pm\nmt. carmel lutheran church, 1701 fredericks st., slo\n\n\nslo motion toastmasters club\nm noon-1pm\nslo city/county library, 995 palm st., slo\n\n\ncal poly toastmasters\nw noon-1pm\nbldg. 70 (facilities), room 110 on the cal poly san luis obispo campus\n\n\nspeakeasy toastmasters club\nth 12:10-1:15pm\nvarious locations around paso robles\n\n\nthe local university of california cooperative extension offers courses in gardening, food preservation, and rangeland and watershed management.\nmany programs are free or low-cost.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "digital-literacy",
+    "title": "Digital Literacy: How to Use Computers and the Internet",
+    "content": "lucia mar adult education offers a digital literacy class designed to teach you basic to intermediate computer skills with a focus on communication and productivity using google's free suite of apps.\ncomputers are provided for use in class.\nto register, submit this online form.\nslo county public libraries offers free basic computer skills courses and courses in amazon web services tools at its learningexpress library.\nthey also have a set of video tutorials that include basic computer skills as well as guides to how to use several popular computer tools (like gmail, facebook, microsoft office, and instagram).\ngoodwill central coast offers a variety of digital literacy classes.\ncontact them at digitalliteracy@ccgoodwill.org for details.\npaso robles senior center has two computers you can use on-site, and they offer free assistance and one-on-one tutoring sessions. \natascadero senior center periodically has \"tech help\" sessions at which an expert is available to help with your technical challenges or to teach you a new skill.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "libraries",
+    "title": "Libraries",
+    "content": "the slo county public libraries has not only books, but online research databases, computers with internet access, english conversation practice sessions, and several online learning programs.\ncal poly's robert e. kennedy library is a resource not just for cal poly students and faculty but for the inhabitants of the central coast in general. \nthe library supports the principle of open access to its collections by the community and region. \nmembers of the community can come to the library during main library opening hours and can access most databases while on the premises by bringing their own device and signing onto cal poly guest wireless. \nsmaller libraries with more eclectic collections include the lending library at the paso robles senior center and \"little free libraries.\"\nlittle free libraries are boxes in public areas (for example adjacent to sidewalks) where people leave books they are giving away.\nanyone is free to take books for their own use from little free libraries.\nthere is no check-out/check-in procedure. just take what you want to read, or leave what you're finished reading.\nthey are typically open 24-hours a day, every day.\nsee little free libraries in the directory for a list of dozens of them in slo county.\nthe slo county law library gives you free access to law- and court-related books and databases.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "citizenship-studies",
+    "title": "Citizenship Studies",
+    "content": "lucia mar adult education offers a u.s. citizenship class that teaches the process of establishing u.s. citizenship and prepares you to pass the naturalization interview & test.\nthe course is every thursday from 5-8pm at the oceano learning center, and you can begin the course any thursday.\nyou must be able to read and understand basic english.\nregister online or call them for more information.\nslo county public libraries gives you access to the procitizen citizenship prep course, covering the civics, reading, and writing parts of the u.s. citizenship exam.\nits brainfuse helpnow elearning program and ebscolearning program also include some u.s. citizenship test preparation.\nif you are a refugee from another country, you may be able to get some help with your education from slo for home.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "literacy",
+    "title": "Literacy",
+    "content": "lucia mar adult education offers basic english literary course that takes place all year at its oceano learning center location.\nthe course is every tuesday from 5-8pm and you can begin the course any tuesday.\nregister online or call them for more information.\nthe literacy connection is a free, volunteer-based, one-on-one tutoring program that helps adults improve their literacy skills.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "diploma-ged-hiset",
+    "title": "High School Diplomas and their Equivalents (GED or HiSET)",
+    "content": "if you did not earn a high school diploma, you can instead get a certificate that demonstrates that you have high-school-graduate-level competency.\nthis can help you apply for jobs or for higher education.\nto get such a certificate, you must pass a test: either the ged test or the hiset test.\nyou can also take such a test to earn such a certificate if you are still in high school but you want to leave school early rather than continue to graduation.\ncuesta college's continuing education program includes free, non-credit courses that are designed to help you build the schools you need to pass the california high school equivalency (ged) exam.\ncourses are offered in english and in spanish.\nthey also offer free tutoring, and free access to software programs to help you study.\nlucia mar adult education offers free high school diploma classes to adults.\nthis will enable you to earn an actual high school diploma, but these classes can also prepare you to take and pass the ged or hiset.\nregister on their website.\nwhen you get your high school diploma or hiset equivalency credential, you can also get a referral to cuesta or hancock colleges if you want to continue your education there.\ntempleton adult school offers free high school diploma classes to adults on a flexible schedule.\ncall them or email clondon@templetonusd.org to begin the process of enrollment.\nsan luis coastal adult school offers free high school diploma / equivalency classes in san luis obispo, morro bay, and at the san luis obispo jail.\nslo county public libraries offers on-line lessons, practice tests, and other learning tools, in english and spanish, at its high school equivalency center.\nthe cal-learn program helps pregnant or parenting teens finish high school or get an equivalent certificate. \nit helps with child care, transportation, educational expenses, and will even give you cash bonuses for getting good grades or for graduating. \napply for this program through the slo county department of social services or contact cal-learn@dss.ca.gov if you have questions. \nthe slo county office of education's \"homeless and foster youth services coordinating program\" can help homeless and foster youth manage their enrollment in school, including choosing which school to attend, getting their records transferred from previous schools, and finding resources that will be useful to them.\nto access this program, contact the liaison for your school district or contact the county office of education at 805-782-7268 or jthomas@slocoe.org.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "esl",
+    "title": "English as a Second Language (ESL)",
+    "content": "english as a second language (esl) classes are for learners who already have another native or \"mother\" language, and they want to learn english as well.\nsan luis coastal adult school offers free esl classes in morro bay and san luis obispo.\nlucia mar adult education offers free esl classes at its nipomo and oceano learning centers\ncuesta college offers free esl classes in arroyo grande, paso robles, and san luis obispo.\nthe literacy connection offers free esl tutoring and on-line conversation practice groups.\nto apply, complete the form on their website or call 805-781-5077.\nrecent refugees from other countries can also get esl help from slo for home.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "education-for-people-with-disabilities",
+    "title": "For People with Disabilities",
+    "content": "cuesta college's continuing education program has an adults with disabilities program of specialized courses that develop independent living & employment skills of people with intellectual disabilities.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "veterans-education",
+    "title": "For U.S. Military Veterans",
+    "content": "as a u.s. military veteran, you may qualify for \"gi bill\" education benefits that can help you pay for school and cover expenses while you're training for a job.\nyou can apply for these benefits online at the veterans affairs website or by phone at 888-442-4551.\nif you were not dishonorably discharged and if you have a service-connected disability rating of at least 10% from the department of veterans affairs, you may be eligible for the veteran readiness & employment (vr&e) program.\nvr&e can help you with with job training, education, and job seeking skills coaching.\nyou can apply for this program by submitting a form 28-1900.\nyou can also get help from veterans services.\npeople in the u.s. military, u.s. military veterans, and their spouses, adult children, and caregivers can also take free, online training courses in fields like data analytics, cybersecurity, artificial intelligence (ai), cloud computing, and information technology (it) support through the ibm skillsbuild program\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "phones",
+    "title": "Phones and Phone Service",
+    "content": "the california lifeline program (866-272-0357) gives low-income households discounts on home phone or cell phone service.\nin many cases the discounts are enough to make the service free.\nyou apply for this program through a commercial phone service provider that supports the program.\nsome providers also give you a free phone when you register for california lifeline through their service, for example airtalk wireless, entouch wireless, or gen mobile.\nthe california connect program can loan you, for free, assistive telecommunications equipment that helps if you have medically-documented functional limitations of hearing, vision, mobility, speech, and/or interpretation of information.\nthe deaf and disabled telecommunications program (ddtp) can give you specialized telephone equipment, accessories, and services such as amplified phones for the hard-of-hearing, big-button phones for those with low-vision, and cordless phones for people with mobility disabilities.\nthis program is for california residents with medically-certified limitations of hearing, vision, mobility, speech, learning, or memory.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "internet-and-email",
+    "title": "Internet Access / Email / Digital Access Assistance",
+    "content": "\nsee the digital literacy: how to use computers and the internet section of this guide for classes and tutorials that can help you learn how to use the internet.\n\nslo county public libraries have computers you can use on-site.\nthey also have printing services for a small fee.\nthey may also be able to help you establish an email account.\nyou can also borrow a wi-fi hotspot from the library.\nthe slo cal careers center has computers you can use for job-search purposes.\nthey can also help you establish a caljobs account and submit online job applications.\nthe county of san luis obispo information technology department provides free wi-fi access in all san luis obispo county government buildings.\nboth the 5cities homeless coalition office and the 40 prado homeless services center offer computer and internet access to their clients. \narroyo grande recreation services offers a basic iphone for seniors class.\npaso robles senior center has two computers you can use on-site, and they offer free assistance and one-on-one tutoring sessions including specialized android and ipad/iphone workshops. \nnipomo senior center also has a computer with internet access which is available to the public on a first come, first serve basis.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "charging-stations",
+    "title": "Charging Stations for Devices",
+    "content": "the 5cities homeless coalition office has device charging stations for its clients. \nshower the people has a device charging station available at the sites where it operates during operating hours.\nslo county public libraries have computers you can use on-site with usb charging ports.\nthere are also some electrical outlets you can use to charge devices.\nthe free front porch cafe on the cal poly campus has many charging outlets.\n40 prado homeless services center has electrical outlets you can use to charge your mobile devices. \n\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "children-youth-parents",
+    "title": "Children, Youth, and People with Children",
+    "content": "in this section:\n\nhelp with parenting\ndaycare, preschool, and after-school programs\nholiday gifts for children\nresources for homeless youth\n\nhelp me grow slo county offers no-cost developmental screenings for infants, and connections to resources and education if these screenings discover developmental issues.\nfamily care network serves families with children who are experiencing or at risk of homelessness, are impacted by unaddressed mental health challenges, or are involved with child welfare services or the justice system.\nservices include therapy and other mental health services, facilitating foster care and adoption, independent living skills, educational continuity,\nthey also help families experiencing homelessness to move into safe housing (family care network operates housing complexes for this purpose).\nthey offer services in english and spanish.\nthe slo children's museum is full of interactive exhibits for children aged 2-10.\nif you are \"housing insecure\" you can get a free \"city play pass\" to the museum from capslo.\nif you have a snap/ebt card, you can also get up to four admissions for $3 each.\nopen th-m 10am-4pm, 1010 nipomo st., slo.\nfor more info: 805-544-kids or info@slocm.org.\nchild care resource connection operates a toy lending library.\ncalifornia children's services pays for and helps arrange doctor visits, hospital stays, surgery, physical therapy, tests, medical equipment, etc. for children and youths whose parents otherwise could not afford it.\nmartha's place children's center helps children ages 0-5 who have (or may have) behavioral or mental health issues or who were exposed to alcohol or other intoxicants while in the womb.\nit provides screening, assessment, referral, and treatment.\nthese services are free to people with medi-cal/cencal coverage, and available on a sliding feed schedule otherwise.\n\nsee calfresh / ebt (food stamps) and wic in the food resources section of this guide for information about the women, infants, and children (wic) program.\n\n\nsee family law / child support in the legal help & crime victim protection section of this guide for information about enforcing child support orders and other family law issues.\n\n\nsee the medical resources for specific populations: children in the health & medical care section of this guide for pediatric and other child-oriented medical services.\n\nhelp with parenting\n\nsee the hotlines and emergency contacts section of this guide for the fussy baby network warmline, the national maternal mental health hotline, and a number you can call to learn about safe surrender site locations.\n\nparent connection of slo county hosts free parenting skills workshops and parenting support groups, and can help you find resources for your particular needs.\nsan luis coastal adult school offers parent participation classes that teach useful parenting skills to people with children up to the age of five (you attend the class with your child).\nclasses are held in san luis obispo and morro bay.\nscholarships that cover part of the class fees are available to people with low incomes or special circumstances.\nthe free triple p fear less class offered by transitions mental health association (tmha) helps parents and caregivers of children (ages 6-14) who experience anxiety to foster confident and healthy children, cultivate strong family relationships, and effectively address misbehavior.\npregnancy & parenting support has a \"baby bank\" from which you can get free maternity and breastfeeding supplies, diapers, baby wipes, formula, safe sleep equipment, child car seats, books, and toys.\n(car seat installation by appointment only.)\n\nsee the peer support groups: pregnancy and parenthood section for information about a variety of support groups for new parents and pregnant people.\n\n\nsee pregnancy, childbirth, lactation in the health & medical care section of this guide for pregnancy and postpartum resources.\n\ndaycare, preschool, and after-school programs\nchild care resource connection connects slo county families with child care centers, licensed family child care homes, and after-school programs.\nthey can provide child care payment assistance for income-eligible families.\nif you are in the calworks homeless assistance program, you can apply for child care from this program through the slo county department of social services.\notherwise complete an online application or call 888-727-2272 to begin the process of applying through the california alternative payment program.\nthis program may have a waiting list.\ncapslo operates head start and early head start programs for children during their first five years of life.\nthe programs aim to help children gain school readiness skills, confidence, and self-esteem.\nhead start child care centers also serve children three free meals a day.\nthese programs operate in several locations in slo county.\nto enroll your child in these programs, find a service provider that is convenient to you and appropriate for the child's age and then apply for the waitlist.\nfor more information, including eligibility requirements, contact childcare@capslo.org or 888-315-6741.\nthere is also a \"migrant and seasonal head start\" program designed specifically for the children of migrant farm workers.\nyou can apply for that program by completing the form on this page.\nfor more information, contact mshschildcare@capslo.org or 888-633-6747.\nbright futures is a program in the lucia mar unified school district that gives k-8 students a safe before- and after-school environment including academic support and enrichment classes, as well as a free supper.\nthere are limited spaces available, and sometimes there is a waiting list.\npriority is given to foster youth, students experiencing homelessness, english language learners, and students qualifying for free/reduced price lunch services.\nyou can apply to enroll your child in this program at the bright futures website.\nthe child development resource center operates several programs including childcare for children aged 2-5 that includes early-childhood education, therapy and rehabilitation for children who need it, meals (breakfast, lunch, and an afternoon snack), and family events.\nthey specialize in working with children who come from circumstances that included poverty, homelessness, foster care, domestic violence, or child abuse.\nto apply for the childcare program, complete and submit an application.\nthere may be a waiting list.\ntuition is a sliding-scale fee based on income, and financial aid is available.\nboys & girls clubs offer free, out-of-school enrichment programs for schoolchildren during the week: after school and during school breaks like summer vacation.\nthere is an annual membership fee and also fees per child per day, but boys & girls clubs are committed to ensuring that cost is not a barrier to participation.\nask them about scholarships and subsidies.\nthere are two boys & girls clubs chapters in slo county:\n\nboys & girls clubs of south slo county which covers grover beach, oceano, pismo beach, and shell beach (myclubhub@bgcslo.org, 805-481-7339)\nboys & girls clubs of mid central coast which covers atascadero, creston, guadalupe, paso robles, and shandon (info@centralcoastkids.org, 805-922-7163)\n\nstudents of cuesta college who qualify for extended opportunity programs and services and who are single heads-of-households can get help paying for child care services from cooperative agencies resources for education (care).\ncontact cafecenters@cuesta.edu or 805-546-3144 to learn how to apply.\nslo county ymca offers one hour of childcare to members while they are exercising at the facility.\nyou must reserve this in advance.\nthey also operate summer camps for children and teens.\nthey also operate before- and after-school care, and programs during school holidays and breaks, featuring homework help, enriching activities, and healthy snacks.\nthere is sometimes a wait list to apply for these school age care and school's out care programs.\nthey occasionally offer kid's night out evening childcare programs too.\nfinancial assistance is available to ensure that you can afford these programs.\n\nsee summer meal sites (for children) in the food resources section of this guide for information on how children can get meals during the summer months when school is out.\n\nholiday gifts for children\nthere are several programs in slo county that provide gifts for children during the holiday season.\nyou typically need to apply a month or so ahead of time to receive these gifts.\nyou may need to upload documents such as the children's birth certificates to prove eligibility and proof of residence.\n\nsee the ids and other documents section of this guide for ways to obtain or replace documents like these.\n\nsalvation army operates the \"angel tree\" program which provides free christmas gifts for children.\nregister at this web page.\nthe toy bank of greater paso robles gives toys and coats to families with children aged 0-12 years who live in paso robles, san miguel, shandon, bradley and heritage ranch and who have a household income blow the federal poverty line, or are unemployed, receiving medi-cal, receiving snap/ebt, or homeless.\nto receive gifts from the program, register in november at this web page.\nfor questions, contact 805-369-9816 or registration@prtoybank.org.\ntoys for tots gives toys to children during the holidays.\nthey operate in atascadero/santa margarita/templeton/pozo/creston/california valley.\nregister for toys for your children at this web page.\nyou must select and collect the toys in person (but without your children) at their distribution site.\nfor more information, contact 805-391-4430 or atascadero.ca@toysfortots.org.\ntoys for tots also operates in cambria/san simeon.\nregister for toys for your children at this web page unless your child attends cambria grammar school (in which case, apply through the school family advocate instead).\nfor more information, contact 805-927-1876 or cambria.ca@toysfortots.org.\nsome people who are imprisoned at the slo county jail's \"honor farm\" refurbish children's bicycles so they can be given away as gifts during the holiday season.\nto apply for a free bicycle for your child, contact your child's elementary or middle school resource officer.\n\nsee the (mostly) free stuff section of this guide for more possible gift ideas.\n\nresources for homeless youth\n\nsee the hotlines and emergency contacts section of this guide for the youth crisis line, the national runaway safeline, the love is respect line, and the trevor lifeline.\n\nthe 5cities homeless coalition has a homeless youth outreach program that offers individualized case management to unaccompanied homeless youth (ages 16-24) with the goal of helping them with immediate needs, housing, independent living, steady employment, and continued education.\nslo county youth (ages 21 or below, or current or former foster youth up to age 26) who are enrolled in cencal health qualify for enhanced care management through seneca central coast if one of the following is true:\n\nthey are experiencing homelessness.\nthey are transitioning out of incarceration.\nthey are a current or former foster youth.\nthey have significant behavioral health needs.\nthey experience frequent hospitalization.\n\nenhanced care management teams you up with a professional who can help you find medical providers, make appointments, arrange transportation to appointments, and meet other healthcare needs.\nto apply for enhanced care management, contact cencal health who can help you with the process, or contact seneca central coast directly.\natascadero recreation has a teen center, open weekday afternoons until 6pm, with air hockey, pool, ping pong, ps5, movies, board games, dodgeball, and basketball.\nmembership is $20/year.\natascadero recreation also has organized sports programs, classes, and camps.\nthere is a youth activity scholarship fund that can pay for up to $250 per child in registration fees for qualifying children in the atascadero school district (details here)\npaso robles parks & recreation has a free teen center, open weekday afternoons until 5pm, with video games, music, a pool table, a gym, and a small cafe.\npaso robles parks & recreation also offers many classes, sports, and other activities.\nthey typically cost money, but there is a scholarship program for people with low incomes.\ncity of slo parks and recreation offers a variety of sports clinics, classes, and camps.\nthey have a limited fee reduction program that helps eligible slo city children obtain scholarship credit towards program fees.\n\nsee also medical resources for specific populations: teens & youth in the health & medical care section of this guide for youth-oriented medical care.\n\n\nsee the peer support groups: behavioral health section for information about alateen and narateen groups for teens who have family members who are addicts.\n\n\nsee the peer support groups: gltbq+ section for information about support groups for queer and trans youth.\n\n\nsee free clothes for kids in the clothing section of this guide for information about \"coats for kids,\" \"operation school bell,\" \"traveling children's closet,\" \"the teen's closet,\" and \"outreach apparel.\"\n\neducational continuity (mckinney-vento act)\nfederal law (the mckinney-vento homeless assistance act) protects homeless students in elementary through high school in several ways:\n\nyou have the right to enroll in school even if you currently lack documents such as proof of residency, immunization records, or birth certificates.\nyou have the right to attend the same school you were enrolled in when you were last housed, even if you have since lost your home.\nyou have the right to transportation to and from school.\nyou have the right to the same educational services as non-homeless students.\nif you are an unaccompanied homeless youth, you have the right to enroll in school without the consent of your parent or guardian.\n\nhomelessness, as the mckinney-vento act defines it, also includes situations when you are living at someone else's house, living in a motel or campground, living in a vehicle, living in a shelter, or squatting in an abandoned building.\nevery school district has a mckinney-vento liaison whom you can go to if you need help defending these rights.\nyou can find a list of these liaisons and their contact information at the slo county office of education website.\nthe slo county office of education's \"homeless and foster youth services coordinating program\" can help homeless and foster youth manage their enrollment in school, including choosing which school to attend, getting their records transferred from previous schools, and finding resources that will be useful to them.\nto access this program, contact the mckinney-vento liaison for your school district or contact the county office of education at 805-782-7268 or jthomas@slocoe.org.\n\nsee high school diplomas and their equivalents in the education section of this guide for ways to stay on track to get your diploma.\n\n\n\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "parenting",
+    "title": "Help with Parenting",
+    "content": "\nsee the hotlines and emergency contacts section of this guide for the fussy baby network warmline, the national maternal mental health hotline, and a number you can call to learn about safe surrender site locations.\n\nparent connection of slo county hosts free parenting skills workshops and parenting support groups, and can help you find resources for your particular needs.\nsan luis coastal adult school offers parent participation classes that teach useful parenting skills to people with children up to the age of five (you attend the class with your child).\nclasses are held in san luis obispo and morro bay.\nscholarships that cover part of the class fees are available to people with low incomes or special circumstances.\nthe free triple p fear less class offered by transitions mental health association (tmha) helps parents and caregivers of children (ages 6-14) who experience anxiety to foster confident and healthy children, cultivate strong family relationships, and effectively address misbehavior.\npregnancy & parenting support has a \"baby bank\" from which you can get free maternity and breastfeeding supplies, diapers, baby wipes, formula, safe sleep equipment, child car seats, books, and toys.\n(car seat installation by appointment only.)\n\nsee the peer support groups: pregnancy and parenthood section for information about a variety of support groups for new parents and pregnant people.\n\n\nsee pregnancy, childbirth, lactation in the health & medical care section of this guide for pregnancy and postpartum resources.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "daycare",
+    "title": "Daycare, Preschool, and After-School Programs",
+    "content": "child care resource connection connects slo county families with child care centers, licensed family child care homes, and after-school programs.\nthey can provide child care payment assistance for income-eligible families.\nif you are in the calworks homeless assistance program, you can apply for child care from this program through the slo county department of social services.\notherwise complete an online application or call 888-727-2272 to begin the process of applying through the california alternative payment program.\nthis program may have a waiting list.\ncapslo operates head start and early head start programs for children during their first five years of life.\nthe programs aim to help children gain school readiness skills, confidence, and self-esteem.\nhead start child care centers also serve children three free meals a day.\nthese programs operate in several locations in slo county.\nto enroll your child in these programs, find a service provider that is convenient to you and appropriate for the child's age and then apply for the waitlist.\nfor more information, including eligibility requirements, contact childcare@capslo.org or 888-315-6741.\nthere is also a \"migrant and seasonal head start\" program designed specifically for the children of migrant farm workers.\nyou can apply for that program by completing the form on this page.\nfor more information, contact mshschildcare@capslo.org or 888-633-6747.\nbright futures is a program in the lucia mar unified school district that gives k-8 students a safe before- and after-school environment including academic support and enrichment classes, as well as a free supper.\nthere are limited spaces available, and sometimes there is a waiting list.\npriority is given to foster youth, students experiencing homelessness, english language learners, and students qualifying for free/reduced price lunch services.\nyou can apply to enroll your child in this program at the bright futures website.\nthe child development resource center operates several programs including childcare for children aged 2-5 that includes early-childhood education, therapy and rehabilitation for children who need it, meals (breakfast, lunch, and an afternoon snack), and family events.\nthey specialize in working with children who come from circumstances that included poverty, homelessness, foster care, domestic violence, or child abuse.\nto apply for the childcare program, complete and submit an application.\nthere may be a waiting list.\ntuition is a sliding-scale fee based on income, and financial aid is available.\nboys & girls clubs offer free, out-of-school enrichment programs for schoolchildren during the week: after school and during school breaks like summer vacation.\nthere is an annual membership fee and also fees per child per day, but boys & girls clubs are committed to ensuring that cost is not a barrier to participation.\nask them about scholarships and subsidies.\nthere are two boys & girls clubs chapters in slo county:\n\nboys & girls clubs of south slo county which covers grover beach, oceano, pismo beach, and shell beach (myclubhub@bgcslo.org, 805-481-7339)\nboys & girls clubs of mid central coast which covers atascadero, creston, guadalupe, paso robles, and shandon (info@centralcoastkids.org, 805-922-7163)\n\nstudents of cuesta college who qualify for extended opportunity programs and services and who are single heads-of-households can get help paying for child care services from cooperative agencies resources for education (care).\ncontact cafecenters@cuesta.edu or 805-546-3144 to learn how to apply.\nslo county ymca offers one hour of childcare to members while they are exercising at the facility.\nyou must reserve this in advance.\nthey also operate summer camps for children and teens.\nthey also operate before- and after-school care, and programs during school holidays and breaks, featuring homework help, enriching activities, and healthy snacks.\nthere is sometimes a wait list to apply for these school age care and school's out care programs.\nthey occasionally offer kid's night out evening childcare programs too.\nfinancial assistance is available to ensure that you can afford these programs.\n\nsee summer meal sites (for children) in the food resources section of this guide for information on how children can get meals during the summer months when school is out.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "holiday-gifts-for-children",
+    "title": "Holiday Gifts for Children",
+    "content": "there are several programs in slo county that provide gifts for children during the holiday season.\nyou typically need to apply a month or so ahead of time to receive these gifts.\nyou may need to upload documents such as the children's birth certificates to prove eligibility and proof of residence.\n\nsee the ids and other documents section of this guide for ways to obtain or replace documents like these.\n\nsalvation army operates the \"angel tree\" program which provides free christmas gifts for children.\nregister at this web page.\nthe toy bank of greater paso robles gives toys and coats to families with children aged 0-12 years who live in paso robles, san miguel, shandon, bradley and heritage ranch and who have a household income blow the federal poverty line, or are unemployed, receiving medi-cal, receiving snap/ebt, or homeless.\nto receive gifts from the program, register in november at this web page.\nfor questions, contact 805-369-9816 or registration@prtoybank.org.\ntoys for tots gives toys to children during the holidays.\nthey operate in atascadero/santa margarita/templeton/pozo/creston/california valley.\nregister for toys for your children at this web page.\nyou must select and collect the toys in person (but without your children) at their distribution site.\nfor more information, contact 805-391-4430 or atascadero.ca@toysfortots.org.\ntoys for tots also operates in cambria/san simeon.\nregister for toys for your children at this web page unless your child attends cambria grammar school (in which case, apply through the school family advocate instead).\nfor more information, contact 805-927-1876 or cambria.ca@toysfortots.org.\nsome people who are imprisoned at the slo county jail's \"honor farm\" refurbish children's bicycles so they can be given away as gifts during the holiday season.\nto apply for a free bicycle for your child, contact your child's elementary or middle school resource officer.\n\nsee the (mostly) free stuff section of this guide for more possible gift ideas.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "homeless-youth",
+    "title": "Resources for Homeless Youth",
+    "content": "\nsee the hotlines and emergency contacts section of this guide for the youth crisis line, the national runaway safeline, the love is respect line, and the trevor lifeline.\n\nthe 5cities homeless coalition has a homeless youth outreach program that offers individualized case management to unaccompanied homeless youth (ages 16-24) with the goal of helping them with immediate needs, housing, independent living, steady employment, and continued education.\nslo county youth (ages 21 or below, or current or former foster youth up to age 26) who are enrolled in cencal health qualify for enhanced care management through seneca central coast if one of the following is true:\n\nthey are experiencing homelessness.\nthey are transitioning out of incarceration.\nthey are a current or former foster youth.\nthey have significant behavioral health needs.\nthey experience frequent hospitalization.\n\nenhanced care management teams you up with a professional who can help you find medical providers, make appointments, arrange transportation to appointments, and meet other healthcare needs.\nto apply for enhanced care management, contact cencal health who can help you with the process, or contact seneca central coast directly.\natascadero recreation has a teen center, open weekday afternoons until 6pm, with air hockey, pool, ping pong, ps5, movies, board games, dodgeball, and basketball.\nmembership is $20/year.\natascadero recreation also has organized sports programs, classes, and camps.\nthere is a youth activity scholarship fund that can pay for up to $250 per child in registration fees for qualifying children in the atascadero school district (details here)\npaso robles parks & recreation has a free teen center, open weekday afternoons until 5pm, with video games, music, a pool table, a gym, and a small cafe.\npaso robles parks & recreation also offers many classes, sports, and other activities.\nthey typically cost money, but there is a scholarship program for people with low incomes.\ncity of slo parks and recreation offers a variety of sports clinics, classes, and camps.\nthey have a limited fee reduction program that helps eligible slo city children obtain scholarship credit towards program fees.\n\nsee also medical resources for specific populations: teens & youth in the health & medical care section of this guide for youth-oriented medical care.\n\n\nsee the peer support groups: behavioral health section for information about alateen and narateen groups for teens who have family members who are addicts.\n\n\nsee the peer support groups: gltbq+ section for information about support groups for queer and trans youth.\n\n\nsee free clothes for kids in the clothing section of this guide for information about \"coats for kids,\" \"operation school bell,\" \"traveling children's closet,\" \"the teen's closet,\" and \"outreach apparel.\"\n\neducational continuity (mckinney-vento act)\nfederal law (the mckinney-vento homeless assistance act) protects homeless students in elementary through high school in several ways:\n\nyou have the right to enroll in school even if you currently lack documents such as proof of residency, immunization records, or birth certificates.\nyou have the right to attend the same school you were enrolled in when you were last housed, even if you have since lost your home.\nyou have the right to transportation to and from school.\nyou have the right to the same educational services as non-homeless students.\nif you are an unaccompanied homeless youth, you have the right to enroll in school without the consent of your parent or guardian.\n\nhomelessness, as the mckinney-vento act defines it, also includes situations when you are living at someone else's house, living in a motel or campground, living in a vehicle, living in a shelter, or squatting in an abandoned building.\nevery school district has a mckinney-vento liaison whom you can go to if you need help defending these rights.\nyou can find a list of these liaisons and their contact information at the slo county office of education website.\nthe slo county office of education's \"homeless and foster youth services coordinating program\" can help homeless and foster youth manage their enrollment in school, including choosing which school to attend, getting their records transferred from previous schools, and finding resources that will be useful to them.\nto access this program, contact the mckinney-vento liaison for your school district or contact the county office of education at 805-782-7268 or jthomas@slocoe.org.\n\nsee high school diplomas and their equivalents in the education section of this guide for ways to stay on track to get your diploma.\n\n\n\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "peer-support-groups",
+    "title": "Peer Support Groups",
+    "content": "in peer support groups, you gather with other people who are in a similar situation to you in some way to talk.\nyou may share practical advice, or just give each other emotional support.\nthere are many peer support groups active in slo county.\nthese are some of them:\ndisabilities, medical conditions, and mental illnesses\nalzheimer's disease: there are monthly alzheimer's support groups for caregivers and other people affected by alzheimer's disease in arroyo grande, atascadero, cambria, morro bay, nipomo, paso robles, and slo, as well as on-line.\nthere are also support groups for people recently diagnosed, and for people suffering bereavement because of a loved one with dementia.\nto register for a group, call 800-272-3900.\namyotrophic lateral sclerosis (als): an als support group meets monthly via zoom.\nto join, contact organizer julie scurich at jscurich@alsnetwork.org or 831-247-9878.\ncancer: cancer support community offers a variety of no-cost services for people with cancer, including health education and exercise classes, as well as several support groups, some of which meet in templeton, some on-line.\nmission hope cancer center in arroyo grande also hosts cancer support groups including in-person groups for people with breast cancer and for oral, head, and neck cancer, and a number of other groups that meet on-line.\nfrench hospital medical center hosts several support groups at the hearst cancer resource center.\nthese include groups for patients with cancer and advanced cancer, and groups for people with specific types of cancer, such as cancers of the blood, breast, or prostate.\nto register, call hcrc at 805-542-6234 or email hcrc@dignityhealth.org.\ncaregivers: the coast caregiver resource center has several support groups, some of which meet on-line, others in slo or morro bay.\nthey include groups for caregivers of people with dementia, for lgbtq caregivers, for caregivers of parkinson's disease patients, and groups that are conducted in spanish.\ndiabetes: french hospital medical center hosts a quarterly diabetes support group.\nmental illness: the slo county chapter of national alliance on mental illness holds support groups for family members of people with mental health challenges, online, in arroyo grande, and in atascadero, every month.\ncontact sgroups.nami.sloco@gmail.com for details.\ntransitions mental health association (tmha) has weekly support groups in person and on zoom for people with loved ones who experience mental illness, in english and in spanish.\nthey also have a variety of in-person support groups and more informal gatherings for people with mental illness, as well as several virtual/online support groups.\nparkinson's disease: the central coast parkinson association holds monthly in-person support groups in atascadero, morro bay, pismo beach, and san luis obispo.\nthey also hold a monthly, on-line support group, and a monthly in-person group in paso robles, for caregivers only.\nstroke: arroyo grande community hospital hosts a monthly stroke support group.\nadventist health sierra vista hosts a hope for stroke survivors group for people who have had strokes and for their caregivers.\nanother hope for stroke group meets in templeton.\ngrief\nhospice slo operates a weekly, on-line family caregiver support group for slo county residents that you can register for at this page.\nthey also have a grief support and education group that meets online and others that meet in person in paso robles and in slo city.\nthey also have an in-person support group in slo city specifically for people who are grieving the loss of a spouse or partner.\nthey occasionally hold other support groups as well.\ncentral coast home health and hospice facilitates grief support groups weekly at the morro bay senior center, paso robles senior center, and slo senior center.\ncall 805-540-6020 to speak with a bereavement counselor prior to attending.\nseveral slo county churches host griefshare support groups with a christian focus on grieving.\nbehavioral health\n\nsee 12-step and similar recovery programs in the drug use, recovery, and harm reduction section above for support groups for people recovering from drug addictions.\n\nal-anon has support groups for family members of alcoholics that meet online and in arroyo grande, atascadero, cambria, cayucos, grover beach, morro bay, nipomo, paso robles, pismo beach, and slo.\nthere is also an alateen meeting in grover beach specifically for teen-aged family members of alcoholics.\nnar-anon has in-person weekly meetings for family members of people addicted to drugs that meet in atascadero as well as several online meetings.\nthere are also narateen on-line weekly meetings specifically for teen-aged family members of addicts.\nan eating disorder support group meets on wednesdays from 7-8pm at gala pride & diversity center in slo city and by zoom.\ncontact libby@notyouraveragenutritionist.com for more information.\novereaters anonymous holds weekly meetings in arroyo grande, morro bay, and slo.\ndebtors anonymous holds meetings by phone or zoom every day of the week.\nglbtq\nthe gala pride & diversity center maintains a list of support groups, including:\n\ntherapist-led trans/genderqueer monthly support group-contact laurenphelpsmft@gmail.com for more information\n\"q\" youth (grades 6-12)-contact youthdirector@galacc.org or drop-in at gala any thursday from 6-8pm\ntrans and gender-nonconforming teen support group\ntrans and gender-nonconforming adult support group\ntransmasculine, and gender-nonconforming masculine-identifying support group\nlgbt seniors-third wednesday of the month 4:30-6:30pm at gala or by zoom\nstand out parent support group-for parents of lgbtq+ youth; contact email@galacc.org for more information\n\npregnancy and parenthood\nadventist health twin cities hosts \"newborn and parent support\" and \"navigating motherhood\" weekly support groups.\nfrench hospital medical center operates the online weekly support group \"the mommy hour\".\nto join, contact facilitator wendy beres at wendy.beres@dignityhealth.org or 805-541-2229.\nthey also host a \"bellies and babies\" weekly in-person support group.\nfor more information call 805-542-6659.\nthere is a moms club support group in atascadero that also covers templeton, paso robles, and san miguel.\nwrite to atownmoms@gmail.com for more information.\ncommunity action partnership san luis obispo (capslo) hosts parent cafés and pops2 groups (for fathers specifically) with childcare and a meal provided.\nfor details on how to join, contact pops@capslo.org or 805-295-1628.\npacific midwifery offers free \"mama mentoring\" groups on tuesdays in arroyo grande.\ncontact megan@pacificmidwiferycare.com (805-994-0446) for details.\npostpartum support international also organizes many free online support groups.\nother\ncorazón latino holds monthly emotional support groups for people in the latinx community online and in paso robles.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "conditions-peer-support",
+    "title": "Disabilities, Medical Conditions, and Mental Illnesses",
+    "content": "alzheimer's disease: there are monthly alzheimer's support groups for caregivers and other people affected by alzheimer's disease in arroyo grande, atascadero, cambria, morro bay, nipomo, paso robles, and slo, as well as on-line.\nthere are also support groups for people recently diagnosed, and for people suffering bereavement because of a loved one with dementia.\nto register for a group, call 800-272-3900.\namyotrophic lateral sclerosis (als): an als support group meets monthly via zoom.\nto join, contact organizer julie scurich at jscurich@alsnetwork.org or 831-247-9878.\ncancer: cancer support community offers a variety of no-cost services for people with cancer, including health education and exercise classes, as well as several support groups, some of which meet in templeton, some on-line.\nmission hope cancer center in arroyo grande also hosts cancer support groups including in-person groups for people with breast cancer and for oral, head, and neck cancer, and a number of other groups that meet on-line.\nfrench hospital medical center hosts several support groups at the hearst cancer resource center.\nthese include groups for patients with cancer and advanced cancer, and groups for people with specific types of cancer, such as cancers of the blood, breast, or prostate.\nto register, call hcrc at 805-542-6234 or email hcrc@dignityhealth.org.\ncaregivers: the coast caregiver resource center has several support groups, some of which meet on-line, others in slo or morro bay.\nthey include groups for caregivers of people with dementia, for lgbtq caregivers, for caregivers of parkinson's disease patients, and groups that are conducted in spanish.\ndiabetes: french hospital medical center hosts a quarterly diabetes support group.\nmental illness: the slo county chapter of national alliance on mental illness holds support groups for family members of people with mental health challenges, online, in arroyo grande, and in atascadero, every month.\ncontact sgroups.nami.sloco@gmail.com for details.\ntransitions mental health association (tmha) has weekly support groups in person and on zoom for people with loved ones who experience mental illness, in english and in spanish.\nthey also have a variety of in-person support groups and more informal gatherings for people with mental illness, as well as several virtual/online support groups.\nparkinson's disease: the central coast parkinson association holds monthly in-person support groups in atascadero, morro bay, pismo beach, and san luis obispo.\nthey also hold a monthly, on-line support group, and a monthly in-person group in paso robles, for caregivers only.\nstroke: arroyo grande community hospital hosts a monthly stroke support group.\nadventist health sierra vista hosts a hope for stroke survivors group for people who have had strokes and for their caregivers.\nanother hope for stroke group meets in templeton.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "grief-peer-support",
+    "title": "Grief",
+    "content": "hospice slo operates a weekly, on-line family caregiver support group for slo county residents that you can register for at this page.\nthey also have a grief support and education group that meets online and others that meet in person in paso robles and in slo city.\nthey also have an in-person support group in slo city specifically for people who are grieving the loss of a spouse or partner.\nthey occasionally hold other support groups as well.\ncentral coast home health and hospice facilitates grief support groups weekly at the morro bay senior center, paso robles senior center, and slo senior center.\ncall 805-540-6020 to speak with a bereavement counselor prior to attending.\nseveral slo county churches host griefshare support groups with a christian focus on grieving.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "behavioral-health-peer-support",
+    "title": "Behavioral Health",
+    "content": "\nsee 12-step and similar recovery programs in the drug use, recovery, and harm reduction section above for support groups for people recovering from drug addictions.\n\nal-anon has support groups for family members of alcoholics that meet online and in arroyo grande, atascadero, cambria, cayucos, grover beach, morro bay, nipomo, paso robles, pismo beach, and slo.\nthere is also an alateen meeting in grover beach specifically for teen-aged family members of alcoholics.\nnar-anon has in-person weekly meetings for family members of people addicted to drugs that meet in atascadero as well as several online meetings.\nthere are also narateen on-line weekly meetings specifically for teen-aged family members of addicts.\nan eating disorder support group meets on wednesdays from 7-8pm at gala pride & diversity center in slo city and by zoom.\ncontact libby@notyouraveragenutritionist.com for more information.\novereaters anonymous holds weekly meetings in arroyo grande, morro bay, and slo.\ndebtors anonymous holds meetings by phone or zoom every day of the week.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "glbtq-peer-support",
+    "title": "GLBTQ",
+    "content": "the gala pride & diversity center maintains a list of support groups, including:\n\ntherapist-led trans/genderqueer monthly support group-contact laurenphelpsmft@gmail.com for more information\n\"q\" youth (grades 6-12)-contact youthdirector@galacc.org or drop-in at gala any thursday from 6-8pm\ntrans and gender-nonconforming teen support group\ntrans and gender-nonconforming adult support group\ntransmasculine, and gender-nonconforming masculine-identifying support group\nlgbt seniors-third wednesday of the month 4:30-6:30pm at gala or by zoom\nstand out parent support group-for parents of lgbtq+ youth; contact email@galacc.org for more information\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "parenthood-peer-support",
+    "title": "Pregnancy and Parenthood",
+    "content": "adventist health twin cities hosts \"newborn and parent support\" and \"navigating motherhood\" weekly support groups.\nfrench hospital medical center operates the online weekly support group \"the mommy hour\".\nto join, contact facilitator wendy beres at wendy.beres@dignityhealth.org or 805-541-2229.\nthey also host a \"bellies and babies\" weekly in-person support group.\nfor more information call 805-542-6659.\nthere is a moms club support group in atascadero that also covers templeton, paso robles, and san miguel.\nwrite to atownmoms@gmail.com for more information.\ncommunity action partnership san luis obispo (capslo) hosts parent cafés and pops2 groups (for fathers specifically) with childcare and a meal provided.\nfor details on how to join, contact pops@capslo.org or 805-295-1628.\npacific midwifery offers free \"mama mentoring\" groups on tuesdays in arroyo grande.\ncontact megan@pacificmidwiferycare.com (805-994-0446) for details.\npostpartum support international also organizes many free online support groups.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "other-peer-support",
+    "title": "Other",
+    "content": "corazón latino holds monthly emotional support groups for people in the latinx community online and in paso robles.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "recreation-fitness-socializing-connection",
+    "title": "Recreation, Fitness, Socializing, Connection",
+    "content": "fitness\nthere are free, outdoor fitness courts with exercise equipment at emerson park in slo (pismo st. & nipomo st.), and behind french hospital in slo (along the bike path between breck st. and the french hospital parking lot).\nthe \"vita fitness courses\" in meadow park (between corrida drive and south street in slo) and around laguna lake park in slo have some stations with rudimentary equipment that are designed for fitness exercises.\n\n\nthe slo county ymca has a gym in slo city with weight machines, fitness classes (on-line and in person), aqua fitness classes, swim lessons, and more.\nmembership is not free, but the ymca policy is that \"no one is denied membership because of inability to pay.\"\nask them about options for people with low incomes.\narroyo grande recreation services offers low-cost barreconnect, fitness, somatic breathwork, pilates, tai chi, yoga, and zumba classes.\natascadero recreation offers low-cost yoga classes.\ngrover beach community services classes include tai chi, stretch & balance, dance fitness, and body movement.\npaso robles parks & recreation offers many fitness classes including aquatic fitness, yoga, and zumba.\nthey typically cost money, but there is a scholarship program for people with low incomes.\ncity of slo parks and recreation offers low-cost yoga classes (they provide the yoga mat and any other necessary supplies) and sports (such as pickleball, volleyball, table tennis, softball, dodgeball, and basketball).\nthe darebee website has more than 2,500 free, illustrated workout guides, most of which do not require any special equipment.\nsome local yoga studios offer occasional \"community yoga\" classes that are free or on a donation or sliding-scale basis.\nfitness for seniors\narroyo grande recreation services offers low-cost senior fitness classes.\natascadero senior center offers fitness classes such as senior yoga, tai chi, and qigong.\ncentral coast senior center (oceano) offers low-cost yoga, chair exercises, and tai chi.\nmorro bay senior citizens offers yoga, tai chi, strength training, balance class, adult class exercise for seniors (aces), pace (people with arthritis can exercise).\nnipomo senior center offers low-impact chair exercise classes.\npaso robles senior center offers yoga, balance and strength classes, flexercise, arthritis exercise, and brain fitness classes.\nslo senior center leads \"slo hikers & walkers\" hikes of local trails and strolls through downtown, designed for people age 55 and older.\nsee the hikers & walkers section of the city's senior center web page for details on upcoming hikes and walks.\nthey also host low-cost yoga classes (the first class is free), a free chair exercise class, and a free strength & balance class, all for people age 55 and older.\nrecreation and socializing\nslo city has a free, public skate park, open daily 7am-10pm, at santa rosa park.\nyou must wear a helmet and elbow & knee pads to use the skate park.\nthe slo county ymca runs a local basketball league and organizes pick-up game hours.\nthe city of slo offers free concerts in the plaza downtown on friday evenings during the summer.\narroyo grande recreation services offers free concerts at the rotary bandstand mid-day on sundays during the summer.\ngrover beach community services offers free concerts on sundays in ramona park during the summer.\nmorro bay active adults offers free concerts on thursdays in the early fall at tidelands park.\npaso robles recreation services offers free concerts on thursday evenings during the summer in the downtown city park.\narroyo grande recreation services offers low-cost classes in things like improvisation, bagpipes, bridge, line dance, drumming, and fabric arts.\natascadero recreation offers an adult basketball and kickball league, as well as drop-in basketball three days a week, and drop-in volleyball one day a week.\nthey also offer classes in arts & crafts\ngrover beach community services classes include acrylic & oil painting, dance, calligraphy, ukulele, and sailing.\npaso robles parks & recreation offers many classes and activities including karate, pickleball, line dancing, crafting, dog training, and first aid.\nthey typically cost money, but there is a scholarship program for people with low incomes.\npismo beach recreation division has two beach wheelchairs available to the public to be borrowed for four hours at a time at no charge.\ncall 805-773-2422 for details.\nthere are five major disc golf courses in slo county.\nthe slo city bicycling community operates several free events, such as bike-in movie nights, group rides, and free bike breakfasts, many of which take place during \"bike month\" (lately, may).\nthe first thursday of every month, soon after slo's downtown farmers' market, is the \"bike happening\" in which dozens to hundreds of bicyclists do circuits around downtown, hooting and hollering.\nthe bay osos folk dancers club meets on tuesdays from 11am-3pm at the south bay community center to learn and practice folk and line dances.\ndonations are requested to cover costs.\nrecreation and socializing for seniors\natascadero senior center offers classes, board and card games, arts & crafts sessions, discussion groups, movies, walking groups.\nmost are free for members ($20 annual dues), and $2 for non-members.\nthey also have a lending library of games and puzzles.\ncentral coast senior center (oceano) hosts games, a ukulele group, line dancing, and bingo.\nmorro bay senior citizens hosts bingo, bocce, bridge, chess, dance, drawing & watercolor, ping-pong, pool and billiards, hand & foot cards, and special-interest classes.\nthere are pickleball courts in del mark park in morro bay, open to all from 8am-noon and open by reservation (for a fee through the morro bay recreation department) in the afternoons.\nfree lessons are available (balls and paddles provided) on saturdays from 8:30-9:00am.\nnipomo senior center hosts bingo, canasta, a potluck, and has free coffee daily.\npaso robles senior center hosts scrabble, hand & foot, pinochle, meditation & mindfulness, knitting, bridge, mahjong, poker, bingo, mexican train, rummikub, cribbage, movies, a book club, and a walking group.\nslo senior center operates free \"around the town\" tours of local places of interest for people age 55 and older.\nsee the around the town section of the city's senior center web page for details on upcoming tours and instructions on how to register.\nthey also host bingo, bridge, mahjong, mexican train dominoes, pinochle, and other activities at various times during the week (some of these are free, some cost a few dollars).\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "fitness",
+    "title": "Fitness",
+    "content": "there are free, outdoor fitness courts with exercise equipment at emerson park in slo (pismo st. & nipomo st.), and behind french hospital in slo (along the bike path between breck st. and the french hospital parking lot).\nthe \"vita fitness courses\" in meadow park (between corrida drive and south street in slo) and around laguna lake park in slo have some stations with rudimentary equipment that are designed for fitness exercises.\n\n\nthe slo county ymca has a gym in slo city with weight machines, fitness classes (on-line and in person), aqua fitness classes, swim lessons, and more.\nmembership is not free, but the ymca policy is that \"no one is denied membership because of inability to pay.\"\nask them about options for people with low incomes.\narroyo grande recreation services offers low-cost barreconnect, fitness, somatic breathwork, pilates, tai chi, yoga, and zumba classes.\natascadero recreation offers low-cost yoga classes.\ngrover beach community services classes include tai chi, stretch & balance, dance fitness, and body movement.\npaso robles parks & recreation offers many fitness classes including aquatic fitness, yoga, and zumba.\nthey typically cost money, but there is a scholarship program for people with low incomes.\ncity of slo parks and recreation offers low-cost yoga classes (they provide the yoga mat and any other necessary supplies) and sports (such as pickleball, volleyball, table tennis, softball, dodgeball, and basketball).\nthe darebee website has more than 2,500 free, illustrated workout guides, most of which do not require any special equipment.\nsome local yoga studios offer occasional \"community yoga\" classes that are free or on a donation or sliding-scale basis.\nfitness for seniors\narroyo grande recreation services offers low-cost senior fitness classes.\natascadero senior center offers fitness classes such as senior yoga, tai chi, and qigong.\ncentral coast senior center (oceano) offers low-cost yoga, chair exercises, and tai chi.\nmorro bay senior citizens offers yoga, tai chi, strength training, balance class, adult class exercise for seniors (aces), pace (people with arthritis can exercise).\nnipomo senior center offers low-impact chair exercise classes.\npaso robles senior center offers yoga, balance and strength classes, flexercise, arthritis exercise, and brain fitness classes.\nslo senior center leads \"slo hikers & walkers\" hikes of local trails and strolls through downtown, designed for people age 55 and older.\nsee the hikers & walkers section of the city's senior center web page for details on upcoming hikes and walks.\nthey also host low-cost yoga classes (the first class is free), a free chair exercise class, and a free strength & balance class, all for people age 55 and older.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "recreation-and-socializing",
+    "title": "Recreation and Socializing",
+    "content": "slo city has a free, public skate park, open daily 7am-10pm, at santa rosa park.\nyou must wear a helmet and elbow & knee pads to use the skate park.\nthe slo county ymca runs a local basketball league and organizes pick-up game hours.\nthe city of slo offers free concerts in the plaza downtown on friday evenings during the summer.\narroyo grande recreation services offers free concerts at the rotary bandstand mid-day on sundays during the summer.\ngrover beach community services offers free concerts on sundays in ramona park during the summer.\nmorro bay active adults offers free concerts on thursdays in the early fall at tidelands park.\npaso robles recreation services offers free concerts on thursday evenings during the summer in the downtown city park.\narroyo grande recreation services offers low-cost classes in things like improvisation, bagpipes, bridge, line dance, drumming, and fabric arts.\natascadero recreation offers an adult basketball and kickball league, as well as drop-in basketball three days a week, and drop-in volleyball one day a week.\nthey also offer classes in arts & crafts\ngrover beach community services classes include acrylic & oil painting, dance, calligraphy, ukulele, and sailing.\npaso robles parks & recreation offers many classes and activities including karate, pickleball, line dancing, crafting, dog training, and first aid.\nthey typically cost money, but there is a scholarship program for people with low incomes.\npismo beach recreation division has two beach wheelchairs available to the public to be borrowed for four hours at a time at no charge.\ncall 805-773-2422 for details.\nthere are five major disc golf courses in slo county.\nthe slo city bicycling community operates several free events, such as bike-in movie nights, group rides, and free bike breakfasts, many of which take place during \"bike month\" (lately, may).\nthe first thursday of every month, soon after slo's downtown farmers' market, is the \"bike happening\" in which dozens to hundreds of bicyclists do circuits around downtown, hooting and hollering.\nthe bay osos folk dancers club meets on tuesdays from 11am-3pm at the south bay community center to learn and practice folk and line dances.\ndonations are requested to cover costs.\nrecreation and socializing for seniors\natascadero senior center offers classes, board and card games, arts & crafts sessions, discussion groups, movies, walking groups.\nmost are free for members ($20 annual dues), and $2 for non-members.\nthey also have a lending library of games and puzzles.\ncentral coast senior center (oceano) hosts games, a ukulele group, line dancing, and bingo.\nmorro bay senior citizens hosts bingo, bocce, bridge, chess, dance, drawing & watercolor, ping-pong, pool and billiards, hand & foot cards, and special-interest classes.\nthere are pickleball courts in del mark park in morro bay, open to all from 8am-noon and open by reservation (for a fee through the morro bay recreation department) in the afternoons.\nfree lessons are available (balls and paddles provided) on saturdays from 8:30-9:00am.\nnipomo senior center hosts bingo, canasta, a potluck, and has free coffee daily.\npaso robles senior center hosts scrabble, hand & foot, pinochle, meditation & mindfulness, knitting, bridge, mahjong, poker, bingo, mexican train, rummikub, cribbage, movies, a book club, and a walking group.\nslo senior center operates free \"around the town\" tours of local places of interest for people age 55 and older.\nsee the around the town section of the city's senior center web page for details on upcoming tours and instructions on how to register.\nthey also host bingo, bridge, mahjong, mexican train dominoes, pinochle, and other activities at various times during the week (some of these are free, some cost a few dollars).\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "pet-care-and-pet-supplies",
+    "title": "Pet Care and Pet Supplies",
+    "content": "slo county animal services operates the only open-intake animal shelter in slo county.\nservices include dog licensing, pet microchipping, lost and found pet assistance, animal adoption, assistance animal identification tags, rabies control, animal welfare investigations, nuisance animal response, and humane education programs.\nthey have an on-line registry of all animals currently at the pound, with photos and you can use a web interface to report a lost pet.\nyou can call 805-781-4407 to listen to a found animal recording that describes recently-found animals that are being held at the pound.\ncentral coast partnership for animal welfare conducts regular free pet food distributions in grover beach and oceano.\nyou can also call their emergency pet care phone line to arrange for emergency veterinary treatment.\nc.a.r.e.4paws, in partnership with \"the street dog coalition,\" operates mobile pet wellness clinics in nipomo, grover beach, arroyo grande, san luis obispo, and oceano, as well as several sites in santa barbara county.\nthese provide vaccines, spay/neuter service, health exams, medical care, and pet food assistance.\nthey specialize in care for pets of homeless people.\nthey also operate the \"pet refuge\" program, which can temporarily board pets for people whose housing situation has become unstable or who are temporarily unable to care for their pets. \nwoods humane society has a pet pantry for pet owners facing challenges and offers financial assistance for spay/neuter procedures.\nthey can also help you find lost pets and can find new homes for pets when their owners can no longer take care of them.\nsome services are by-appointment only.\nnorth county paws cause can help people in northern slo county who need help caring for their cats while they are homeless or transitioning into new housing.\npets of the homeless is a national organization that focuses on feeding and providing veterinary care to pets of people experiencing homelessness.\nif your pet needs veterinary care, call them to arrange an interview with a case manager who will determine your eligibility, approve an exam, and help make an appointment at local hospital or clinic.\nthere is no charge to the pet owner, but donations are appreciated.\nthe 40 prado homeless services center has a pet kennel for guests (both overnight guests and warming/cooling center guests).\npets must have documentation of rabies vaccinations.\ncal poly \"doggy days\" veterinary clinics are periodic pop-up clinics that offer free veterinary care including vaccinations, exams, and nail trims.\nthey happen 3-4 times per quarter at various locations around slo county, often coordinating with other community outreach programs like shower the people.\nkritter care, based in morro bay, can give dog & cat food, pet supplies, and assistance with vet bills to pet owners who have only limited funds.\nvoice for the animals helping friends program helps seniors, people with disabilities, terminal illnesses, and individuals on fixed incomes to pay for medical treatments for their pets.\nthe pet fund is a national organization that provides financial assistance to pet owners who need non-emergency veterinary care but lack sufficient funds.\nsubmit an application at their website.\nyou must document your financial need and provide veterinary care estimates.\nred rover relief provides one-time urgent care grants of up to $1,000 to pay for pet medical emergencies.\nthis is only for people in the u.s. with income under $60,000 per year.\nyou must make a fundraising effort first before you contact red rover relief.\nyou must supply a current veterinary diagnosis and treatment plan.\ngrants do not cover exams or testing.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "disaster-preparedness",
+    "title": "Disaster Planning/Preparation",
+    "content": "fires, floods, and earthquakes sometimes strike slo county.\nextremes of weather like heat waves, freezing temperatures, and storms are also increasingly common.\nepidemics, tsunamis, and hazardous materials releases can also happen.\nif you are homeless and sleeping outdoors, you can be especially vulnerable to such dangers.\nthe slo county office of emergency services has resources that can help you prepare for and respond to emergency situations.\ntheir readyslo.org site includes the following sections:\n\nprepareslo.org-how to prepare for the next emergency, how to learn your evacuation zone number, and how to understand emergency alerts\nemergencyslo.org-information about ongoing emergencies, evacuation orders and warnings, evacuation shelters, and road closures\nrecoverslo.org-after an emergency, this page lists some ways to recover from it\n\nyou can register to get local emergency alerts by text message on your phone at alertslo.\nyou can choose which sorts of alerts you are interested in receiving (for example \"flood / flash flood\" and \"fire\").\nthe red cross operates emergency shelters during major disasters.\nthey usually have pet-friendly options.\nfire safety in camp\nif you are camping outdoors, be very careful with fire.\ncalifornia frequently experiences major wildfires, and campfires are a frequent cause.\nbuild fires at least 25 feet away from tents, shrubs, and flammable materials.\ndo not build fires under overhanging tree branches.\navoid fires on windy days and during periods when fire danger is particularly high (such as mid to late summer).\ndo not use flammable liquids like gasoline or lighter fluid to start camp fires.\nkeep fires small.\nit is wiser and takes less effort to make a small fire and sit close to it than to make a big fire and sit far away.\nuse existing fire rings when these are available.\notherwise clear a five-foot (two-meter) radius around the fire of all vegetation and flammable material.\nhave a bucket of water handy.\ndo not leave a fire unattended.\nalways extinguish it thoroughly first.\nto extinguish a fire thoroughly, soak it with water.\nstir the ashes to expose any unburned material, and soak it again.\nthe fire is not thoroughly extinguished until you can place your hand anywhere into the ashes without getting burned.\nnote that in slo county it is not legal to have a campfire outside of a developed campground unless you have a valid california campfire permit.\nin many times and places in slo county it is not legal to make a campfire whether you have such a permit or not.\nextreme cold and heat\nslo county is in general blessed with a moderate climate, but rainy or dangerously cold overnight weather is common in winter, and dangerously hot daytime weather is common in summer.\nsee the warming/cooling centers of this guide for some ways to get shelter from these temperature extremes.\nwarming centers typically open when temperatures are due to drop to 38°f or below or there is more than a 50% chance of rain.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "fire-safety",
+    "title": "Fire Safety in Camp",
+    "content": "if you are camping outdoors, be very careful with fire.\ncalifornia frequently experiences major wildfires, and campfires are a frequent cause.\nbuild fires at least 25 feet away from tents, shrubs, and flammable materials.\ndo not build fires under overhanging tree branches.\navoid fires on windy days and during periods when fire danger is particularly high (such as mid to late summer).\ndo not use flammable liquids like gasoline or lighter fluid to start camp fires.\nkeep fires small.\nit is wiser and takes less effort to make a small fire and sit close to it than to make a big fire and sit far away.\nuse existing fire rings when these are available.\notherwise clear a five-foot (two-meter) radius around the fire of all vegetation and flammable material.\nhave a bucket of water handy.\ndo not leave a fire unattended.\nalways extinguish it thoroughly first.\nto extinguish a fire thoroughly, soak it with water.\nstir the ashes to expose any unburned material, and soak it again.\nthe fire is not thoroughly extinguished until you can place your hand anywhere into the ashes without getting burned.\nnote that in slo county it is not legal to have a campfire outside of a developed campground unless you have a valid california campfire permit.\nin many times and places in slo county it is not legal to make a campfire whether you have such a permit or not.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "extreme-cold-and-heat",
+    "title": "Extreme Cold and Heat",
+    "content": "slo county is in general blessed with a moderate climate, but rainy or dangerously cold overnight weather is common in winter, and dangerously hot daytime weather is common in summer.\nsee the warming/cooling centers of this guide for some ways to get shelter from these temperature extremes.\nwarming centers typically open when temperatures are due to drop to 38°f or below or there is more than a 50% chance of rain.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "advocacy-and-organizing",
+    "title": "Advocacy & Lobbying: Influencing Government Homelessness Policy",
+    "content": "in this section:\n\ninfluencing policy\nreporting concerns and problems\nreporting crimes\nreporting government misconduct\n\nsan luis obispo county is an especially challenging place for people trying to avoid or to escape homelessness.\nnearly one in four homeless people in the united states lives in california.\ncalifornia has one of the highest per-capita rates of homelessness in the nation, and the highest percentage of unsheltered homeless people.\nin san luis obispo county, there are only enough shelter beds for about 20-30% of the people known to be homeless here, and so the county has the third highest percentage of unsheltered homelessness of any mostly-rural county in the u.s.\nthe city of san luis obispo is one of the top ten most expensive cities in the u.s. based on how much income (relative to the median income) you must have to afford to buy a home.\n10% of schoolchildren in slo county are homeless.\nwhy are things especially difficult here?\nthere are many reasons, but the most important one is \"too few homes for the number of people who need them.\"\nthe reasons why that is a problem are complicated, but include government policies that reduce the availability of homes and make them more expensive, resource constraints, and high demand.\n\n\n\nexternal links\n\n\n\nquarterly homelessness dashboard: the slo county department of social services's summary of the ongoing work of homeless management agencies.\n\n\nwikipedia: homelessness in california\n\n\nhomelessness is a housing problem by gregg colburn & clayton page aldern\n\n\ninfluencing policy\nthe slo county homeless services division is in charge of implementing county policies to address homelessness.\nthese policies include the san luis obispo countywide plan to address homelessness, 2022-2027.\nyou can contact them at ss_homelessservices@co.slo.ca.us.\nthe homeless services division is advised and overseen by the homeless services oversight council (hsoc).\nthis council welcomes people with current or past lived experience of homelessness to join it.\nyou can apply for a seat on this council by completing this form and submitting it to ss_homelessservices@co.slo.ca.us.\nthe meetings of this council and its committees are open to the public, either in person, or via zoom or phone.\nvisit slocounty.gov/hsoc for meeting schedules.\nevery two years, typically in january, a census of homeless people in the united states is attempted.\nthis is called the \"point-in-time count\".\nthis helps the government estimate how many people are homeless, where homeless people are, and what their characteristics are.\nthis in turn helps the government decide what policy responses to prioritize.\nyou can read the official report on slo county's 2024 point-in-time count.\nthe point-in-time count is conducted by volunteers.\nif you would like to help with the count, email hsd_pitcount@co.slo.ca.us for details.\nsloco yimby is a grassroots group that advocates for building more housing in slo county, and for policy changes like legalizing multifamily housing, streamlining permitting, increasing affordable housing funding, and strengthening renter protections.\nthey mobilize citizen action and outreach campaigns in support of those goals.\ncontact hello@slocoyimby.org for details.\nthe national coalition for the homeless campaigns on the national level for changes in u.s. federal policy to alleviate homelessness and help people who are homeless.\nthe national union of the homeless has a sacramento chapter that helped slo county homeless people fight for legal protection when the kansas avenue (a.k.a. oklahoma avenue) safe parking program was closed.\nyou can contact the sacramento chapter at sacramento.homeless.union@gmail.com.\nreporting concerns and problems\nsome slo county cities have on-line platforms with which you can report non-emergency problems.\nyour report is routed to the correct department where people can address your concern:\n\n\n\ncity\nplatform\n\n\n\narroyo grande\ncitizen request tracker or citizenserv\n\n\natascadero\npublic safety & reporting\n\n\ngrover beach\nreport an issue\n\n\nmorro bay\ncitysourced\n\n\npaso robles\nseeclickfix\n\n\npismo beach\npismo pulse\n\n\nslo\naskslo\n\n\nsome cities have special contacts specifically for issues concerning homelessness.\nfor homeless-specific questions in paso robles, contact homelessinfo@prcity.com.\nin slo city, contact the homelessness response manager at dwiberg@slocity.org or 805-781-7025.\nreporting crimes\nto report a crime in process, or a crime where you know who committed it, you should contact the local police department (in a city) or the sheriff (outside city limits).\ncalling 911 is the best way of reporting an emergency or a crime in progress.\nin non-emergency situations, you can call the police or sheriff departments directly:\n\n\n\nlocation\nphone number\n\n\n\n(unincorporated areas)\nsheriff: 805-781-4550 x3\n\n\narroyo grande\npolice: 805-473-5100\n\n\natascadero\npolice: 805-461-5051 x5\n\n\ncal poly\npolice: 805-756-2281\n\n\ngrover beach\npolice: 805-473-4511\n\n\n(highways)\nchp: 805-835-5247\n\n\nmorro bay\npolice: 805-772-6225\n\n\npaso robles\npolice: 805-237-6464\n\n\npismo beach\npolice: 805-773-2208\n\n\nslo city\npolice: 805-781-7312\n\n\nin some areas, you can also report a crime in a non-emergency situation, where you do not know who committed the crime, with an on-line form:\n\n\n\nlocation\nonline reporting method\n\n\n\n(unincorporated areas)\nsheriff: public safety citizens service portal\n\n\natascadero\npolice: crime reporting\n\n\npaso robles\npolice: file a police report\n\n\nslo city\npolice: online reporting\n\n\nhighways and other cities\ncall one of the phone numbers in the table above\n\n\nyou can also submit tips to law enforcement about crimes (anonymously if you choose) through slo county crime stoppers.\nyou can do this either by using the on-line tip form at sanluisobispocounty.crimestoppersweb.com or by calling 805-549-stop.\nif you are an adult who is dependent on others, and you are subjected to abuse or neglect-or if you know of another adult in such a situation-you can get help from adult protective services.\nmake emergency calls to 805-781-1790 (m-f 8am-5pm) or 844-729-8011 (all other hours).\nreporting government misconduct\nyou can report misconduct by police or sheriff personnel to the police or sheriff departments.\nsome departments welcome such reports and use them to improve or to discipline misbehaving employees.\nother departments are hostile to such complaints and may even retaliate against people who report misconduct.\nyou may want to carefully consider the pros and cons before filing misconduct complaints.\n\n\n\ndepartment\ncomplaint method\n\n\n\narroyo grande police\ncitizen complaint\n\n\ncal poly police\npolice@calpoly.edu\n\n\nchp (highways)\ncommend or complain form\n\n\ngrover beach police\ncitizen feedback\n\n\npismo beach police\n805-773-2208, in person, or by mail\n\n\nslo city police\ncitizen complaint, or 805-781-7317\n\n\nslo county sheriff\ncitizen complaint report\n\n\nothers\ncall, or visit in person\n\n\nfor complaints about county employee or department misconduct, if you have been unable to resolve your complaint by contacting the department itself, you can file a complaint with the county administrative office by using its submit a complaint form.\nfor complaints about county behavioral health specifically, contact the patients' rights advocate (805-781-4738).\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "influencing-policy",
+    "title": "Influencing Policy",
+    "content": "the slo county homeless services division is in charge of implementing county policies to address homelessness.\nthese policies include the san luis obispo countywide plan to address homelessness, 2022-2027.\nyou can contact them at ss_homelessservices@co.slo.ca.us.\nthe homeless services division is advised and overseen by the homeless services oversight council (hsoc).\nthis council welcomes people with current or past lived experience of homelessness to join it.\nyou can apply for a seat on this council by completing this form and submitting it to ss_homelessservices@co.slo.ca.us.\nthe meetings of this council and its committees are open to the public, either in person, or via zoom or phone.\nvisit slocounty.gov/hsoc for meeting schedules.\nevery two years, typically in january, a census of homeless people in the united states is attempted.\nthis is called the \"point-in-time count\".\nthis helps the government estimate how many people are homeless, where homeless people are, and what their characteristics are.\nthis in turn helps the government decide what policy responses to prioritize.\nyou can read the official report on slo county's 2024 point-in-time count.\nthe point-in-time count is conducted by volunteers.\nif you would like to help with the count, email hsd_pitcount@co.slo.ca.us for details.\nsloco yimby is a grassroots group that advocates for building more housing in slo county, and for policy changes like legalizing multifamily housing, streamlining permitting, increasing affordable housing funding, and strengthening renter protections.\nthey mobilize citizen action and outreach campaigns in support of those goals.\ncontact hello@slocoyimby.org for details.\nthe national coalition for the homeless campaigns on the national level for changes in u.s. federal policy to alleviate homelessness and help people who are homeless.\nthe national union of the homeless has a sacramento chapter that helped slo county homeless people fight for legal protection when the kansas avenue (a.k.a. oklahoma avenue) safe parking program was closed.\nyou can contact the sacramento chapter at sacramento.homeless.union@gmail.com.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "reporting-concerns",
+    "title": "Reporting Concerns and Problems",
+    "content": "some slo county cities have on-line platforms with which you can report non-emergency problems.\nyour report is routed to the correct department where people can address your concern:\n\n\n\ncity\nplatform\n\n\n\narroyo grande\ncitizen request tracker or citizenserv\n\n\natascadero\npublic safety & reporting\n\n\ngrover beach\nreport an issue\n\n\nmorro bay\ncitysourced\n\n\npaso robles\nseeclickfix\n\n\npismo beach\npismo pulse\n\n\nslo\naskslo\n\n\nsome cities have special contacts specifically for issues concerning homelessness.\nfor homeless-specific questions in paso robles, contact homelessinfo@prcity.com.\nin slo city, contact the homelessness response manager at dwiberg@slocity.org or 805-781-7025.\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "reporting-crimes",
+    "title": "Reporting Crimes",
+    "content": "to report a crime in process, or a crime where you know who committed it, you should contact the local police department (in a city) or the sheriff (outside city limits).\ncalling 911 is the best way of reporting an emergency or a crime in progress.\nin non-emergency situations, you can call the police or sheriff departments directly:\n\n\n\nlocation\nphone number\n\n\n\n(unincorporated areas)\nsheriff: 805-781-4550 x3\n\n\narroyo grande\npolice: 805-473-5100\n\n\natascadero\npolice: 805-461-5051 x5\n\n\ncal poly\npolice: 805-756-2281\n\n\ngrover beach\npolice: 805-473-4511\n\n\n(highways)\nchp: 805-835-5247\n\n\nmorro bay\npolice: 805-772-6225\n\n\npaso robles\npolice: 805-237-6464\n\n\npismo beach\npolice: 805-773-2208\n\n\nslo city\npolice: 805-781-7312\n\n\nin some areas, you can also report a crime in a non-emergency situation, where you do not know who committed the crime, with an on-line form:\n\n\n\nlocation\nonline reporting method\n\n\n\n(unincorporated areas)\nsheriff: public safety citizens service portal\n\n\natascadero\npolice: crime reporting\n\n\npaso robles\npolice: file a police report\n\n\nslo city\npolice: online reporting\n\n\nhighways and other cities\ncall one of the phone numbers in the table above\n\n\nyou can also submit tips to law enforcement about crimes (anonymously if you choose) through slo county crime stoppers.\nyou can do this either by using the on-line tip form at sanluisobispocounty.crimestoppersweb.com or by calling 805-549-stop.\nif you are an adult who is dependent on others, and you are subjected to abuse or neglect-or if you know of another adult in such a situation-you can get help from adult protective services.\nmake emergency calls to 805-781-1790 (m-f 8am-5pm) or 844-729-8011 (all other hours).\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "reporting-misconduct",
+    "title": "Reporting Government Misconduct",
+    "content": "you can report misconduct by police or sheriff personnel to the police or sheriff departments.\nsome departments welcome such reports and use them to improve or to discipline misbehaving employees.\nother departments are hostile to such complaints and may even retaliate against people who report misconduct.\nyou may want to carefully consider the pros and cons before filing misconduct complaints.\n\n\n\ndepartment\ncomplaint method\n\n\n\narroyo grande police\ncitizen complaint\n\n\ncal poly police\npolice@calpoly.edu\n\n\nchp (highways)\ncommend or complain form\n\n\ngrover beach police\ncitizen feedback\n\n\npismo beach police\n805-773-2208, in person, or by mail\n\n\nslo city police\ncitizen complaint, or 805-781-7317\n\n\nslo county sheriff\ncitizen complaint report\n\n\nothers\ncall, or visit in person\n\n\nfor complaints about county employee or department misconduct, if you have been unable to resolve your complaint by contacting the department itself, you can file a complaint with the county administrative office by using its submit a complaint form.\nfor complaints about county behavioral health specifically, contact the patients' rights advocate (805-781-4738).\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "miscellaneous-free-items",
+    "title": "(Mostly) Free Stuff",
+    "content": "totally free\nthe freecycle san luis obispo network is free to join (you must create an on-line account to participate).\npeople in the network can announce when they have things that they no longer want and would like to give away, or can request items they are looking for.\nall items are cost-free.\nthere are also \"buy nothing\" groups in the area that have a similar focus.\nthe buy nothing project has an app you can use to connect with people nearby who have things to give away.\nyou may have better luck searching facebook for \"buy nothing\" plus the name of the town you are in.\n\"little free libraries\" are boxes in public areas (for example adjacent to sidewalks) where people leave books they are giving away.\nanyone is free to take books for their own use from little free libraries.\nthere is no check-out/check-in procedure. just take what you want to read, or leave what you're finished reading.\nthey are typically open 24-hours a day, every day.\nsee little free libraries in the directory for a list of dozens of them in slo county.\n\"little free pantries\" are similar, but rather than holding books, they specialize in non-perishable food, feminine hygiene products, pet food, and miscellaneous other items.\nsee little free pantries in the directory for a list of several in slo county.\nthe shandon branch of slo county public libraries has a tool-lending library.\npeople with county library cards can borrow power tools like drills, saws, sanders, or a router; outdoor tools like a leaf blower, hedge trimmer, or pole saw; and manual tools like ladders, levels, dollies, or a workbench.\nyou must complete some extra forms and a liability waiver to use the tool lending library.\npg&e's energy savings assistance (esa) program helps low-income households upgrade or repair water heaters, furnaces, lighting, and appliances for no cost.\nthis can also improve energy efficiency, which will lower your utility bills.\nsee their website for information on who is eligible and how to apply, or call 800-933-9555.\ncapslo can connect low-income households with providers of no-cost weatherization through their home and energy services program.\nthey can also connect seniors (aged 60+) with providers of no-cost minor home repairs through that program.\ncall their energy office for details.\nthe front porch cafe on the cal poly campus will pour you a free cup of coffee.\nif you are a cuesta college student, you can get free hygiene products, a scarf, hats, backpacks, laundry soap, menstruation products, and sometimes gift cards to fast food restaurants from the basic needs office. \n\nsee holiday gifts for children in the children, youth, and people with children section of this guide for information on how to get free toys, coats, bicycles, and other such gifts for your children during the holidays.\n\nlow-cost\n\nsee clothing: thrift stores for a list of low-cost thrift stores in slo county. many sell a variety of goods other than clothing.\n\nhabitat for humanity restore sells recycled construction materials, building supplies, furniture, appliances, and home décor at low prices.\nslo makerspace can give you access to a variety of tools-everything from basic hand tools to laser cutters and 3d printers.\nyou can get a free \"partner pass\" membership through slo county public libraries.\nthis allows you to access some tools during some operating hours.\nto access their full set of tools always, you may need to pay for a full membership.\nyou will also need to attend a general orientation.\nsome advanced tools also require that you take tool-specific orientation classes before you can use them, and some of those cost money.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "totally-free-stuff",
+    "title": "Totally Free",
+    "content": "the freecycle san luis obispo network is free to join (you must create an on-line account to participate).\npeople in the network can announce when they have things that they no longer want and would like to give away, or can request items they are looking for.\nall items are cost-free.\nthere are also \"buy nothing\" groups in the area that have a similar focus.\nthe buy nothing project has an app you can use to connect with people nearby who have things to give away.\nyou may have better luck searching facebook for \"buy nothing\" plus the name of the town you are in.\n\"little free libraries\" are boxes in public areas (for example adjacent to sidewalks) where people leave books they are giving away.\nanyone is free to take books for their own use from little free libraries.\nthere is no check-out/check-in procedure. just take what you want to read, or leave what you're finished reading.\nthey are typically open 24-hours a day, every day.\nsee little free libraries in the directory for a list of dozens of them in slo county.\n\"little free pantries\" are similar, but rather than holding books, they specialize in non-perishable food, feminine hygiene products, pet food, and miscellaneous other items.\nsee little free pantries in the directory for a list of several in slo county.\nthe shandon branch of slo county public libraries has a tool-lending library.\npeople with county library cards can borrow power tools like drills, saws, sanders, or a router; outdoor tools like a leaf blower, hedge trimmer, or pole saw; and manual tools like ladders, levels, dollies, or a workbench.\nyou must complete some extra forms and a liability waiver to use the tool lending library.\npg&e's energy savings assistance (esa) program helps low-income households upgrade or repair water heaters, furnaces, lighting, and appliances for no cost.\nthis can also improve energy efficiency, which will lower your utility bills.\nsee their website for information on who is eligible and how to apply, or call 800-933-9555.\ncapslo can connect low-income households with providers of no-cost weatherization through their home and energy services program.\nthey can also connect seniors (aged 60+) with providers of no-cost minor home repairs through that program.\ncall their energy office for details.\nthe front porch cafe on the cal poly campus will pour you a free cup of coffee.\nif you are a cuesta college student, you can get free hygiene products, a scarf, hats, backpacks, laundry soap, menstruation products, and sometimes gift cards to fast food restaurants from the basic needs office. \n\nsee holiday gifts for children in the children, youth, and people with children section of this guide for information on how to get free toys, coats, bicycles, and other such gifts for your children during the holidays.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "low-cost-stuff",
+    "title": "Low-Cost",
+    "content": "\nsee clothing: thrift stores for a list of low-cost thrift stores in slo county. many sell a variety of goods other than clothing.\n\nhabitat for humanity restore sells recycled construction materials, building supplies, furniture, appliances, and home décor at low prices.\nslo makerspace can give you access to a variety of tools-everything from basic hand tools to laser cutters and 3d printers.\nyou can get a free \"partner pass\" membership through slo county public libraries.\nthis allows you to access some tools during some operating hours.\nto access their full set of tools always, you may need to pay for a full membership.\nyou will also need to attend a general orientation.\nsome advanced tools also require that you take tool-specific orientation classes before you can use them, and some of those cost money.\n\n",
+    "type": "resource-section",
+    "level": 3
+  },
+  {
+    "id": "other-guides",
+    "title": "Other Guides, Web Pages, Information Sources",
+    "content": "some other groups assemble resource guides like this one.\nsome have a different focus (for instance, they highlight resources for seniors or for veterans) or cover a different region.\nhere are some of these local guides:\n\ncentral coast senior resource guide: a comprehensive guide covering services for seniors in slo and santa barbara counties. also exists as a searchable on-line directory at centralcoastseniors.myresourcedirectory.com.\nnorth county senior resource guide: available in english and spanish; covers education, meals, housing, in-home care, transportation, mental health, legal support, financial assistance, recreation, and healthcare\nsan luis obispo county mental health resource guide\n211 slo county: united way's directory of slo county resources\ncommunity support services: a list of services available in southern slo county, maintained by 5cities homeless coalition\nnavslo: slo county public health agency's directory of resources\nhelpslo resource list of aid groups, programs, and services in slo county\n2024 financial aid/assistance resources - san luis obispo: faith legrande's list that they put together while searching for help\nassistance programs in slo county: from the \"need help paying bills\" website\n(tmha) helpful links: with a focus on resources having to do with mental health\nslo county behavioral health resource center\nresource guide estero bay: focusing on los osos and nearby communities\nsharing slo wiki: \"an overview of some of san luis obispo's sharing economy\"\nimmigrant services guide: resources for undocumented immigrants in slo county\nslo county job seeker resource guide\nthe homeless veteran's resource guide\n\nif you would like some in-person help, you can get assistance on a variety of issues from the library outreach team at slo county public libraries branches:\n\n\n\natascadero library, wednesdays, 10:30am-noon\narroyo grande library, thursdays, 9:30am-11am\nlos osos library, fridays, 1-2:30pm\nmorro bay library, thursdays, 12:30pm-2pm\nslo city library, tuesdays, 10-11:30am & 2:30-4pm\n\nyou can drop in, or make an appointment by calling or texting 805-540-0057.\n\n",
+    "type": "resource-section",
+    "level": 2
+  },
+  {
+    "id": "40-Prado",
+    "title": "40 Prado Homeless Services Center",
+    "content": "40 prado homeless services center\n\nwebsite: capslo.org/40-prado\nlocation: 40 prado road, slo map\nphone:\n805-544-4004 x2 (general services) \n805-544-4004 x100 (more information)\n805-459-1073 (questions about on-site safe parking)\n\n\nhours: every day, 8am-2:30pm and 4:30pm-7am (closed 2:30pm-4:30pm and 7-8am) \novernight shelter intake: m-th 9am-2pm, fridays by appointment only  (intake is a one-time registration process where you provide personal information, complete paperwork, and get added to the shelter system)\nlaundry services: 8am-2:30pm\nday services: 8am-4pm \nbreakfast: before 9am \nlunch: noon-12:30pm (open to all) \novernight shelter check-in: daily, 4:30-6pm (check-in is done each day you want a bed; you must arrive during check-in hours to secure a spot for that night)\ndinner: 5-5:30pm (overnight shelter and cooling center residents only)\nwarming center: 7pm-8am (only when warming center is in operation) \ncooling center: 8am-6pm (only when cooling center is in operation) \nsafe parking: 6pm-7pm \n\n\nhow to access: come to the shelter during intake hours\nto use the shelter, you must be homeless, you must have a valid photo id, and you must not have a p.c. 290 sex offender criminal record. you must be able to care for yourself independently (bathing, feeding, dressing, etc.). there are a limited number of beds; priority is given to slo county residents.\n\n\nnotes:\noperates rotating overnight safe parking program\noperates slo hub \noperates the \"mid county warming and cooling center\" \noperates the \"40 prado safe parking program\" \nhealthcare for the homeless program takes place at 40 prado\npeople's kitchen takes place at 43 prado \nrecuperative care program takes place at 40 prado \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "40 Prado Homeless Services Center"
+    ]
+  },
+  {
+    "id": "5CHC",
+    "title": "5Cities Homeless Coalition (5CHC)",
+    "content": "5cities homeless coalition (5chc)\n\nwebsite: 5chc.org\nlocation: 100 south 4th st., grover beach map \nwarming center: 1023 e. grand ave., arroyo grande map \n\n\nphone:\n805-574-1638 \n805-202-3615 (warming center hotline) \n805-295-1501 (warming center) \n805-295-1501 (warming center automatic text updates) \n\n\nemail: info@5chc.org \nshelter@5chc.org (warming center) \n\n\nnotes:\noperates cabins for change and \"balay ko on barka\" a.k.a. \"my home for hope\"\noperates supportive services for veteran families\noperates \"homeless youth outreach\"\nhosts the \"pet resource center\" of c.a.r.e.4paws \nentry-point for the coordinated entry system (ces)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "5Cities Homeless Coalition (5CHC)",
+      "“My Home for Hope”"
+    ]
+  },
+  {
+    "id": "805-Street-Outreach",
+    "title": "805 Street Outreach",
+    "content": "805 street outreach\n\nwebsite: 805streetoutreach.org\nemail: izzy@805streetoutreach.org \nshower program:\nlocation: morro bay public library parking lot, 625 harbor st., morro bay map \nhours: every monday, 12pm-3pm \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "805 Street Outreach"
+    ]
+  },
+  {
+    "id": "Abundance-Shop",
+    "title": "Abundance Shop",
+    "content": "abundance shop\n\nwebsite: stbenslososos.org/abundance-shop\nlocation: 2025 9th st., los osos map \nphone: 805-528-1370 \nemail: office@stbenslososos.org\nhours: th-sa 11am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Abundance Shop"
+    ]
+  },
+  {
+    "id": "AARP-Tax-Aide",
+    "title": "AARP Tax-Aide Program (Central Coast Tax-Aide)",
+    "content": "aarp tax-aide program (central coast tax-aide)\n\nwebsite: ccfreetax.org\nlocation: various locations, see appointments\nphone: 805-931-6308 \nemail: info@ccfreetax.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "AARP Tax-Aide Program (Central Coast Tax-Aide)"
+    ]
+  },
+  {
+    "id": "Access-Central-Coast",
+    "title": "Access Central Coast",
+    "content": "access central coast\n\nsee also central coast aging & disability resource center\n\n\nwebsite: accesscentralcoast.org\nlocation: 51 zaca ln. #140, slo map \nphone: 805-462-1162 (videophone: 805-464-3203) \nemail: info@accesscentralcoast.org \nhours: m-f: 9am-noon & 1-5pm (but closed every other friday)\nnote: formerly known as the \"independent living resource center\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "Access Central Coast",
+      "the “Independent Living Resource Center”",
+      "**Central Coast Aging & Disability Resource Center**"
+    ]
+  },
+  {
+    "id": "ASN",
+    "title": "Access Support Network (ASN)",
+    "content": "access support network (asn)\n\nwebsite: accesssupportnetwork.org/san-luis-obispo\nlocation: 1320 nipomo st., slo map \nalso has a mobile outreach van:\nevery other monday, 1:30-4pm at 40 prado in slo map \ntuesdays 9:30-11:30am at 1320 nipomo st. in slo map \nwednesdays 11:30am-1:30pm at paso robles echo shelter (1134 black oak dr. map) \nwednesdays 3-6pm at atascadero echo shelter (6370 atascadero ave. map)  \nsecond sunday of the month at the slo library on palm st. map \n\n\n\n\nphone: 805-781-3660 \nemail: theasnsupp@gmail.com \nhours: m-f 9am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Access Support Network (ASN)"
+    ]
+  },
+  {
+    "id": "Achievement-House-Thrift-Store",
+    "title": "Achievement House Thrift Stores",
+    "content": "achievement house thrift stores\n\nwebsite: achievementhouse.org/pages/thrift-stores\n\n\n\n\n\nlocation\nphone\nhours\n\n\n\n1446 e. grand ave., arroyo grande map\n805-202-3068\ndaily 9:30am-5pm\n\n\n730 morro bay blvd., morro bay map\n805-772-6744\ndaily 9:30am-5pm\n\n\n553 higuera st., slo map\n805-543-0412\ndaily 9:30am-5pm\n\n\n3003 cuesta college rd., slo map\n805-543-9383\nm-sa 9am-4pm\n\n\n\nemail: info@achievementhouse.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Achievement House Thrift Stores"
+    ]
+  },
+  {
+    "id": "ACLU",
+    "title": "ACLU of Southern California",
+    "content": "aclu of southern california\n\nwebsite: aclusocal.org\nphone:\n213-977-9500 (main) \n213-977-5253 (legal intake)\n\n\nhours: m-f 10am-7pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "ACLU of Southern California"
+    ]
+  },
+  {
+    "id": "Adult-Protective-Services",
+    "title": "Adult Protective Services",
+    "content": "adult protective services\n\nwebsite: slocounty.ca.gov/aps\n\n\n\n\n\nlocation\nphone\n\n\n\narroyo grande: 1086 e. grand ave. map\n805-474-2000\n\n\natascadero: 9630 el camino real map\n805-461-6000\n\n\nmorro bay: 600 quintana rd. map\n805-772-6405\n\n\nnipomo: 681 w. tefft st. #1 map\n805-931-1800\n\n\npaso robles: 406 spring st. map\n805-237-3110\n\n\nslo: 3433 s. higuera st. map\n805-781-1600\n\n\n\nphone: 805-781-1790 (m-f 8am-5pm); 844-729-8011 (after hours); 911 (emergency) \nhours: m-f 8am-4pm (and by appointment only 4-5pm) \nnotes:\ncan make referrals to medically fragile homeless program\ncan make referrals to center for family strengthening (cfs)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Adult Protective Services"
+    ]
+  },
+  {
+    "id": "Adventist-Health-Sierra-Vista",
+    "title": "Adventist Health Sierra Vista",
+    "content": "adventist health sierra vista\n\nwebsite: adventisthealth.org/central-coast/locations/sierra-vista-regional-medical-center\nlocation: 1010 murray ave., slo map \nphone: 805-546-7600 \nhours: 24/7 \nnote: hosts liberty tattoo removal program\n\n",
+    "type": "directory",
+    "aliases": [
+      "Adventist Health Sierra Vista"
+    ]
+  },
+  {
+    "id": "Adventist-Health-Twin-Cities",
+    "title": "Adventist Health Twin Cities",
+    "content": "adventist health twin cities\n\nwebsite: adventisthealth.org/central-coast/locations/twin-cities-community-hospital\nlocation: 1100 las tablas rd., templeton map \nphone: 805-434-3500 \nhours: 24/7 \n\n",
+    "type": "directory",
+    "aliases": [
+      "Adventist Health Twin Cities"
+    ]
+  },
+  {
+    "id": "Aegis-Treatment-Centers",
+    "title": "Aegis Treatment Centers",
+    "content": "aegis treatment centers\natascadero\n\nwebsite: pinnacletreatment.com/location/california/atascadero/aegis-treatment-centers-atascadero\nlocation: 6500 morro rd. suites c & d, atascadero map \nphone: 805-461-5212 \nhours:\nmedication services:\nm-th: 6am-10am, 11am-3:30pm \nf: 6am-10am, 11am-1:30pm \nsa/su/holidays: 7am-11am \n\n\nadministrative:\nm-th: 6am-4pm \nf: 6am-2:30pm \nsa/su/holidays: 7am-11am \n\n\n\n\nhow to access: walk-ins welcome; same-day admissions available \n\nslo city\n\nwebsite: pinnacletreatment.com/location/california/san-luis-obispo/aegis-san-luis-obispo-med-unit\nlocation: 1551 bishop st. #520, slo map \nphone: 805-461-5212 \nhours:\nmedication services:\nm-f: 6am-10am, 11am-1:30pm \nsa/su/holidays: 6am-10am \n\n\nadministrative:\nm-f: 6am-2:30pm \nsa/su/holidays: 6am-10am \n\n\n\n\nhow to access: schedule a visit here\n\n",
+    "type": "directory",
+    "aliases": [
+      "Aegis Treatment Centers"
+    ]
+  },
+  {
+    "id": "Aevum",
+    "title": "Aevum Home Health and Aevum Hospice Care",
+    "content": "aevum home health and aevum hospice care\n\nwebsites:\nhome health: aevumhomehealth.com\nhospice care: aevumhospice.com\n\n\nlocation: 1302 marsh st., slo map \nphone:\nhome health: 805-586-2033 \nhospice care: 805-465-2492 \n\n\nemail:\nhome health: info@aevumhomehealth.com \nhospice care: info@aevumhospice.com \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Aevum Home Health and Aevum Hospice Care"
+    ]
+  },
+  {
+    "id": "Agape-Church",
+    "title": "Agape Church",
+    "content": "agape church\n\nwebsite: agapeslo.church\nlocation: 950 laureate lane, slo map \nphone: 805-541-0777 \nemail: adminslo@agape.church \nhours:\noffice: m-th 9am-4pm \nfood pantry: tu 10-10:30am, su noon-12:30pm\n\n\nnote: \"men of agape\" serve a free meal at meadow park, slo map, thursdays at 11am\n\n",
+    "type": "directory",
+    "aliases": [
+      "Agape Church"
+    ]
+  },
+  {
+    "id": "AGS-Recycling",
+    "title": "AGS Recycling",
+    "content": "ags recycling\n\nwebsite: agsreciclyng.com\nlocations:\narroyo grande: 564 mesa view dr., arroyo grande map \nmorro bay: 2650 main street, morro bay map \n\n\nphone: 805-598-6285 \nhours:\narroyo grande: tu-sa 9am-5pm (closed noon-12:30pm) \nmorro bay: tu-sa 9am-5pm (closed noon-12:30pm) \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "AGS Recycling"
+    ]
+  },
+  {
+    "id": "Alano-Club",
+    "title": "Alano Club",
+    "content": "alano club\n\n\nwebsite: sloalanoclub.org\nlocation: 3075 broad street, slo map \nphone: 805-543-9817 \nemail: sloalanoclub@gmail.com \nhours: open 7 days/week (see meeting schedule for specific meeting times)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Alano Club"
+    ]
+  },
+  {
+    "id": "AA",
+    "title": "Alcoholics Anonymous",
+    "content": "alcoholics anonymous\n\nwebsite: sloaa.org\nlocation: 1333 van beurden dr. #102, los osos \nphone: 805-541-3211 \nemail: info@sloaa.org\nhours:\ncentral coast intergroup office: m-f noon-6pm, sa 1-4pm \nindividual meetings: many hours and locations\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Alcoholics Anonymous"
+    ]
+  },
+  {
+    "id": "APA",
+    "title": "Alliance for Pharmaceutical Access",
+    "content": "alliance for pharmaceutical access\n\nwebsite: apameds.org/for-clients\n\n\n\n\nlocation\nphone\nhours\n\n\n\n345 s. halcyon rd. (arroyo grande) map\n805-489-4261 x4267\nmo. 1pm-7pm\n\n\n1428 phillips lane #b4 (slo, inside noor clinic) map\n805-548-0894\ntu. 1pm-5pm\n\n\n\nemail: advocates@apameds.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Alliance for Pharmaceutical Access"
+    ]
+  },
+  {
+    "id": "American-Cancer-Society",
+    "title": "American Cancer Society",
+    "content": "american cancer society\n\npatient lodging programs: cancer.org/support-programs-and-services/patient-lodging.html\nroad to recovery (transportation to medical appointments): cancer.org/support-programs-and-services/road-to-recovery.html\nphone: 800-227-2345 \n\n",
+    "type": "directory",
+    "aliases": [
+      "American Cancer Society"
+    ]
+  },
+  {
+    "id": "American-Legion-Post-66",
+    "title": "American Legion Post 66",
+    "content": "american legion post 66\n\nwebsite: post66slo.org\nlocation: 1661 mill st., slo map \nphone: 805-543-6445 \nnotes: for boyd bristol medical equipment program hours, call to make an appointment\n\n",
+    "type": "directory",
+    "aliases": [
+      "American Legion Post 66"
+    ]
+  },
+  {
+    "id": "Arise-Central-Coast",
+    "title": "Arise Central Coast",
+    "content": "arise central coast\n\nwebsite: arisevineyard.com\nlocation: 1775 calle joaquin, slo map \nphone: 805-543-3162 \nhours:\noffice: m-th 9am-4pm \nfood pantry: m 2:30-4:30pm\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Arise Central Coast"
+    ]
+  },
+  {
+    "id": "Arroyo-Grande-Community-Hospital",
+    "title": "Arroyo Grande Community Hospital",
+    "content": "arroyo grande community hospital\n\nsee also dignity health\n\n\nwebsite: dignityhealth.org/central-coast/locations/arroyo-grande\nlocation: 345 s. halcyon rd., arroyo grande map \nphone:\nfront desk: 805-489-4261 \ner: 805-473-7626\n\n\nhours: 24/7 \n\n",
+    "type": "directory",
+    "aliases": [
+      "Arroyo Grande Community Hospital",
+      "**Dignity Health**"
+    ]
+  },
+  {
+    "id": "Arroyo-Grande-Recreation-Services",
+    "title": "Arroyo Grande Recreation Services",
+    "content": "arroyo grande recreation services\n\nwebsite: arroyogrande.org/168/recreation-services\nlocation: 1221 ash st., arroyo grande map \nphone: 805-473-5474 \nemail: agrec@arroyogrande.org\nhours: m-th 9am-5pm, f 9am-1pm  (walk-in registration available)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Arroyo Grande Recreation Services"
+    ]
+  },
+  {
+    "id": "Aspire-Counseling-Service",
+    "title": "Aspire Counseling Service",
+    "content": "aspire counseling service\n\nwebsite: aspirecounselingservice.com/san-luis-obispo\nlocation: 865 aerovista pl. #130, slo map \nphone:\n805-329-5595 (main) \n888-585-7373 (24/7 call or text) \n\n\nemail: info@aspirecounselingservice.com \nhours: m-f 9am-9pm, sa. 9am-1pm \nnotes: hosts recovery dharma\n\n",
+    "type": "directory",
+    "aliases": [
+      "Aspire Counseling Service"
+    ]
+  },
+  {
+    "id": "Auntie-Isabell-Foundation",
+    "title": "Auntie Isabell Foundation",
+    "content": "auntie isabell foundation\n\nwebsite: auntieisabellfoundation.org\nemail: info@auntieisabellfoundation.org \nservice area: paso robles and slo county\n\n",
+    "type": "directory",
+    "aliases": [
+      "Auntie Isabell Foundation"
+    ]
+  },
+  {
+    "id": "Assistance-League-of-SLO-County",
+    "title": "Assistance League of SLO County",
+    "content": "assistance league of slo county\n\nwebsite: assistanceleague.org/san-luis-obispo-county\nlocation: 667a marsh st., slo map \nphone: 805-782-0824 \nemail: info@alslocounty.org \nnotes:\noperates assistance league thrift store \noperates \"operation school bell\" \noperates \"access to career education (ace)\" \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Assistance League of SLO County"
+    ]
+  },
+  {
+    "id": "Assistance-League-Thrift-Store",
+    "title": "Assistance League Thrift Store",
+    "content": "assistance league thrift store\n\nwebsite: assistanceleague.org/san-luis-obispo-county/thrift-shop\nlocation: 667a marsh st., slo map \nphone: 805-782-0824 \nhours: tu-sa 11am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Assistance League Thrift Store"
+    ]
+  },
+  {
+    "id": "Atascadero-Senior-Center",
+    "title": "Atascadero Senior Center",
+    "content": "atascadero senior center\n\n\nwebsite: atascaderoseniorcenter.org\nlocation: 5905 east mall, atascadero map \nphone: 805-466-4674  \nemail:\nseniorcitizensunitedinc@outlook.com \nseniorcenter93422@gmail.com \n\n\nhours: m 11am-1pm, tu-f 11am-3pm (some activities at other times) \nhow to access: most activities free for members ($2 for guests); membership ($20/year minimum) open to people 50+\nnotes:\na lunch site for meals that connect\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Atascadero Senior Center"
+    ]
+  },
+  {
+    "id": "Atascadero-Parks-and-Recreation",
+    "title": "Atascadero Parks & Recreation",
+    "content": "atascadero parks & recreation\n\n\nwebsite: atascadero.org/recreation\nlocation: colony park community center, 5599 traffic way, atascadero map \nphone: 805-470-3360 \nemail: recreation@atascadero.org \nhours: m-f 9am-5pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Atascadero Parks & Recreation"
+    ]
+  },
+  {
+    "id": "Balay-Ko-on-Barka",
+    "title": "Balay Ko on Barka",
+    "content": "balay ko on barka\n\na.k.a. \"my home for hope\"\n\n\nlocation: barka st. in grover beach map\nphone: 805-305-3031\nemail: shelter@5chc.org\nhow to access: apply through 5cities homeless coalition to get on waiting list\n\n",
+    "type": "directory",
+    "aliases": [
+      "Balay Ko on Barka",
+      "“My Home for Hope”*"
+    ]
+  },
+  {
+    "id": "Bargain-Boutique",
+    "title": "Bargain Boutique",
+    "content": "bargain boutique\n\nsee achievement house thrift stores\n\n",
+    "type": "directory",
+    "aliases": [
+      "Bargain Boutique"
+    ]
+  },
+  {
+    "id": "Beach-Area-Storage",
+    "title": "Beach Area Storage",
+    "content": "beach area storage\n\nwebsite: beachareastorage.com\nlocation: 464 leoni dr., grover beach map { source: https://beachareastorage.com/ }\nphone: 805-489-9272 { source: https://beachareastorage.com/ }\nemail: beachareastorage@gmail.com { source: https://beachareastorage.com/ }\nhours:\noffice: m-f 9am-5pm (closed noon-1pm), sa 10am-5pm (closed noon-1pm), su noon-5pm (closed 1:30-2pm) { source: https://beachareastorage.com/location-grover-beach/ }\nstorage access: daily 7am-7pm (daylight saving time) or 7am-6pm (standard time) { source: https://beachareastorage.com/location-grover-beach/ }\nclosed major holidays { source: https://beachareastorage.com/location-grover-beach/ }\n-->\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Beach Area Storage"
+    ]
+  },
+  {
+    "id": "BHBH",
+    "title": "Behavioral Health Bridge Housing (BHBH) Program",
+    "content": "behavioral health bridge housing (bhbh) program\n\nsee transitions mental health association (tmha)\n\n\nwebsite: www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/justice-services/behavioral-health-bridge-housing\nphone: 805-540-6500 (mark lamore, director of homeless services at tmha) \nemail: mtorell@co.slo.ca.us and jmprice@co.slo.ca.us \nhow to access: must be referred by another agency; call to ask for details \n\n",
+    "type": "directory",
+    "aliases": [
+      "Behavioral Health Bridge Housing (BHBH) Program"
+    ]
+  },
+  {
+    "id": "Bella-Vista-by-the-Sea",
+    "title": "Bella Vista by the Sea",
+    "content": "bella vista by the sea\n\nwebsite: bellavistabythesea.com\nlocation: 350 n. ocean ave., cayucos map \nphone: 805-995-3644 \nemail: bellavistamhp@tprop.net \nhours: (office hours) m-f 10am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Bella Vista by the Sea"
+    ]
+  },
+  {
+    "id": "Bike-Kitchen",
+    "title": "Bike Kitchen",
+    "content": "bike kitchen\n\nwebsite: bikeslocounty.org/programs/kitchen\nlocation: 860 pacific st. #105, slo map \nphone: 805-547-2055 \nhours: th-su 12-5pm (diy repair), tu-w 12-5pm (shopping only), m closed \n\n",
+    "type": "directory",
+    "aliases": [
+      "Bike Kitchen"
+    ]
+  },
+  {
+    "id": "Blessed-to-Serve",
+    "title": "Blessed to Serve",
+    "content": "blessed to serve\n\n\n\nlocation\nhours\n\n\n\n12150 los osos valley road, slo map (nissan dealership)\nm 5pm\n\n\n1251 calle joaquin, slo map (bmw dealership)\nth 5pm\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Blessed to Serve"
+    ]
+  },
+  {
+    "id": "Boyd-Bristol-Medical-Equipment-Program",
+    "title": "Boyd Bristol Medical Equipment Program",
+    "content": "boyd bristol medical equipment program\n\nwebsite: post66slo.org/serving-veterans\nlocation: 1161 mill st., slo map\nnote: delivery can also be arranged \n\n\nphone: 805-543-6445 \nhow to access: only for veterans and veterans' dependents. by appointment only; call to make an appointment.\n\n",
+    "type": "directory",
+    "aliases": [
+      "Boyd Bristol Medical Equipment Program"
+    ]
+  },
+  {
+    "id": "Brookside-Thrift",
+    "title": "Brookside Thrift",
+    "content": "brookside thrift\n\nlocation: 9330 el camino real, atascadero map \nphone: 805-466-1679 \nemail: nccts9330@gmail.com \nhours: m-sa 9am-6pm\nnotes: formerly known as \"north county christian thrift\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "Brookside Thrift",
+      "“North County Christian Thrift”"
+    ]
+  },
+  {
+    "id": "Cabins-for-Change",
+    "title": "Cabins for Change",
+    "content": "cabins for change\n\nlocation: rockaway ave. at 16th st. in grover beach map\nphone: 805-305-3031 \ntext: 805-634-9906 \nemail: shelter@5chc.org \nhow to access: apply through 5cities homeless coalition to get on waiting list\n\n",
+    "type": "directory",
+    "aliases": [
+      "Cabins for Change"
+    ]
+  },
+  {
+    "id": "California-Cool-Thrift-Store",
+    "title": "California Cool Thrift Store",
+    "content": "california cool thrift store\n\nlocation: 737 w. grand ave., grover beach map \nphone: 805-481-3071 \nhours: daily 10am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "California Cool Thrift Store"
+    ]
+  },
+  {
+    "id": "California-Childrens-Services",
+    "title": "California Children’s Services",
+    "content": "california children's services\n\nwebsite: dhcs.ca.gov/services/ccs\nlocation: 2925 mcmillan ave. #108, slo map \nphone: 805-781-5527 \nemail: publichealth.cms@co.slo.ca.us \nhours: m-f 8am-5pm by appointment only \n\n",
+    "type": "directory",
+    "aliases": [
+      "California Children’s Services"
+    ]
+  },
+  {
+    "id": "California-Civil-Rights-Department",
+    "title": "California Civil Rights Department",
+    "content": "california civil rights department\n\nwebsite: calcivilrights.ca.gov\nhousing discrimination office: calcivilrights.ca.gov/housing\n\n\nlocation: 651 bannon street #200, sacramento, ca 95811 map \nphone:\n800-884-1684 (voice) \n800-700-2320 (tty) \n\n\nemail: contact.center@calcivilrights.ca.gov \nhow to access: via the california civil rights system on-line platform\n\n",
+    "type": "directory",
+    "aliases": [
+      "California Civil Rights Department"
+    ]
+  },
+  {
+    "id": "California-Connect",
+    "title": "California Connect",
+    "content": "california connect\n\nwebsite: caconnect.org\nlocation: 3426 empresa dr. #120, slo map \nphone: 800-806-1191  (tty: 800-806-4474) \nemail:\ninfo@caconnect.org \nddtp@cpuc.ca.gov\n\n\nhours: m-f 8am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "California Connect"
+    ]
+  },
+  {
+    "id": "California-Department-of-Rehabilitation",
+    "title": "California Department of Rehabilitation",
+    "content": "california department of rehabilitation\n\nwebsite: dor.ca.gov\nlocation: 3320 s. higuera #102, slo map \nphone:\nlocal office:\n805-594-6100\n805-549-3361 (for ages 16-21) \n805-544-7367 (tty)\n\n\nstatewide:\n800-952-5544 (voice) \n916-324-1313 (voice) \n916-558-5673 (tty) \nsource: dor.ca.gov\n\n\n\n\nhow to access: no walk-ins. call them to schedule an orientation, or complete a form on their website.\nnotes:\ncan refer you to the \"supported employment\" program\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "California Department of Rehabilitation"
+    ]
+  },
+  {
+    "id": "California-DMV",
+    "title": "California DMV",
+    "content": "california dmv\n\nwebsite: dmv.ca.gov\nlocation: 3190 s. higuera st., slo map \nphone: 800-777-0133 (for appointments)\nhours: m/tu/th/f/sa 8am-5pm, w 9am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "California DMV"
+    ]
+  },
+  {
+    "id": "California-Rural-Legal-Assistance",
+    "title": "California Rural Legal Assistance (CRLA)",
+    "content": "california rural legal assistance (crla)\n\nwebsite: crla.org\nlocation: 1880 santa barbara ave. #240, slo map \nphone: 805-544-7994 \nhours: m-th 9am-12pm & 1pm-5pm, f 1pm-5pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "California Rural Legal Assistance (CRLA)"
+    ]
+  },
+  {
+    "id": "Cal-Poly-Doggy-Days",
+    "title": "Cal Poly “Doggy Days” Veterinary Clinics",
+    "content": "cal poly \"doggy days\" veterinary clinics\n\nsocial media:\nfacebook: facebook.com/calpolydoggydays\ninstagram: @cpdoggydays\n\n\nphone: 805-756-2419 (cal poly animal science department)\nemail: calpolydoggydays@gmail.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Cal Poly “Doggy Days” Veterinary Clinics"
+    ]
+  },
+  {
+    "id": "Cal-Poly-Food-Pantry",
+    "title": "Cal Poly Food Pantry",
+    "content": "cal poly food pantry\n\nwebsite: basicneeds.calpoly.edu/foodpantry\nlocation: cal poly campus, building 27, room 10 map \nphone: 805-756-7818 \nhours:\nm-f 8:30am-6pm (cal poly students) \nf 8:30am-6pm (cal poly employees) \n\n\nhow to access: all cal poly students and employees welcome; no additional eligibility requirements \n\n",
+    "type": "directory",
+    "aliases": [
+      "Cal Poly Food Pantry"
+    ]
+  },
+  {
+    "id": "CalJOBS",
+    "title": "CalJOBS",
+    "content": "caljobs\n\nwebsite: caljobs.ca.gov\nphone: 800-758-0398 \nnote: can access locally via slo cal careers center\n\n",
+    "type": "directory",
+    "aliases": [
+      "CalJOBS"
+    ]
+  },
+  {
+    "id": "CalWORKs",
+    "title": "CalWORKs Homeless Assistance Program",
+    "content": "calworks homeless assistance program\n\nwebsite: slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance\nlocations: see slo county department of social services\nphone: 805-781-1600\nhours: m-f 8am-4pm (4-5pm by appointment only)\nhow to access: contact slo county department of social services\n\n",
+    "type": "directory",
+    "aliases": [
+      "CalWORKs Homeless Assistance Program"
+    ]
+  },
+  {
+    "id": "Cambria-Recycling-Center",
+    "title": "Cambria Recycling Center",
+    "content": "cambria recycling center\n\nlocation: 1275 tamson st., cambria map \nphone: 805-550-5489 \nhours: tu-sa 10am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Cambria Recycling Center"
+    ]
+  },
+  {
+    "id": "Cambria-Vineyard-Church",
+    "title": "Cambria Vineyard Church",
+    "content": "cambria vineyard church\n\nwebsite: cambriavineyardchurch.org\nlocation: 1617 main st., cambria map \nphone: 805-927-5550 \nemail: info@cambriavineyard.org\nhours (food pantry): second & fourth thursdays, noon-2pm \nnotes: operates \"re·create thrift store\" at 1601 main st., cambria (m/th/f/sa 10am-4pm) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Cambria Vineyard Church"
+    ]
+  },
+  {
+    "id": "Cambrias-Anonymous-Neighbors",
+    "title": "Cambria’s Anonymous Neighbors (CAN)",
+    "content": "cambria's anonymous neighbors (can)\n\nwebsite: joslynrec.org/can\nphone: 805-927-5673 \n\n",
+    "type": "directory",
+    "aliases": [
+      "Cambria’s Anonymous Neighbors (CAN)"
+    ]
+  },
+  {
+    "id": "Captive-Hearts",
+    "title": "Captive Hearts",
+    "content": "captive hearts\n\nwebsite: captivehearts.org\nlocation: 882 w. grand ave., grover beach map \nphone: 805-481-4500 (before 3pm) \nemail: info@captivehearts.org \nnotes: operates second chances thrift store\n\n",
+    "type": "directory",
+    "aliases": [
+      "Captive Hearts"
+    ]
+  },
+  {
+    "id": "C.A.R.E.4Paws",
+    "title": "C.A.R.E.4Paws",
+    "content": "c.a.r.e.4paws\n\nwebsite: care4paws.org\nlocation: mobile clinics\npet resource center: 100 s. 4th st., grover beach map \n\n\nphone: 805-968-care \nemail:\ninfo@care4paws.org \noutreach@care4paws.org\n\n\nhours:\nmobile clinics schedule\npet resource center: m-th 9am-5pm, f 11am-5pm \n\n\nnotes:\npartners with \"the street dog coalition\"\noperates the \"pet resource center\" with 5cities homeless coalition \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "C.A.R.E.4Paws"
+    ]
+  },
+  {
+    "id": "Carbon-Health-Urgent-Care-Atascadero",
+    "title": "Carbon Health Urgent Care (Atascadero)",
+    "content": "carbon health urgent care (atascadero)\n\nwebsite: carbonhealth.com/en/locations/atascadero-ca\nlocation: 7330 el camino real, atascadero map \nphone: 831-621-1184 \nhours: every day 8am-6pm \nnotes: accepts medicare but not medi-cal; walk-ins welcome, same-day appointments available\n\n",
+    "type": "directory",
+    "aliases": [
+      "Carbon Health Urgent Care (Atascadero)"
+    ]
+  },
+  {
+    "id": "Carbon-Health-Urgent-Care-Paso-Robles",
+    "title": "Carbon Health Urgent Care (Paso Robles)",
+    "content": "carbon health urgent care (paso robles)\n\nwebsite: carbonhealth.com/en/locations/paso-robles-ca\nlocation: 500 1st st., paso robles map \nphone: 831-621-1449 \nhours: every day 8am-6pm \nnotes: accepts medicare but not medi-cal; walk-ins welcome, same-day appointments available\n\n",
+    "type": "directory",
+    "aliases": [
+      "Carbon Health Urgent Care (Paso Robles)"
+    ]
+  },
+  {
+    "id": "CASA",
+    "title": "CASA (Court Appointed Special Advocates)",
+    "content": "casa (court appointed special advocates)\n\n\nwebsite: slocasa.org\nlocation: 75 higuera st. #180, slo map \nphone: 805-541-6542 \nemail: staff@slocasa.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "CASA (Court Appointed Special Advocates)"
+    ]
+  },
+  {
+    "id": "Casa-Solana",
+    "title": "Casa Solana",
+    "content": "casa solana\n\n\nwebsite: casasolanainc.org\nlocation: 383 s. 13th st., grover beach map\nphone: 805-481-8555 (9am-4pm) \nemail: casasolanainc@gmail.com \nnotes: also known as \"sunshine house\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "Casa Solana",
+      "“Sunshine House”"
+    ]
+  },
+  {
+    "id": "Catholic-Charities",
+    "title": "Catholic Charities (Diocese of Monterey)",
+    "content": "catholic charities (diocese of monterey)\n\n\n\nwebsite: catholiccharitiesdom.org\nimmigration and citizenship program\ntattoo removal program\n\n\nlocations:\nmain office: 3250 s. higuera st. #d, slo map \nfinancial assistance: 3592 broad street #104, slo map \nbehind the mission: 715 palm st., slo map\npaso robles satellite: st. rose of lima church, 642 trigo ln., paso robles map \n\n\nphone:\nmain: 805-541-9110 \npaso robles: 805-541-9120 (to schedule appointments) \nimmigration and citizenship program: 831-722-2675\ntattoo removal: 831-316-9121 (note: tattoo removal office is in santa cruz, not slo) \n\n\nhours:\nslo offices: m-f 8am-5pm (call to confirm hours for specific location)\npaso robles: second wednesday of every month, 1-5pm\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Catholic Charities (Diocese of Monterey)"
+    ]
+  },
+  {
+    "id": "Cayucos-Community-Church",
+    "title": "Cayucos Community Church",
+    "content": "cayucos community church\n\nwebsite: cayucoschurch.org\nlocation: 60 s. 3rd st., cayucos map \nphone: 805-995-3821 \nemail: info@cayucoschurch.com \nhours:\noffice: tu-th 10am-2pm (closed fridays and holidays)\nfood pantry (\"harvest bag\"): first, third, fourth, & fifth wednesdays at 10:30am \nusda food distribution: second wednesday at 10:30am \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Cayucos Community Church"
+    ]
+  },
+  {
+    "id": "CenCal",
+    "title": "CenCal Health",
+    "content": "cencal health\n\nsee also medi-cal\n\n\nwebsite: cencalhealth.org\nlocations: see slo county department of social services \nphone:\nbusiness office: 800-421-2560 or 805-685-9525 \nenrollment: 877-227-3051 \nmember services: 877-814-1861 (m-f, 8am-5pm) \n\n\nhow to access: you can submit an application online via covered california or my benefits calwin or you can get help applying from the slo county department of social services \nnote: for cencal shuttle, see ride-on transportation\n\n",
+    "type": "directory",
+    "aliases": [
+      "CenCal Health",
+      "**Medi-Cal**"
+    ]
+  },
+  {
+    "id": "CARD",
+    "title": "Center for Autism & Related Disorders",
+    "content": "center for autism & related disorders\n\nwebsite: centerforautism.com\nlocation: 1212 marsh st. #1, slo map \nphone: 805-703-2120 \nemail: info@centerforautism.com \nhours: m-f 8am-7pm (weekend hours vary) \nhow to access:\nenroll at this web page\nor call 877-448-4747 x2 \nor email cardenrollment@centerforautism.com \n\n\nnotes: accepts cencal health and most other insurance providers \n\n",
+    "type": "directory",
+    "aliases": [
+      "Center for Autism & Related Disorders"
+    ]
+  },
+  {
+    "id": "CFS",
+    "title": "Center for Family Strengthening (CFS)",
+    "content": "center for family strengthening (cfs)\n\nwebsite: cfsslo.org\nlocation: 1428 phillips lane #203, slo map \nphone: 805-439-1994 \nemail: info@cfsslo.org \nhours: by appointment (call or email to schedule) \nnotes:\nmake referrals via adult protective services\noperates medically fragile homeless program\noperates parent connection of slo county\noperates the link family resource center (atascadero and paso robles locations)\npartner in slo county undocusupport\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Center for Family Strengthening (CFS)"
+    ]
+  },
+  {
+    "id": "The-Center",
+    "title": "The Center for Health & Prevention",
+    "content": "the center for health & prevention\n\nwebsite: capslo.org/the-center\n\n\n\n\n\nlocation\nphone\nhours\n\n\n\n1152 e. grand ave. (arroyo grande) map\n805-489-4026 (arroyo grande)\nm-f 8:30am-5:30m \n\n\n705 grand ave. (slo) map\n805-544-2498 x211 (slo)\nm-f 8:30am-5:30pm \n\n\n\nphone:\n805-422-2498 x121 (info line) \n805-544-2409 x111 (mobile reproductive health clinic info) \n\n\nhow to access: walk-ins ok, but appointments recommended. \nnote:\noperated by community action partnership san luis obispo (capslo)\nteen clinic tuesday 3-6pm, friday 3-5:30pm in arroyo grande\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "The Center for Health & Prevention"
+    ]
+  },
+  {
+    "id": "CCADRC",
+    "title": "Central Coast Aging & Disability Resource Center (CCADRC)",
+    "content": "central coast aging & disability resource center (ccadrc)\n\nwebsite: centralcoastseniors.org/aging-and-disability-resource-center\nlocation: 528 s. broadway, santa maria map\nphone: 805-928-2552 / 800-510-2020 \nemail: info@centralcoastseniors.org \nhours: m-f 8am-5pm (closed noon-1pm)\nhow to access: walk-ins ok.\nnotes:\npartner in access central coast\noperated by central coast commission for senior citizens\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Aging & Disability Resource Center (CCADRC)"
+    ]
+  },
+  {
+    "id": "CCATC",
+    "title": "Central Coast Assistive Technology Center",
+    "content": "central coast assistive technology center\n\nwebsite: ccatc.org\nlocation: 11491 los osos valley rd. #202, slo map \nphone: 805-549-7420  (tty: 805-549-7424)\nhow to access: call to make an appointment\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Assistive Technology Center"
+    ]
+  },
+  {
+    "id": "Central-Coast-Autism-Spectrum-Center",
+    "title": "Central Coast Autism Spectrum Center",
+    "content": "central coast autism spectrum center\n\nwebsite: sloautism.org\nmailing address: p.o. box 3417, slo, ca 93403 \nphone: 805-763-1100 \nemail: contact@sloautism.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Autism Spectrum Center"
+    ]
+  },
+  {
+    "id": "Central-Coast-Coalition-for-Undocumented-Student-Success",
+    "title": "Central Coast Coalition for Undocumented Student Success",
+    "content": "central coast coalition for undocumented student success\n\nwebsite: ccc-uss.org\nmailing address: p.o. box 15759, slo, ca 93406 \nemail:\nccc.undocu@gmail.com \n\n\n\n\n\nnotes:\ncal poly dream center contact: vania agama ramirez\ncuesta monarch dream center: 805-546-3109\nallan hancock: 805-922-6966 x3177\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Coalition for Undocumented Student Success"
+    ]
+  },
+  {
+    "id": "Central-Coast-Commission-for-Senior-Citizens",
+    "title": "Central Coast Commission for Senior Citizens",
+    "content": "central coast commission for senior citizens\n\nwebsite: centralcoastseniors.org\nlocation: 528 s. broadway, santa maria map \nphone:\n805-925-9554 \n800-434-0222\n\n\nemail: info@centralcoastseniors.org\nhours: m-f 8am-5pm\nnotes:\nthe local \"area agency on aging\" \noperates senior connection\noperates hicap\noperates central coast aging & disability resource center\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Commission for Senior Citizens"
+    ]
+  },
+  {
+    "id": "CCDS",
+    "title": "Central Coast Dental Society",
+    "content": "central coast dental society\n\nwebsite: centralcoastdentalsociety.org\nlocation: 1356 marsh st., slo map \nphone: 805-544-1113 \nemail: ccds@charter.net \n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Dental Society"
+    ]
+  },
+  {
+    "id": "Central-Coast-Home-Health",
+    "title": "Central Coast Home Health and Hospice",
+    "content": "central coast home health and hospice\n\nwebsite: centralcoasthomehealth.com\nlocation: 253 granada dr. #d, slo map \nphone:\n805-543-2244 (home health) \n805-540-6020 (hospice) \n855-240-2530 (medi-cal verification and financial assistance)\n\n\nemail: info@cchh08.com \nhours: 24/7 (monday-sunday)\nnotes: accepts medicare; call 855-240-2530 to verify medi-cal acceptance and discuss financial assistance options\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Home Health and Hospice"
+    ]
+  },
+  {
+    "id": "CCPAW",
+    "title": "Central Coast Partnership for Animal Welfare",
+    "content": "central coast partnership for animal welfare\n\nlocations: (pet food distribution)\n946 rockaway ave., grover beach (lifepoint church) map\nparking lot at 1710 ocean st., oceano map\n\n\nphone: 805-574-0563\nemergency pet care: 775-841-7463\n\n\nemail: mamagack@hotmail.com\nhours:\ngrover beach: m-f, 2-3:30pm\noceano: w 1-2pm\n\n\nhow to access:\nfor pet food distributions, come to locations during operating hours, or call them for delivery options\nfor emergency pet care, call, then a case manager conducts interview for emergency vet care program qualification and vet referrals\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Partnership for Animal Welfare"
+    ]
+  },
+  {
+    "id": "Central-Coast-Senior-Center",
+    "title": "Central Coast Senior Center (Oceano)",
+    "content": "central coast senior center (oceano)\n\nlocation: 1580 railroad st., oceano map \nphone: 805-481-7886 \nhours: m-f, 9am-3pm \nnotes:\nopen to seniors 50+; for more information call senior connection\nactivities cost $2 for members, $3 for non-members (membership is $30 for individuals, $40 for couples)\na lunch site for meals offered through meals that connect\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Senior Center (Oceano)"
+    ]
+  },
+  {
+    "id": "Central-Coast-Veterans-Helping-Veterans",
+    "title": "Central Coast Veterans Helping Veterans",
+    "content": "central coast veterans helping veterans\n\nwebsite: ccvhv.org\nmailing address: p.o. box 12725, slo, ca 93406 { source: https://www.ccvhv.org/contact.html }\nphone: 805-285-5526 { source: https://www.ccvhv.org/contact.html }\nemail: ccvetshelpingvets@outlook.com { source: https://www.ccvhv.org/contact.html }\n{ note: organization uses p.o. box; no physical office address or public operating hours found (as of october 2025). contact via phone or email for services }\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Central Coast Veterans Helping Veterans"
+    ]
+  },
+  {
+    "id": "Child-Care-Resource-Connection",
+    "title": "Child Care Resource Connection",
+    "content": "child care resource connection\n\nwebsite: capslo.org/child-care-resource-connection\nlocation: 805a fiero ln., slo map \nphone:\n888-727-2272 \n805-541-2272 (slo) \n805-474-2062 (south county)\n805-226-3249 (north county)\n\n\nhours: m-f, 8am-5pm\nhow to access: walk-ins ok\nget a referral from the slo county department of social services\n\n\nnotes:\noperated by community action partnership san luis obispo\nthere is often a waiting list for some services\ntoy lending library by appointment only\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Child Care Resource Connection"
+    ]
+  },
+  {
+    "id": "Child-Development-Resource-Center",
+    "title": "Child Development Resource Center",
+    "content": "child development resource center\n\nwebsite: childrensresource.org\nlocation: 1720 bishop st., slo map \nphone: 805-544-0801 \nemail: info@slocdc.org\nhow to access: complete an application or get a referral from child welfare services or from a legal, medical, social services, or emergency shelter provider. tuition is on a sliding scale based on income. financial aid is available.\n\n",
+    "type": "directory",
+    "aliases": [
+      "Child Development Resource Center"
+    ]
+  },
+  {
+    "id": "Child-Support-Services",
+    "title": "Child Support Services",
+    "content": "child support services\n\nwebsite: slocounty.ca.gov/departments/child-support\nlocation: 1200 monterey st., slo map \nphone: 866-901-3212 \nemail: css@co.slo.ca.us \nhours: m-f 8am-4:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Child Support Services"
+    ]
+  },
+  {
+    "id": "Childrens-Resource-Network-of-the-Central-Coast",
+    "title": "Children’s Resource Network of the Central Coast",
+    "content": "children's resource network of the central coast\n\nwebsite: childrensresourcenetwork.org \nlocation: 1212 farroll ave., arroyo grande map \nmailing address: p.o. box 454, pismo beach, ca 93448-0454\nphone: 805-709-8673 \nemail: lisa@childrensresourcenetwork.org \nnotes: operates \"outreach apparel\" and \"the teen's closet\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "Children’s Resource Network of the Central Coast"
+    ]
+  },
+  {
+    "id": "City-of-SLO-Parks-and-Recreation",
+    "title": "City of SLO Parks and Recreation",
+    "content": "city of slo parks and recreation\n\nwebsite: slocity.org/government/department-directory/parks-and-recreation\nlocation: 1341 nipomo st., slo map \nphone: 805-781-7300 \nemail: recreation@slocity.org \nhours: m-f 8am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "City of SLO Parks and Recreation"
+    ]
+  },
+  {
+    "id": "Coastal-Dunes",
+    "title": "Coastal Dunes RV Park & Campground",
+    "content": "coastal dunes rv park & campground\n\nwebsite: slocountyparks.com/camp/coastal-dunes\nlocation: 1001 pacific blvd. map\nphone:\npark ranger office 805-781-4900  m-th 8am-4:30pm; f-su 8am-6pm\nreservations: 805-781-5930\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Coastal Dunes RV Park & Campground"
+    ]
+  },
+  {
+    "id": "CoastHills-Credit-Union",
+    "title": "CoastHills Credit Union",
+    "content": "coasthills credit union\n\nwebsite: coasthills.coop\n\n\n\n\n\nlocation\nhours\n\n\n\n1360 e. grand ave., arroyo grande map\nm-th 9am-5pm, f 9am-6pm, sa. 10am-1pm\n\n\n8900 pueblo ave., atascadero map\nm-th 9am-5pm, f 9am-6pm\n\n\n671 w. tefft st. #6, nipomo map\nm-th 9am-5pm, f 9am-6pm\n\n\n1402 spring st., paso robles map\nm-th 9am-5pm, f 9am-6pm, sa. 10am-1pm\n\n\n751 marsh st., slo map\nm-th 9am-5pm, f 9am-6pm\n\n\n\nphone: 805-733-7600 / 800-262-4488 \n\n",
+    "type": "directory",
+    "aliases": [
+      "CoastHills Credit Union"
+    ]
+  },
+  {
+    "id": "CAPSLO",
+    "title": "Community Action Partnership San Luis Obispo (CAPSLO)",
+    "content": "community action partnership san luis obispo (capslo)\n\nwebsite: capslo.org\nlocation:\nmain office: 1030 southwood dr., slo map \nhomeless services: 40 prado rd., slo map \nenergy office: 3970 short st. #110, slo map (no walk-ins) \n\n\nphone:\nhotline: 805-706-8663 \nadministration: 805-544-4355 \nhomeless services center: 805-544-4004\nlow income home energy assistance program: 805-541-4122 x2125 or 800-495-0501 x2114\nenergy office: 805-541-4122 \n\n\nemail: hotline@capslo.org \nlow income home energy assistance program: heap@capslo.org \n\n\nhours: m-f 9am-5pm\nenergy office: m-f 8am-noon & 1pm-4pm (no walk-ins)\n\n\nnotes:\noperates 40 prado homeless services center\noperates the center for health & prevention\noperates \"child care resource connection (ccrc)\"\noperates coordinated entry system (ces)\noperates \"head start\"\noperates \"home and energy services\"\noperates liberty tattoo removal program\noperates \"low income home energy assistance program (liheap)\"\noperates outreach & engagement services\noperates rotating overnight safe parking program\noperates \"senior health screening\"\noperates supportive services for veteran families\noperates \"teen wellness\"\npartner in slo hub\npartner in slo county undocusupport\nentry-point for the coordinated entry system (ces)\nentry-point for the enhanced care management\non board of \"emergency food and shelter program\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Community Action Partnership San Luis Obispo (CAPSLO)"
+    ]
+  },
+  {
+    "id": "Community-Counseling-Center",
+    "title": "Community Counseling Center",
+    "content": "community counseling center\n\nsee also cal poly community counseling service\n\n\nwebsite: cccslo.org/what-we-do.php\nlocation: 676 pismo st., slo map \nphone: 805-543-7969 \nhours: m-f 9am-6pm \nhow to access: call to make an appointment or use their contact form \n\n",
+    "type": "directory",
+    "aliases": [
+      "Community Counseling Center",
+      "**Cal Poly Community Counseling Service**"
+    ]
+  },
+  {
+    "id": "CHC",
+    "title": "Community Health Centers of the Central Coast",
+    "content": "community health centers of the central coast\n\nwebsite: communityhealthcenters.org\n\n\n\n\n\nlocation\nphone\nnotes\n\n\n\n260 station way, arroyo grande map\n805-573-6201\n\n\n\n1057 grand ave., arroyo grande map\n805-270-1700\n\n\n\n1205 e. grand ave. #h, arroyo grande map\n805-994-2300\n(\"urgent care\"; walk-ins ok; m-f 8am-8pm, sa/su 9am-5pm)\n\n\n7512 morro rd., atascadero map\n805-792-1400\n\n\n\n1276 tamsen dr., cambria map\n805-927-5292\n\n\n\n150 tejas place, nipomo map\n805-929-3211\n\n\n\n2120 cienaga st., oceano map\n805-994-2100\n\n\n\n2800 riverside ave. #101, paso robles map\n805-238-7250\n(\"immediate care\"; walk-ins ok; m-sa 8am-noon & 1pm-5pm)\n\n\n1385 mission st., san miguel map\n805-467-2344\n\n\n\n1551 bishop st. #240, slo map\n805-549-0402\n(specializes in women's health)\n\n\n77 casa st., slo map\n805-269-1500\n\n\n\n40 prado, slo map\n805-269-1500\n(healthcare for the homeless program)\n\n\n1330 las tablas rd., templeton map\n805-542-6700\n(\"immediate care\"; walk-ins ok; m-th 8am-6pm)\n\n\n292 posada ln., templeton map\n805-542-6701\n\n\n\n\nphone: 866-614-4636 \ntext: 805-361-8400 \n\n\nhow to access: \"immediate care\" or \"urgent care\" centers accept walk-ins. otherwise, make an appointment.\naccepts private pay, full- and partially-insured, medi-cal, and medicare. also offers a sliding fee scale based on income and family size to people without any health insurance. \n\n\nnotes:\nalso operates healthcare for the homeless program at the 40 prado homeless services center\n\"chc transportation services\" is a door-to-door ride service to appointments (877-743-3242)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Community Health Centers of the Central Coast"
+    ]
+  },
+  {
+    "id": "Community-Partners-in-Caring",
+    "title": "Community Partners in Caring",
+    "content": "community partners in caring\n\nwebsite: partnersincaring.org\nlocation: 120 e. jones st. #130, santa maria map \nphone: 805-925-8000 \nemail: info@partnersincaring.org \nhours: m-f 8:30am-5pm \nhow to access: complete the client onboarding forms (which can be done via their website) to access the services. \nnotes: operates in nipomo and the five cities area, in addition to santa barbara county\n\n",
+    "type": "directory",
+    "aliases": [
+      "Community Partners in Caring"
+    ]
+  },
+  {
+    "id": "CES",
+    "title": "Coordinated Entry System (CES)",
+    "content": "coordinated entry system (ces)\n\nhow to access:\nsouth county: contact 5cities homeless coalition\ncounty-wide: contact slo county department of social services\nor initiate contact via other participating agencies like community action partnership san luis obispo (capslo), transitions mental health association (tmha), good samaritan shelter, slo county department of social services, slo county health department\n\n\nnotes:\npoint of entry for housing now, (at least some of) peoples' self-help housing, welcome home village\noverseen by \"homeless services oversight council (hsoc)\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Coordinated Entry System (CES)"
+    ]
+  },
+  {
+    "id": "Cottage-Urgent-Care",
+    "title": "Cottage Urgent Care",
+    "content": "cottage urgent care\n\nwebsite: cottagehealth.org/urgent-care\n\n\n\n\n\nlocation\nphone\nhours\n\n\n\nmarigold center: 3970 broad street suite 2, slo map\n805-762-4996\nevery day: 8am-8pm\n\n\nfoothill plaza: 777 e. foothill blvd., slo map\n805-762-4348\nevery day 8am-8pm\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Cottage Urgent Care"
+    ]
+  },
+  {
+    "id": "Creative-Mediation",
+    "title": "Creative Mediation",
+    "content": "creative mediation\n\nwebsite: slobar.org/legal-resources/listing/creative-mediation\nlocation: 285 south st. #p, slo map\nphone: 805-549-0442\nhours: m/w/th/f 9am-5pm, tu 8am-5pm\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Creative Mediation"
+    ]
+  },
+  {
+    "id": "CSF-Medical-Non-Profit-Foundation",
+    "title": "CSF Medical Non Profit Foundation",
+    "content": "csf medical non profit foundation\n\nwebsite: csffoundation.org\nphone: 661-404-4748 \nemail: info@csffoundation.org \nhours: m-f 9am-5:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "CSF Medical Non Profit Foundation"
+    ]
+  },
+  {
+    "id": "Cuesta-College",
+    "title": "Cuesta College",
+    "content": "cuesta college\n\nwebsite: cuesta.edu\nlocations:\nslo campus: 3000 education dr., slo (at highway 1) map \nnorth county campus: 2800 buena vista dr., paso robles map \nsouth county center: a.g. high school office, room 900, corner of orchard st. & w. cherry ave, arroyo grande map \n\n\nphone:\n805-546-3100 (slo campus) \n805-591-6200 (north county campus) \n805-474-3913 (south county center) \n805-591-6273 (continuing education office)\nenglish as a second language (esl) program:\n805-592-9463 (slo campus) \n805-591-6273 (north county campus) \n805-592-9463 (south county center) \ncall m-th 10am-7pm\n\n\ncontinuing education program:\n805-592-9463 (slo campus) \n805-591-6273 (north county campus) \n\n\n\n\nemail:\nbasicneeds@cuest.edu (basic needs center) \nadmit@cuesta.edu (admission)\nscchelp@cuesta.edu (south county campus)\ncontinuinged@cuesta.edu (continuing education) \n\n\nnotes:\nbasic needs office is in room 5014b of the slo campus, open m/th/f 9am-4pm, tu 9am-6pm \nthe paso robles campus hosts a cougar food pantry for students in room n1005, m-f 9am-5pm; 805-591-4301 \nthe slo campus hosts a cougar food pantry for students in room 5014a's cafeteria, m-f 9am-4:30pm \ncommunity education programs are open to otherwise unenrolled people\ncontinuing education has vocational / lifetime-learning programs, and esl\npartners with the bridge cafe for its culinary arts program\npartners with lucia mar adult education for esl classes\nthe slo & north county campuses are slo food bank food box distribution sites \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Cuesta College"
+    ]
+  },
+  {
+    "id": "Dignity-Health",
+    "title": "Dignity Health",
+    "content": "dignity health\n\nwebsite: dignityhealth.org\noperates arroyo grande community hospital, french hospital medical center, and dignity health urgent care\noperates the \"substance use navigator\" program\n\n",
+    "type": "directory",
+    "aliases": [
+      "Dignity Health"
+    ]
+  },
+  {
+    "id": "Dignity-Health-Urgent-Care",
+    "title": "Dignity Health Urgent Care",
+    "content": "dignity health urgent care\n\nsee also dignity health\n\n\n\n\n\nlocation\nphone\n\n\n\natascadero: 5920 w mall, atascadero map\n805-461-2131\n\n\npismo beach: 877 oak park blvd, pismo beach map\n805-474-8450\n\n\n\nhours: m-f 8am-6pm, sa 8am-4pm, su closed \nnotes: accepts medicare and medi-cal as well as several private insurers; walk-ins welcome, no appointment necessary; lab and x-ray services on site \n\n",
+    "type": "directory",
+    "aliases": [
+      "Dignity Health Urgent Care",
+      "**Dignity Health**"
+    ]
+  },
+  {
+    "id": "Disability-Rights-California",
+    "title": "Disability Rights California",
+    "content": "disability rights california\n\nwebsite: www.disabilityrightsca.org/get-help\nphone: 800-776-5746 (tty: 800-719-5798) \nhours: m/tu/th/f 9am-3pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Disability Rights California"
+    ]
+  },
+  {
+    "id": "Discipleship-Home",
+    "title": "Discipleship Home",
+    "content": "discipleship home\n\nwebsite: thediscipleshiphome.com\nlocation: 1359 21st court, oceano map \nphone: 805-668-9185 \nemail: thediscipleshiphome15@gmail.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Discipleship Home"
+    ]
+  },
+  {
+    "id": "Dove-Creek-Church",
+    "title": "Dove Creek Church of the Nazarene",
+    "content": "dove creek church of the nazarene\n\nwebsite: dovecreekchurch.org\nlocation: 9333 santa barbara rd., atascadero map { source: https://dovecreekchurch.org/who-we-are/find-us }\nphone: 805-466-9505 { source: https://dovecreekchurch.org/who-we-are/find-us }\nemail: office@dovecreekchurch.org { source: https://dovecreekchurch.org/who-we-are/find-us }\nnotes:\noperates a food pantry; also known as atascadero dove creek church of the nazarene\nas of october 2025, the website says \"we are currently on hiatus and in a period of rebuilding\"\nsee also restoration church which may be a ministry at this same address\n-->\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Dove Creek Church of the Nazarene",
+      "Atascadero Dove Creek Church of the Nazarene"
+    ]
+  },
+  {
+    "id": "Eckerd-Connects-Workforce-Development",
+    "title": "Eckerd Connects Workforce Development",
+    "content": "eckerd connects workforce development\n\nwebsite: eckerd.org/jobs-training/slo\nlocations:\n3450 broad street #103a, slo map \n534 spring street, paso robles map \n\n\nphone:\n805-439-2557 \n941-585-9659 \n\n\nemail: slocal@eckerd.org\nhours: m-f 9am-4pm (slo)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Eckerd Connects Workforce Development"
+    ]
+  },
+  {
+    "id": "ECHO",
+    "title": "El Camino Homeless Organization (ECHO)",
+    "content": "el camino homeless organization (echo)\n\nwebsite: www.echoshelter.org\nlocations:\n6370 atascadero ave., atascadero map \n1134 black oak dr., paso robles map \n\n\nphone: 805-462-food \nemail: wlewis@echoshelter.org \nhow to access:\nfor transitional housing, contact echo to get on a waiting list; for dinner/showers/laundry, just attend on time\nemergency shelter bed signup at the paso robles location only, 4:30-5:30pm \n\n\nnotes:\ndinner (also available to non-residents) at 5pm at both locations \nshowers (available to non-residents) m-f from 4-5:30pm at both locations \nlaundry (available to non-residents) w from 10am-6pm at the paso robles location. \nthe paso robles location operates as an emergency warming center during adverse weather \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "El Camino Homeless Organization (ECHO)"
+    ]
+  },
+  {
+    "id": "El-Chorro-Regional-Park-Campground",
+    "title": "El Chorro Regional Park Campground",
+    "content": "el chorro regional park campground\n\nwebsite: slocountyparks.com/camp/el-chorro\nlocation: state hwy 1 @ dairy creek (4 miles nw of slo) map\nphone: 805-781-5930 x4 (monday-friday 8:30am-4:30pm)\nemail: sloparks@co.slo.ca.us\n\n",
+    "type": "directory",
+    "aliases": [
+      "El Chorro Regional Park Campground"
+    ]
+  },
+  {
+    "id": "Elks-Lodge-2504",
+    "title": "Elks Lodge #2504",
+    "content": "elks lodge #2504\n\nwebsite: oceanoelks2504.org\nlocation: 410 air park drive, oceano map \nphone: 805-489-2504\nemail: elks2504@gmail.com\nhours: m-th 9am-4pm\nhow to access: walk-ins ok, but it's better to call ahead\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Elks Lodge #2504"
+    ]
+  },
+  {
+    "id": "Employment-Development-Department",
+    "title": "Employment Development Department",
+    "content": "employment development department\n\nwebsite: edd.ca.gov\nlocation: 3450 broad st. #103a, slo map \nphone:\n800-300-5616\nlocal office: 805-878-2842\ncustomer service: 805-439-2557 \n\n\nhours: m-f 8am-5pm\nnotes:\noperates \"migrant seasonal farmworker\" program\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Employment Development Department"
+    ]
+  },
+  {
+    "id": "Enhanced-Care-Management",
+    "title": "Enhanced Care Management",
+    "content": "enhanced care management\n\nwebsite: slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/enhanced-care-management\nphone: 805-781-4687 \nemail: ph.ecm@co.slo.ca.us \nnotes:\ncommunity action partnership san luis obispo (capslo) is the entry-point for this program (including its outreach and engagement services center)\noffered to youth through seneca central coast\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Enhanced Care Management"
+    ]
+  },
+  {
+    "id": "EyeCare-America",
+    "title": "EyeCare America",
+    "content": "eyecare america\n\nwebsite: aao.org/eyecare-america\nphone: 877-887-6327 (m-f 8am-2pm) \nemail: eyecareamerica@aao.org \nhow to access: to begin, complete a questionnaire on their website\n\n",
+    "type": "directory",
+    "aliases": [
+      "EyeCare America"
+    ]
+  },
+  {
+    "id": "Family-and-Industrial-Medical-Center",
+    "title": "Family and Industrial Medical Center",
+    "content": "family and industrial medical center\n\nwebsite: fimcslo.com\nlocation: 47 santa rosa st., slo map \nphone: 805-542-9596 \nhours: m-f 8am-7pm, sa.-su. 9am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Family and Industrial Medical Center"
+    ]
+  },
+  {
+    "id": "Family-Care-Network",
+    "title": "Family Care Network",
+    "content": "family care network\n\nwebsite: fcni.org\nlocation: 1255 kendall rd., slo map \nphone: 805-781-3535 \nemail: contact@fcni.org \nnotes: operates housing support program (hsp) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Family Care Network"
+    ]
+  },
+  {
+    "id": "Five-Cities-Christian-Women-Food-Pantry",
+    "title": "Five Cities Christian Women Food Pantry",
+    "content": "five cities christian women food pantry\n\nwebsite: fivecitieschristianwomenfoodpantry.org\nlocation: 946 rockaway ave., grover beach map \nphone: 805-473-3368 \nhours: m-f 2-3:30pm except federal holidays \nhosted by lifepoint church\n\n",
+    "type": "directory",
+    "aliases": [
+      "Five Cities Christian Women Food Pantry"
+    ]
+  },
+  {
+    "id": "5Cities-Meals-on-Wheels",
+    "title": "Five Cities Meals on Wheels",
+    "content": "five cities meals on wheels\n\nwebsite: 5citiesmow.com\nlocation: 780 bello street, pismo beach map \nphone: 805-773-2053 \nemail: info@5citiesmow.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Five Cities Meals on Wheels"
+    ]
+  },
+  {
+    "id": "Flying-Flags-Avila-Beach",
+    "title": "Flying Flags Avila Beach",
+    "content": "flying flags avila beach\n\nwebsite: flyingflagsavilabeach.com\nlocation: 6450 babe lane, avila beach map\nphone: 805-888-0158\nhours: every day 8am-6pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Flying Flags Avila Beach"
+    ]
+  },
+  {
+    "id": "Food-Not-Bombs",
+    "title": "Food Not Bombs",
+    "content": "food not bombs\n\nsocial media:\nfacebook: facebook.com/foodnotbombsslo\ninstagram: @foodnotbombs_slo\n\n\nemail: slofoodnotbombs@gmail.com \nlocation: mitchell park, slo map \nhours: su 1-3pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Food Not Bombs"
+    ]
+  },
+  {
+    "id": "Foxys-Thrift-Shop",
+    "title": "Foxy’s Thrift Shop",
+    "content": "foxy's thrift shop\n\nlocation: 655 morro bay blvd., morro bay map \nphone: 805-772-8800 \nhours: daily 10am-5pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Foxy’s Thrift Shop"
+    ]
+  },
+  {
+    "id": "Fred-and-Bettys",
+    "title": "Fred & Betty’s Thrift Store",
+    "content": "fred & betty's thrift store\n\nwebsite: fredandbettys.org\nlocation: 532 higuera st., slo map \nphone: 805-593-0255 \nhours: m-sa 10am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Fred & Betty’s Thrift Store"
+    ]
+  },
+  {
+    "id": "French-Hospital-Medical-Center",
+    "title": "French Hospital Medical Center",
+    "content": "french hospital medical center\n\nsee also dignity health\n\n\nwebsite: dignityhealth.org/central-coast/locations/frenchhospital\nlocation: 1911 johnson ave., slo map \nphone:\ner: 805-542-6621\nfront desk: 805-543-5353 \n\n\nhours: 24/7\n\n",
+    "type": "directory",
+    "aliases": [
+      "French Hospital Medical Center",
+      "**Dignity Health**"
+    ]
+  },
+  {
+    "id": "Front-Porch",
+    "title": "Front Porch",
+    "content": "front porch\n\nwebsite: https://www.frontporchslo.org/\nlocation: 1468 e. foothill, slo map \nphone: 818-731-4984\nemail: hello@frontporchslo.org \nhours: m-th 7am-11pm, f 7am-4pm, su 7am-6pm (depending on volunteer availability, likely closed during cal poly breaks) \nhow to access: oriented toward students from cuesta college or cal poly, but \"whoever you are, you are welcome here\" and \"no matter what, you're welcome here.\" \n\n",
+    "type": "directory",
+    "aliases": [
+      "Front Porch"
+    ]
+  },
+  {
+    "id": "GALA",
+    "title": "GALA Pride & Diversity Center",
+    "content": "gala pride & diversity center\n\nwebsite: galacc.org\nlocation: 1060 palm st., slo map \nphone: 805-541-4252 \nemail: info@galacc.org\nhours: m-f 8am-5pm\nfood pantry m-f 10am-3pm\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "GALA Pride & Diversity Center"
+    ]
+  },
+  {
+    "id": "Genoa-Pharmacy",
+    "title": "Genoa Pharmacy",
+    "content": "genoa pharmacy\n\nwebsite: slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/genoa-pharmacy\nlocation: 2178 johnson avenue #p1, slo map \nphone: 805-242-4051 \nhours: m-f 8:30am-5pm (closed 12:30-1pm) \nnotes: the on-site pharmacy for slo county behavioral health \n\n",
+    "type": "directory",
+    "aliases": [
+      "Genoa Pharmacy"
+    ]
+  },
+  {
+    "id": "Golden-1-Credit-Union",
+    "title": "Golden 1 Credit Union",
+    "content": "golden 1 credit union\n\nwebsite: golden1.com\nlocations: \n8727 el camino real, atascadero map\n128 niblick rd., paso robles map\n852 e. foothill blvd., slo map\n\n\nphone: 877-golden-1 \nhours: m-f 10am-5pm, sa 10am-2pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Golden 1 Credit Union"
+    ]
+  },
+  {
+    "id": "Good-Samaritan-Shelter",
+    "title": "Good Samaritan Shelter",
+    "content": "good samaritan shelter\n\nwebsite: goodsamaritanshelter.org\nlocations:\nsanta maria emergency shelter: 401 w. morrison ave., santa maria map \nadministrative offices: 400 west park, santa maria map \n\n\nphone: emergency shelter: 805-347-3338 x101 \nemail: layne harlow (lharlow@goodsamaritanshelter.org)\nhours:\nemergency shelter: 24/7 \nshelter intake appointments 8:30am-5pm m-f\nshelter opens at 4:30pm daily\nadministrative offices open 9am-5pm m-f \n\n\nhow to access: (shelter) call m-f 8:30am-4:00pm, or walk in 9am-3pm, to establish an intake appointment \nnotes:\noperates welcome home village\nentry-point for the coordinated entry system (ces)\noperates supportive services for veteran families \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Good Samaritan Shelter"
+    ]
+  },
+  {
+    "id": "Goodwill",
+    "title": "Goodwill Stores",
+    "content": "goodwill stores\n\nwebsite: ccgoodwill.org\n\n\n\n\n\nlocation\nhours\n\n\n\n8310 el camino real #a, atascadero map\ndaily 9am-7pm\n\n\n1628 w. grand ave., grover beach map\ndaily 9am-7pm\n\n\n1020 park st., paso robles map\nsu-th 9am-7pm, fr-sa 9am-8pm\n\n\n15 s. higuera st., slo map\ndaily 9am-6pm\n\n\n880 industrial way, slo map (outlet)\ndaily 7am-4pm\n\n\n\nphone: 800-894-8440\nopportunity platform: 805-544-0542 x8520, jjauregui@ccgoodwill.org \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Goodwill Stores"
+    ]
+  },
+  {
+    "id": "Grace-Central-Coast",
+    "title": "Grace Central Coast",
+    "content": "grace central coast\n\nwebsite: gracecentralcoast.org\nlocation: 1350 osos street, slo map \nphone: 805-543-2358 \nemail: info@gracecentralcoast.org \nhours (god's storehouse food distribution): sa. 8-10am \n\n",
+    "type": "directory",
+    "aliases": [
+      "Grace Central Coast"
+    ]
+  },
+  {
+    "id": "Green-Pastures",
+    "title": "Green Pastures",
+    "content": "green pastures\n\nwebsite: fpcslo.org/greenpastures\nlocation: 981 marsh st., slo (first presbyterian church) map \nphone: 805-543-5451 \nemail: churchoffice@fpcslo.org \nhours: first and third wednesdays at 1pm \nhow to access: lottery system-first 8 names drawn receive assistance; must be present to enter \n\n",
+    "type": "directory",
+    "aliases": [
+      "Green Pastures"
+    ]
+  },
+  {
+    "id": "Grover-Beach-Community-Services",
+    "title": "Grover Beach Community Services",
+    "content": "grover beach community services\n\nwebsite: groverbeach.org/141/community-services\nlocation: 1230 trouville ave., grover beach map \nphone: 805-473-4580 \nemail: cs@groverbeach.org \nhours: m-f 8am-5pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Grover Beach Community Services"
+    ]
+  },
+  {
+    "id": "Gryphon-Society",
+    "title": "Gryphon Society",
+    "content": "gryphon society\n\nwebsite: gryphonsociety.weebly.com\nlocations: various; gender-segregated\nphone:\n805-550-8140 (men)\n805-748-8491 (women)\n805-748-6204\n\n\nemail: info@gryphonsociety.weebly.com\n\n",
+    "type": "directory",
+    "aliases": [
+      "Gryphon Society"
+    ]
+  },
+  {
+    "id": "Habitat-for-Humanity",
+    "title": "Habitat for Humanity SLO County",
+    "content": "habitat for humanity slo county\n\n\nwebsite: habitatslo.org\nlocation: 844 9th st., paso robles map \nphone: 805-782-0687 \nemail: info@habitatslo.org \n\nrestore (recycled construction and home renovation materials):\n\nwebsite: habitatslo.org/restores\nlocations:\npaso robles: 844 9th st., paso robles map \nphone: 805-434-0486 \nemail: restorepaso@habitatslo.org \nhours: tu-sa 10am-5pm \n\n\nslo: 2790 broad st., slo map \nphone: 805-546-8699 \nemail: restoreslo@habitatslo.org \nhours: tu-sa 10am-5pm \n\n\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Habitat for Humanity SLO County"
+    ]
+  },
+  {
+    "id": "Healing-and-Restoration-Campus",
+    "title": "Healing and Restoration Campus",
+    "content": "healing and restoration campus\n\n\nwebsite: sloharc.org\nlocation: los osos valley road near laguna lake (former devaul ranch / sunny acres property) map\n\n\n\nnotes: a project of restorative partners\n\n",
+    "type": "directory",
+    "aliases": [
+      "Healing and Restoration Campus"
+    ]
+  },
+  {
+    "id": "HCHP",
+    "title": "Healthcare for the Homeless Program",
+    "content": "healthcare for the homeless program\n\nwebsite: communityhealthcenters.org/locations/slo-prado/\nlocation: 40 prado rd., slo map \nphone: 805-473-4712 \nhours: m/tu/th 8am-5pm, w 9am-6pm \nnotes:\noperated by community health centers of the central coast\nhosted by 40 prado homeless services center\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Healthcare for the Homeless Program"
+    ]
+  },
+  {
+    "id": "Help-Hope-Live",
+    "title": "Help Hope Live",
+    "content": "help hope live\n\nwebsite: helphopelive.org\nphone: 800-642-8399 (m-f 9am-6pm eastern time) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Help Hope Live"
+    ]
+  },
+  {
+    "id": "Help-Me-Grow",
+    "title": "Help Me Grow SLO County",
+    "content": "help me grow slo county\n\nwebsite: slohelpmegrow.org\n\n\n\n\n\nlocation\nphone\n\n\n\n1030 southwood dr., slo map\n805-305-4481\n\n\n704 spring st., paso robles map\n805-440-1878\n\n\n\nhours: m-f 8am-4:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Help Me Grow SLO County"
+    ]
+  },
+  {
+    "id": "HiCAP",
+    "title": "HiCAP (Health Insurance Counseling & Advocacy Program)",
+    "content": "hicap (health insurance counseling & advocacy program)\n\nwebsite: centralcoastseniors.org/hicap\nlocation:\n1445 santa rosa st., slo map\n528 s. broadway, santa maria map\n\n\nphone: 805-928-5663 / 800-434-0222\nemail: hicap@centralcoastseniors.org\nhours: m-f 8am-5pm\nhow to access: make an appointment by phone or by visiting the website.\n\n",
+    "type": "directory",
+    "aliases": [
+      "HiCAP (Health Insurance Counseling & Advocacy Program)"
+    ]
+  },
+  {
+    "id": "Homeless-Outreach-Full-Service-Partnership",
+    "title": "Homeless Outreach Full Service Partnership",
+    "content": "homeless outreach full service partnership\n\nwebsite: slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-adult-services/homeless-outreach-full-service-partnership\nphone:\ntmha: 805-540-6500 \nbehavioral health access line: 800-838-1361 \n\n\nemail: info@t-mha.org \nhow to access: contact transitions mental health association at the above phone number or email \n\n",
+    "type": "directory",
+    "aliases": [
+      "Homeless Outreach Full Service Partnership"
+    ]
+  },
+  {
+    "id": "HomeShare-SLO",
+    "title": "HomeShare SLO",
+    "content": "homeshare slo\n\nwebsite: smartsharehousingsolutions.org/homeshare-slo\nphone: 805-215-5474 \nemail: info@smartsharehousingsolutions.org \nnotes: a project of smartshare housing solutions \n\n",
+    "type": "directory",
+    "aliases": [
+      "HomeShare SLO"
+    ]
+  },
+  {
+    "id": "Hopes-Village",
+    "title": "Hope’s Village",
+    "content": "hope's village\n\nwebsite: hopesvillageofslo.com\nmailing address: po box 1991, templeton, ca 93465 \nphone: 805-234-5478 \nemail: beckyrjorgeson@yahoo.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Hope’s Village"
+    ]
+  },
+  {
+    "id": "Hospice-SLO",
+    "title": "Hospice SLO",
+    "content": "hospice slo\n\nwebsite: hospiceslo.org\nlocation: dorothy d. rupe center, 1304 pacific st., slo map \nphone: 805-544-2266 \nemail: hospiceslo@hospiceslo.org \nhours: m-f 10am-4pm \nnotes: all services provided at no charge; does not bill insurance \n\n",
+    "type": "directory",
+    "aliases": [
+      "Hospice SLO"
+    ]
+  },
+  {
+    "id": "HouseKeys",
+    "title": "HouseKeys",
+    "content": "housekeys\n\nwebsite: housekeys19.com\nphone: 877-460-5397 \nemail: customerservice@housekeys.org \nhow to access: create account at myhousekeys to enter drawings and receive notifications about available units\n\n",
+    "type": "directory",
+    "aliases": [
+      "HouseKeys"
+    ]
+  },
+  {
+    "id": "HASLO",
+    "title": "Housing Authority of SLO (HASLO)",
+    "content": "housing authority of slo (haslo)\n\nwebsite: haslo.org\nlocation: 487 leff st., slo map \nphone: 805-543-4478 \nemail: info@haslo.org \nhours: m-th 8am-5pm (also open every other friday) \nhow to access: submit a paper application to get on the waiting list for affordable apartments\nnotes:\noperates \"halcyon collective\" (arroyo grande)\noperates \"macadero gardens\" (atascadero)\noperates \"cleaver & clark commons\" (grover beach)\noperates \"rockview at sunset\" (morro bay)\noperates \"willow walk senior apartments\" (nipomo)\noperates \"oak park 1 & 2\" (paso robles)\noperates \"paso homekey\" (paso robles)\noperates \"sunset terrace\" (shell beach)\noperates \"860 on the wye\" (slo)\noperates \"the anderson apartments\" (slo)\noperates \"apartments at toscano\" (slo)\noperates \"balay-ko on monterey\" (slo)\noperates \"bishop street studios\" (slo)\noperates \"courtyard at the meadows\" (slo)\noperates \"iron works apartments\" (slo)\noperates \"madonna road apartments\" (slo)\noperates \"marvin gardens\" (slo)\noperates \"moylan terrace homeownership\" (slo)\noperates \"slo villages\" (slo)\noperates \"south hills crossing\" (slo)\noperates \"parkwood apartments\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Housing Authority of SLO (HASLO)"
+    ]
+  },
+  {
+    "id": "Housing-Now",
+    "title": "Housing Now",
+    "content": "housing now\n\nhow to access: via the coordinated entry system (ces)\nnotes:\nformerly known as \"50 now\" and \"70 now\"\noperated by transitions mental health association (tmha)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Housing Now",
+      "“50 Now” and “70 Now”"
+    ]
+  },
+  {
+    "id": "Housing-Support-Program",
+    "title": "Housing Support Program",
+    "content": "housing support program\n\nwebsite: fcni.org/how-we-help/ensuring-stability\nlocation: 1255 kendall rd., slo map \nphone: 805-781-3535  \nemail: contact@fcni.org \nhours: m-f 8:30am-5pm\nhow to access: get a referral from a slo county department of social services employment resource specialist\nnotes:\nrun by family care network\ncan make referrals to medically fragile homeless program\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Housing Support Program"
+    ]
+  },
+  {
+    "id": "Immigrant-Hope-Arroyo-Grande",
+    "title": "Immigrant Hope Arroyo Grande",
+    "content": "immigrant hope arroyo grande\n\nwebsite: immigranthopeag.org\nlocation: 995 e. grand ave., arroyo grande map \nphone: 805-221-4319 \nhow to access: call, visit the office, or use their web contact form\n\n",
+    "type": "directory",
+    "aliases": [
+      "Immigrant Hope Arroyo Grande"
+    ]
+  },
+  {
+    "id": "Immigrant-Legal-Defense",
+    "title": "Immigrant Legal Defense (ILD)",
+    "content": "immigrant legal defense (ild)\n\nwebsite: ild.org\nlocation: cal poly dream center, science building (building 52), room e-11, cal poly slo campus map\nphone: 805-756-6362\nemail: info@ild.org \nhow to access: schedule appointments via calendly at calendly.com/csulegalservices/ild or through dream center website at dreamcenter.calpoly.edu/legalservices\n\n",
+    "type": "directory",
+    "aliases": [
+      "Immigrant Legal Defense (ILD)"
+    ]
+  },
+  {
+    "id": "In-Home-Supportive-Services",
+    "title": "In-Home Supportive Services (IHSS)",
+    "content": "in-home supportive services (ihss)\n\nwebsite: slocounty.ca.gov/departments/social-services/adult-services/services/in-home-supportive-services-(ihss)-program\nlocation:\n9630 el camino real, atascadero map \n1086 e. grand ave., arroyo grande map \n\n\nphone:\natascadero: 805-461-6110 \narroyo grande: 805-474-2103 \n\n\nhours: m-f 8am-5pm \nhow to access: by phone, or by completing an online application form, or by visiting any slo county department of social services office (no appointment necessary) \n\n",
+    "type": "directory",
+    "aliases": [
+      "In-Home Supportive Services (IHSS)"
+    ]
+  },
+  {
+    "id": "Jewish-Family-Services",
+    "title": "Jewish Family Services",
+    "content": "jewish family services\n\nwebsite: jccslo.com/jewish-family-services.html\nlocation: 578 marsh st., slo map\nphone: 805-426-5465\nhow to access: use the online form; they cannot process assistance requests by phone or email\n\n",
+    "type": "directory",
+    "aliases": [
+      "Jewish Family Services"
+    ]
+  },
+  {
+    "id": "Judson-Terrace",
+    "title": "Judson Terrace",
+    "content": "judson terrace\n\n\n\n\nname\nlocation\nphone\nages\n\n\n\njudson terrace homes\n3000 augusta st., slo map\n805-544-1600\n55+\n\n\njudson terrace lodge\n3042 augusta st., slo map\n805-541-4567\n62+\n\n\n\nnotes:\nlow-income seniors; hud residents typically pay 30% of gross income for rent\napplications available only when waiting list is open; contact directly for current status\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Judson Terrace"
+    ]
+  },
+  {
+    "id": "Kings-Cupboard",
+    "title": "King’s Cupboard at El Morro Church",
+    "content": "king's cupboard at el morro church\n\nwebsite: sites.vivery.org/kings-cupboard-at-el-morro-church-pantry/los-osos-ca/2156\nlocation: el morro church of the nazarene, 1480 santa ysabel, bldg. a, los osos map \nphone: 805-528-0391 \nhours: tuesdays, 8-10am \n\n",
+    "type": "directory",
+    "aliases": [
+      "King’s Cupboard at El Morro Church"
+    ]
+  },
+  {
+    "id": "Kritter-Care",
+    "title": "Kritter Care",
+    "content": "kritter care\n\nwebsite: krittercare.org\nlocation: morro bay \nphone: 805-889-9808 \n\n",
+    "type": "directory",
+    "aliases": [
+      "Kritter Care"
+    ]
+  },
+  {
+    "id": "Laundry-Love",
+    "title": "Laundry Love",
+    "content": "laundry love\n\nwebsite: laundrylove.org\nlocation: 2179 10th st., los osos map \nphone: 805-441-7262 \nemail: naseema6@sbcglobal.net \nhours: last weds. of the month, 11am-1pm (seniors only) & 4-6pm (anyone) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Laundry Love"
+    ]
+  },
+  {
+    "id": "Le-Sage-Riviera-RV-Park",
+    "title": "Le Sage Riviera RV Park",
+    "content": "le sage riviera rv park\n\nwebsite: lesageriviera.com\nlocation: 319 n highway 1, grover beach map \nphone: 805-489-5506 \nemail: info@lesageriviera.com \nhours: m-sa 9am-4:30pm, su 9am-3pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Le Sage Riviera RV Park"
+    ]
+  },
+  {
+    "id": "Legacy-Church-Pantry",
+    "title": "Legacy Church Pantry",
+    "content": "legacy church pantry\n\nwebsite: ourlegacy.church\nlocation:\nfood pantry: 6030 del rio rd., atascadero map\nchurch: 5545 ardilla ave., atascadero map \n\n\nphone: 805-466-2626 \nemail: info@ourlegacy.church \nhours (food pantry): th 1-2pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Legacy Church Pantry"
+    ]
+  },
+  {
+    "id": "Liberty-Tattoo-Removal-Program",
+    "title": "Liberty Tattoo Removal Program",
+    "content": "liberty tattoo removal program\n\nphone: 805-540-8353 \nemail:\nlibertytattooremoval@capslo.org \nfloydbland@capslo.org \n\n\nnotes:\noperated by community action partnership san luis obispo\nhosted by adventist health sierra vista\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Liberty Tattoo Removal Program"
+    ]
+  },
+  {
+    "id": "Lifepoint-Church",
+    "title": "Lifepoint Church",
+    "content": "lifepoint church\n\n\nwebsite: lifepointcentralcoast.com \nlocations:\nmain: 207 pilgrim way, arroyo grande map\noutreach location: 946 rockaway ave., grover beach map\n\n\nphone: 805-489-3328\nemail: church@lifepointcentralcoast.com\nnotes:\nhosts central coast partnership for animal welfare\nhosts five cities christian women food pantry\nhosts people's kitchen (grover beach)\nhosts shower the people\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Lifepoint Church"
+    ]
+  },
+  {
+    "id": "Lifesigns",
+    "title": "Lifesigns",
+    "content": "lifesigns\n\nwebsite: lifesignsinc.org\nphone: 888-930-7776 x1 \nfor after-hours emergency interpreting: 800-633-8883 \n\n\nemail: lifesigns@lifesignsinc.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Lifesigns"
+    ]
+  },
+  {
+    "id": "Life-Steps-Foundation",
+    "title": "Life Steps Foundation",
+    "content": "life steps foundation\n\nwebsite: lifestepsfoundation.org\nlocation: 218 w. carmen lane #108, santa maria map \nphone: 805-549-0150 \nemail: ccasoffice@lifestepsfoundation.org \nhours: m-f 9am-5:30pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Life Steps Foundation"
+    ]
+  },
+  {
+    "id": "Link-Family-Resource-Center",
+    "title": "The Link Family Resource Center",
+    "content": "the link family resource center\n\nwebsite: linkslo.org\nlocations:\natascadero: 4507 del rio ave bldg. #1, atascadero map \npaso robles: 1802 chestnut st., paso robles map\n\n\nphone: 805-466-5404 \nfamily advocate services: 805-794-0217 \n\n\nhours: m-f 9am-5pm \nhow to access: accepts self-referrals, school referrals, and community agency referrals\nnotes:\noperated by center for family strengthening (cfs)\nsee also north county family resource center\nsee also safe family resource centers\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "The Link Family Resource Center"
+    ]
+  },
+  {
+    "id": "Literacy-For-Life",
+    "title": "Literacy For Life",
+    "content": "literacy for life\n\nwebsite: literacyforlifeslo.org\nlocation: 992 monterey st. #c, slo map\nlearning centers in arroyo grande, atascadero, cambria, los osos, morro bay, nipomo, paso robles, and slo\n\n\nphone: 805-459-5369 { source: https://www.literacyforlifeslo.org/contact.php }\nemail: info@literacyforlifeslo.org { source: https://www.literacyforlifeslo.org/contact.php }\nhours: m-th 9am-5pm\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Literacy For Life"
+    ]
+  },
+  {
+    "id": "Literacy-Connection",
+    "title": "The Literacy Connection",
+    "content": "the literacy connection\n\nwebsite: catalog.slolibrary.org/tlc\nphone: 805-781-5077 \nemail: tlcinfo@slolibrary.org \nhow to access: submit a form on the library website \nnotes: program of slo county public libraries\n\n",
+    "type": "directory",
+    "aliases": [
+      "The Literacy Connection"
+    ]
+  },
+  {
+    "id": "Little-Free-Libraries",
+    "title": "Little Free Libraries",
+    "content": "little free libraries\n🗺️ view all locations on an interactive map\n\nwebsite: littlefreelibrary.org\nlocations:\narroyo grande:\n330 alder st. map\n121 allen st. map\namarillo dr. map\n2510 appaloosa way map\ncorner of cedar & boysenberry map\n529 e. cherry ave. map\n615 e. cherry ave. map\n2385 clarkie way map\ncypress ridge pkwy. near cypress ridge golf course entrance map\n485 dorothy ln. map\n303 n. elm st. map\n512 s. elm st. map\n282 gait way map\n1146 maple st. map\nmaple st. @ walnut st. map\n127 s. mason st. map\n328 orchard st. map\n1270 poplar st. map\n1260 sage st. map\n1414 sierra dr. map\n494 stagecoach rd. map\n958 sycamore dr. map\n250 wesley st. map\n\n\natascadero:\n9481 carmel rd. map\n8505 carmelita ave. map\n3155 el camino real map\n2720 ferrocarril rd. map\n8934 junipero ave. map\nmariquita ave. map\n9125 mountain view dr. map\n5265 palma ave. map\n14985 powerline rd. map\n8155 san gregorio rd. map\n10675 san marcos rd. map\n13400 santa ana rd. map\n6605 santa ynez ave. map\n7310 sonora ave. map\n8437 vaquero ln. map\n4555 viscano ave. map\n\n\navila beach:\n1401 san luis bay dr. map\n191 san miguel st. map\n259 squire canyon rd. map\n\n\ncambria:\n6404 buckley dr. map\n701 drake st. map\n521 hastings st. map\n2750 holden pl. map\n383 orlando dr. map\n1176 pineridge dr. map\n365 weymouth st. map\n\n\ncayucos:\n84 13th st. map\n1175 cass ave. map\n151 f st. map\n517 lucerne rd. map\n625 s. ocean ave. map\n\n\ngrover beach:\n338 n. 3rd st. map\n251 s. 4th st. map\n266 n. 5th st. map\n240 anita ave. map\n1230 trouville ave. map\n1624 trouville ave. map\n\n\nlos osos / baywood park:\n1643 4th st. map\n1182 7th st. map\n1855 7th st. map\n1180 9th st. map\n1257 11th st. map\n1426 16th st. map\n1539 18th st. map\n1639 18th st. map\n2130 andre ave. map\n2315 bayview heights dr. map\n2148 bush dr. map\n2149 lariat dr. map\n561 loma st. map\n1351 los olivos ave. map\n1078 los osos valley rd. map\n2003 lost oak dr. map\n732 manzanita dr. map\n2345 oak ridge dr. map\n2100 pecho rd. map\n948 santa maria ave. map\n1188 scenic way map\n2340 tierra dr. map\n\n\nmorro bay:\n720 cabrillo pl. map\ncloisters community park map\n482 estero ave. map\n2401 ironwood ave. map\n495 main st. map\n450 san jacinto st. map\n\n\nnipomo:\n421 n. las flores dr. map\n789 live oak ridge rd. map\n525 sandydale dr. map\n\n\noceano:\n1341 18th st. map\n1501 24th st. map\n\n\npaso robles:\n14140 chimney rock rd. map\n5090 deer creek way map\n1130 merry hill rd. map\n2247 oak st. map\n2004 pine st. map\n3773 ruth way #a map\n1103 spring st. map\n539 veronica dr. map\n2105 vine st. map\n904 vista cerro dr. map\n\n\npismo beach:\n28 el viento map\n224 irish way map\n990 price st. map\n2411 price st. map\n2555 price st. map\n995 skyline dr. map\n\n\nsan miguel:\n1197 l st. map\n\n\nsanta margarita:\n22070 h st. map\n3120 ranchita canyon rd. map\n\n\nshell beach:\n302 cuyama ave. map\n262 esparto ave. map\n\n\nslo:\n1330 alder st. map\n1378 avalon st. (@ oceanaire dr.) map\n79 benton way map\nbluerock drive near stoneridge park map\n1410 broad st. @ pacific map\ncenter st. by nazarene church\ncenter st. between chorro and lincoln map\n171 cerro romauldo ave. map\n3450 dairy creek rd. (slo botanical garden) map\n2378 boulevard del campo map\n1295 descanso st. map\n107 earthwood ln. map\n1595 eto circle map\n1383 fairway dr. map\n157 fel mar dr. map\n1348 fernwood dr. map\n1011 george st. map\n1 grand ave. map\n3440 gregory ct. map\n1415 higuera st. map\non a utility pole at morro st. and islay st. map\n1121 islay st. map\n1215 joyce ct. map\n3962 kilbern way map\n10 la entrada ave. map\n286 lawrence dr. map\n655 lawrence dr. map\n1148 leff st. map\nunited church of christ (11245 los osos valley road) map\n1708 lynn map\ncorner of mill & toro map\nmonday club, 1815 monterey at grand map\n1430 noveno ave. map\n1552 oceanaire dr. (near atascadero st.) map\n1906 oceanaire dr. (near pinecove dr.) map\npacific between johnson & pepper map\n1768 pereira dr. map\n1358 purple sage ln. map\n333 sage st. map\n373 sage st. map\n1401 san luis bay dr. map\n1739 san luis dr. map\n1391 san marcos ct. map\nin front of the establishment, 1703 santa barbara ave. map\nby the montessori school at south higuera & los osos valley road map\n3960 s. higuera st. #34 map\nnazarene church on 3396 southwood dr. map\n1767 southwood dr. map\n4475 wavertree st. map\n637 woodbridge map\n\n\ntempleton:\n785 ashley ln. map\n620 old country rd. map\n308 puffin way map\n215 s. main st. map\n1027 santa rita rd. map\n158 wessels way map\n\n\n\n\nhours: daily, 24/7\n\n",
+    "type": "directory",
+    "aliases": [
+      "Little Free Libraries"
+    ]
+  },
+  {
+    "id": "Little-Free-Pantries",
+    "title": "Little Free Pantries",
+    "content": "little free pantries\n🗺️ view all locations on an interactive map\nnote: little free pantries come and go.\nsometimes they are neglected, damaged, or removed.\nif you see one listed here that is no longer in service, please use the feedback button to tell vivaslo about it.\n\nwebsite: littlefreepantry.org\nlocations:\narroyo grande:\n132 south halcyon rd. map\n268 summit station rd. map\n\n\natascadero:\n9557 curbaril ave. map\n9333 santa barbara rd. map\n\n\ngrover beach:\n202 s. 8th st. / 770 rockaway ave. map\n393 n. 16th st. map\n925 newport ave. map\n\n\nlos osos:\n1500 block of 5th st. map\n1559 10th st. map\n490 los osos valley rd. map\n\n\nmorro bay:\n3000 hemlock ave. map\n397 san joaquin st. map\n\n\nnipomo:\n181 w tefft st. map\n267 w tefft st. map\n\n\noceano:\n1322 24th st. map\n1501 24th st. map\n1930 ocean st. map\n615 pier ave. map\n\n\npaso robles:\n8th st. and olive st. map\n3301 oak st. map\n1003 pioneer trail rd. map\n\n\npismo beach: 206 margo way map\nsanta margarita:\n22210 el camino real map\n22495 k st. map\n\n\nslo:\n3320 bullock ln. map\n2021 broad st. map\n226 ferrini rd. map\n335 high st. map\n2075 johnson ave. map\n11245 los osos valley rd. map\n474 marsh st. map\n1306 nipomo st. map \n695 pismo st. map\ncorner of san carlos and bushnell map\n193 san jose ct. map\n\n\ntempleton: 806 old country rd. map\n\n\nhours: daily, 24/7\n\n",
+    "type": "directory",
+    "aliases": [
+      "Little Free Pantries"
+    ]
+  },
+  {
+    "id": "Loaves-and-Fishes-Atascadero",
+    "title": "Loaves & Fishes (Atascadero)",
+    "content": "loaves & fishes (atascadero)\n\nwebsite: alffoodpantry.org\nlocation: 5411 el camino real, atascadero map \nphone: 805-461-1504 \nemail: contact@alffoodpantry.org \nhours (food pantry): m-f 1-3pm \nnotes: not affiliated with loaves & fishes (paso robles)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Loaves & Fishes (Atascadero)"
+    ]
+  },
+  {
+    "id": "Loaves-and-Fishes-Paso-Robles",
+    "title": "Loaves & Fishes (Paso Robles)",
+    "content": "loaves & fishes (paso robles)\n\nwebsite: loavesandfishespaso.org\nlocation: 2650 spring st., paso robles map \nphone: 805-238-4742 \nhours: m-th 2pm-4pm, or by appointment \nnotes: not affiliated with loaves & fishes (atascadero)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Loaves & Fishes (Paso Robles)"
+    ]
+  },
+  {
+    "id": "Long-Term-Care-Ombudsman",
+    "title": "Long Term Care Ombudsman",
+    "content": "long term care ombudsman\n\nwebsite: ombudsmanslo.org\nlocation: 3232 s. higuera st. #101b, slo map \nphone:\n805-785-0132 (office) \n800-231-4024 (24-hour emergency) \n\n\nemail: info@ombudsmanslo.org \nhours: m-f 8:30am-4:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Long Term Care Ombudsman"
+    ]
+  },
+  {
+    "id": "Lopez-Lake-Recreation-Area",
+    "title": "Lopez Lake Recreation Area",
+    "content": "lopez lake recreation area\n\nwebsite: slocountyparks.com/camp/lopez-lake/\nlocation: 6800 lopez dr., arroyo grande map\nphone: 805-788-2381  m-th 8am-5pm; 805-781-5930 (reservations)\nemail: sloparks@co.slo.ca.us\nhours: 6am-sunset daily\n\n",
+    "type": "directory",
+    "aliases": [
+      "Lopez Lake Recreation Area"
+    ]
+  },
+  {
+    "id": "Los-Osos-Cares",
+    "title": "Los Osos Cares Resource Center",
+    "content": "los osos cares resource center\n\nwebsite: losososcares.com\nlocation: sunnyside school, 800 manzanita dr., room 18, los osos map \ncommunity dinners: 2180 palisades ave., los osos \n\n\nphone: 805-592-2701 \nemail: wecareinlososos@gmail.com \nhours: tu/w/th 1-3pm \ncommunity dinners: wednesdays 5-6pm \n\n\nnotes:\nhosts community dinner at south bay community center\nhosts \"coastal family resource center\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Los Osos Cares Resource Center"
+    ]
+  },
+  {
+    "id": "Lucia-Mar-Adult-Education",
+    "title": "Lucia Mar Adult Education",
+    "content": "lucia mar adult education\n\nwebsite: adulted.luciamarschools.org\n\n\n\n\n\nname\nlocation\nphone\n\n\n\nmain office\n602 orchard st., arroyo grande map\n805-474-3222\n\n\nnipomo learning center\n190 e. price st. (e & f), nipomo map\n805-474-3000 x7602\n\n\noceano community center\n1575 17th st. (30, 33, & 34), oceano map\n805-474-3000 x7601\n\n\n\nemail: brienne.phillips@lmusd.org \nnotes: partners with cuesta college for esl classes\n\n",
+    "type": "directory",
+    "aliases": [
+      "Lucia Mar Adult Education"
+    ]
+  },
+  {
+    "id": "Lumina-Alliance",
+    "title": "Lumina Alliance",
+    "content": "lumina alliance\n\nwebsite: luminaalliance.org\nlocations:\n555 s. 13th st. #b, grover beach map\n102 s. vine st. #c, paso robles map \n51 zaca ln. #150, slo map \n\n\nphone:\n805-545-8888 (24-hour free & confidential crisis line) \n805-781-6400 (business line) \n\n\nemail: contact@luminaalliance.org \nnote: rise merged with stand strong in 2021 to form lumina alliance\n\n",
+    "type": "directory",
+    "aliases": [
+      "Lumina Alliance"
+    ]
+  },
+  {
+    "id": "Lumina-Thrift",
+    "title": "Lumina Thrift",
+    "content": "lumina thrift\n\nwebsite: luminaalliance.org/thriftstore\nlocation: 545 higuera st., slo map \nphone: 805-592-3596 \nhours: m-sa 10am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Lumina Thrift"
+    ]
+  },
+  {
+    "id": "Marijuana-Anonymous",
+    "title": "Marijuana Anonymous",
+    "content": "marijuana anonymous\n\nwebsite: marijuana-anonymous.org\nlocation: 2939 augusta st., slo map  (middlehouse)\nphone: 800-766-6779 \nemail: slo.marijuana.anonymous@gmail.com \nhours: 6:30-7:30pm on mondays \n\n",
+    "type": "directory",
+    "aliases": [
+      "Marijuana Anonymous"
+    ]
+  },
+  {
+    "id": "Marthas-Place-Childrens-Center",
+    "title": "Martha’s Place Children’s Center",
+    "content": "martha's place children's center\n\nwebsite: slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/marthas-place-childrens-center\nlocation: 2925 mcmillan ave. #108, slo map \nphone: 805-781-4948 \nhours: m-f 8am-5pm \nnotes: for children ages 0-5 with behavioral or mental health issues\n\n",
+    "type": "directory",
+    "aliases": [
+      "Martha’s Place Children’s Center"
+    ]
+  },
+  {
+    "id": "Meals-that-Connect",
+    "title": "Meals that Connect",
+    "content": "meals that connect\n\nwebsite: mealsthatconnect.org\nlocation: 265 south st. #b, slo map (office) \nserves meals in atascadero, templeton, cambria, san simeon, los osos, morro bay, cayucos, nipomo, oceano, paso robles, santa margarita, and slo\nalso does some home delivery \n\n\nphone: 805-541-3312 \nemail: officeadmin@mealsthatconnect.org \nhours: (varies by site)\nhow to access: open to people aged 60 and above; complete an application \n\n",
+    "type": "directory",
+    "aliases": [
+      "Meals that Connect"
+    ]
+  },
+  {
+    "id": "Medi-Cal",
+    "title": "Medi-Cal",
+    "content": "medi-cal\n\nsee also: cencal\n\n\nlocations: see slo county department of social services\nmedi-cal dental:\nwebsite: www.denti-cal.ca.gov\nphone: 800-322-6384 (tty: 800-735-2922)\n\n\nmedi-cal rx:\nwebsite: medi-calrx.dhcs.ca.gov\nphone: 800-977-2273\n\n\nmedi-cal shuttle: see ride-on transportation\nnotes:\ncencal health is the local medi-cal administrator \napply at www.coveredca.com or benefitscal.com or in person at local dss offices \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Medi-Cal"
+    ]
+  },
+  {
+    "id": "Medically-Fragile-Homeless-Program",
+    "title": "Medically Fragile Homeless Program",
+    "content": "medically fragile homeless program\n\nwebsite: cfsslo.org/#mfh\nemail: carrie@linkslo.org \nnotes:\naccess through slo county department of social services or housing support program (hsp) or adult protective services or calworks\noperated by center for family strengthening (cfs)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Medically Fragile Homeless Program"
+    ]
+  },
+  {
+    "id": "MISP",
+    "title": "Medically Indigent Services Program (MISP)",
+    "content": "medically indigent services program (misp)\n\nwebsite: slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/medically-indigent-services-program-(misp)\nlocation: 2180 johnson ave., slo map \nphone: 805-781-5500 \nhours: m-f 8am-5pm (closed noon-1pm) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Medically Indigent Services Program (MISP)"
+    ]
+  },
+  {
+    "id": "MedStop",
+    "title": "MedStop",
+    "content": "medstop\n\nwebsite: medstopurgentcare.com\nlocation: 283 madonna rd. suite b (madonna plaza), slo \nphone: 805-549-8880 \nhours: m-f 8am-7pm, sa.-su. 8am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "MedStop"
+    ]
+  },
+  {
+    "id": "MHET",
+    "title": "Mental Health Evaluation Team",
+    "content": "mental health evaluation team\n\nwebsite:\nmhet: slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-(mhet)\nmobile crisis team: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-(mct)\n\n\nlocation: county-wide\nphone:\nmhet: 800-838-1381 \nmobile crisis team: 800-783-0607 \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Mental Health Evaluation Team"
+    ]
+  },
+  {
+    "id": "Mobile-Crisis-Team",
+    "title": "Mobile Crisis Team",
+    "content": "mobile crisis team\n\nwebsite:\nmhet: slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mental-health-evaluation-team-(mhet)\nmobile crisis team: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-(mct)\n\n\nlocation: county-wide\nphone:\nmhet: 800-838-1381 \nmobile crisis team: 800-783-0607 \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Mental Health Evaluation Team"
+    ]
+  },
+  {
+    "id": "Middlehouse",
+    "title": "Middlehouse",
+    "content": "middlehouse\n\n\nwebsite: middlehouse.org\nlocation: 2939 augusta st., slo map \nphone: 805-544-8328 \nemail: middlehouse93401@gmail.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Middlehouse"
+    ]
+  },
+  {
+    "id": "Mission-Thrift",
+    "title": "Mission Thrift",
+    "content": "mission thrift\n\nwebsite: omsslo.org/apps/pages/index.jsp?urec_id=3643070&type=d&prec_id=2413322\nlocation: 2958 s. higuera st., slo map \nphone: 805-548-2660 \nemail: morradre@omsslo.com \nhours: m-sa 12pm-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Mission Thrift"
+    ]
+  },
+  {
+    "id": "Mobile-Crisis-Unit",
+    "title": "Mobile Crisis Unit",
+    "content": "mobile crisis unit\n\nwebsite: slocity.org/government/department-directory/fire-department/mobile-crisis-unit-mcu\nlocation: slo city only\nphone:\n805-550-7270 \n805-781-7312 \n\n\nhours: m-th 8am-5:30pm; every other friday 8am-5:30pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Mobile Crisis Unit"
+    ]
+  },
+  {
+    "id": "Morro-Bay-Lions-Foundation",
+    "title": "Morro Bay Lions Foundation",
+    "content": "morro bay lions foundation\n\nwebsite: morrobaylions.org/2025/07/24/community-dinners-at-vets-hall\nlocation: morro bay vets memorial building, 209 surf st., morro bay map \nphone: 805-772-4421\nhours:\nmondays: 4:30pm (doors open for pantry shopping, free clothes, towels, toiletries) \ndinner service: 5:30-6:30pm \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Morro Bay Lions Foundation"
+    ]
+  },
+  {
+    "id": "Morro-Bay-Senior-Center",
+    "title": "Morro Bay Senior Citizens",
+    "content": "morro bay senior citizens\n\nwebsite: morrobayseniors.org\nlocation: 1001 kennedy way, morro bay map \nphone: 805-772-4421 \nemail:\ninfo@morrobayseniors.org \nmbactivesrs@gmail.com \n\n\nhours: m-f 9am-4pm \nmembership: $25/year individual, $40/year household (90+ free); open to people 55+ \nnotes:\nhosts hicap\nhosts senior legal services project on the first friday of the month\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Morro Bay Senior Citizens"
+    ]
+  },
+  {
+    "id": "Morro-Bay-Parks-and-Recreation",
+    "title": "Morro Bay Parks & Recreation",
+    "content": "morro bay parks & recreation\n\nwebsite: morrobayca.gov/292/recreation-services\nlocation: morro bay community center, 1001 kennedy way, morro bay map { source: https://www.morrobayca.gov/292/recreation-services }\nphone: 805-772-6278 { source: https://www.morrobayca.gov/292/recreation-services }\nemail: kcarmichael@morrobayca.gov { source: https://www.morrobayca.gov/292/recreation-services }\nhours: m-f 8:30am-5pm (registration)\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Morro Bay Parks & Recreation"
+    ]
+  },
+  {
+    "id": "NAMI-SLO-County",
+    "title": "NAMI SLO County",
+    "content": "nami slo county\n\nwebsite: namislo.org\nmailing address: p.o. box 3158, san luis obispo, ca 93403 { source: https://www.namislo.org/ }\nphone\nimmediate crisis support: nami national helpline 800-950-6264 (m-f 7am-3pm pt), or call/text 988\nnami slo county: 805-434-7220 { source: https://www.namislo.org/ }\n\n\nemail: namisanluisobispo@gmail.com { source: https://www.namislo.org/ }\nsupport groups: sgroups.nami.sloco@gmail.com { source: https://www.namislo.org/nami-support-groups }\n-->\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "NAMI SLO County"
+    ]
+  },
+  {
+    "id": "Narcotics-Anonymous",
+    "title": "Narcotics Anonymous",
+    "content": "narcotics anonymous\n\nwebsite: centralcoastna.org\nlocations: various locations in arroyo grande, atascadero, cambria, guadalupe, lompoc, orcutt, paso robles, san luis obispo, and santa maria \nalso has some virtual (zoom) meetings\n\n\nphone: 805-549-7730 \n\n",
+    "type": "directory",
+    "aliases": [
+      "Narcotics Anonymous"
+    ]
+  },
+  {
+    "id": "NCI-Affiliates-Thrift",
+    "title": "NCI Affiliates Thrift",
+    "content": "nci affiliates thrift\n\nwebsite: nciaffiliates.org/thrift-stores\n\n\n\n\n\nlocation\nphone\n\n\n\n2070 el camino real, atascadero map\n805-462-0500\n\n\n183 niblick rd., paso robles map\n805-296-3153\n\n\n\nhours: daily 10am-6pm \nnotes: operated by nci affiliates; training location for vocational services\n\n",
+    "type": "directory",
+    "aliases": [
+      "NCI Affiliates Thrift"
+    ]
+  },
+  {
+    "id": "NeedyMeds",
+    "title": "NeedyMeds",
+    "content": "needymeds\n\nwebsite: needymeds.org\nphone: 800-503-6897 \nemail: info@needymeds.org \nhours: m-f 9am-5pm eastern time \n\n",
+    "type": "directory",
+    "aliases": [
+      "NeedyMeds"
+    ]
+  },
+  {
+    "id": "New-Life-U-Pick-Pantry",
+    "title": "New Life U-Pick Pantry",
+    "content": "new life u-pick pantry\n\nwebsite: newlifepismo.com/pantry\nlocation: 941 n. oak park blvd., pismo beach map (new life community center) \nphone: 805-489-3891 \nemail: pantry@newlifepismo.com \nhours: tu 6-7:30pm, w 10am-noon, th 1:30-3:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "New Life U-Pick Pantry"
+    ]
+  },
+  {
+    "id": "Nipomo-Community-Presbyterian",
+    "title": "Nipomo Community Presbyterian",
+    "content": "nipomo community presbyterian\n\n\nwebsite: nipomopresbyterian.org\nlocation: 1235 n. thompson ave., arroyo grande map \nphone: 805-473-8059\nhours (food pantry): f 12:45-1:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Nipomo Community Presbyterian"
+    ]
+  },
+  {
+    "id": "Nipomo-Food-Basket",
+    "title": "Nipomo Food Basket",
+    "content": "nipomo food basket\n\nwebsite: nipomofoodbasket.com\nlocation: 197 w. tefft st., nipomo map \nphone: 805-619-7681 \nemail:\nhelpu@nipomofoodbasket.org \ninfo@nipomofoodbasket.com \n\n\nhours: m/tu/th/f 10am-1pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Nipomo Food Basket"
+    ]
+  },
+  {
+    "id": "Nipomo-Senior-Center",
+    "title": "Nipomo Senior Center",
+    "content": "nipomo senior center\n\nwebsite: nipomoseniorcenter.org\nlocation: 200 e. dana st., nipomo map (entrance on beechnut st.)\nphone: 805-929-1615 \nemail: contact@nipomoseniorcenter \nhours: m-f 9am-1pm \nnote: hosts meals that connect lunches \n\n",
+    "type": "directory",
+    "aliases": [
+      "Nipomo Senior Center"
+    ]
+  },
+  {
+    "id": "North-County-Family-Resource-Center",
+    "title": "North County Family Resource Center",
+    "content": "north county family resource center\n\nwebsite: capslo.org/north-county-family-resource-center\nlocation: 704 spring st., paso robles map \nphone: 805-440-1878 \nnotes:\nsee also link family resource center\nsee also safe family resource centers\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "North County Family Resource Center"
+    ]
+  },
+  {
+    "id": "North-County-NeighborAid",
+    "title": "North County NeighborAid",
+    "content": "north county neighboraid\n\nwebsite: cfsslo.org/north-county-neighboraid\nlocation: 1428 phillips lane #203, slo map \nmailing address: 7343 el camino real #346, atascadero \nphone: 805-466-5404 \nemail: info@noconeighboraid.org \nhours: by appointment\nhow to access: make a request by using their web form\nnotes: grassroots initiative managed by center for family strengthening\n\n",
+    "type": "directory",
+    "aliases": [
+      "North County NeighborAid"
+    ]
+  },
+  {
+    "id": "North-County-Paws-Cause",
+    "title": "North County Paws Cause",
+    "content": "north county paws cause\n\nwebsite: northcounty-pawscause.org\nlocation: paso robles \nphone: 805-674-8664 / 805-674-8664 \nemail: northcountypawscause@gmail.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "North County Paws Cause"
+    ]
+  },
+  {
+    "id": "North-County-Care",
+    "title": "North County Care Minor Emergency Services",
+    "content": "north county care minor emergency services\n\n\nlocation: 636 spring st., paso robles map \nphone: 805-238-2422 \nhours: m-f 10am-5pm \n\n\n",
+    "type": "directory",
+    "aliases": [
+      "North County Care Minor Emergency Services"
+    ]
+  },
+  {
+    "id": "Oceano-Campground",
+    "title": "Oceano Campground",
+    "content": "oceano campground\n\nwebsite: https://slocountyparks.com/camp/oceano/\nlocation: 494 air park dr., oceano map\nphone: 805-781-4900  m-th 8am-4:30pm; f-su 8am-6pm, 805-781-5930 (reservations)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Oceano Campground"
+    ]
+  },
+  {
+    "id": "Open-Arms-Pantry",
+    "title": "Open Arms Pantry at Rock Harbor",
+    "content": "open arms pantry at rock harbor\n\nlocation: rock harbor christian fellowship, 1475 quintana rd., morro bay map \nphone: 805-799-7031 \nhours: sa 9:30-10:30am; also available throughout the week on a walk-in basis \n\n",
+    "type": "directory",
+    "aliases": [
+      "Open Arms Pantry at Rock Harbor"
+    ]
+  },
+  {
+    "id": "Outreach-and-Engagement-Services",
+    "title": "Outreach and Engagement Services",
+    "content": "outreach and engagement services\n\nsee also community action partnership san luis obispo (capslo)\n\n\nlocation: 1320 nipomo st., slo map \nphone: 805-544-4004\nhours: m-f 10am-3pm\nhow to access: walk-ins ok\n\n",
+    "type": "directory",
+    "aliases": [
+      "Outreach and Engagement Services",
+      "**Community Action Partnership San Luis Obispo (CAPSLO)**"
+    ]
+  },
+  {
+    "id": "Parent-Connection-of-SLO-County",
+    "title": "Parent Connection of SLO County",
+    "content": "parent connection of slo county\n\nwebsite: sloparents.org\nphone: 805-543-3700  (español: 805-540-1223)\nemail: info@sloparents.org \nnote: operated by center for family strengthening (cfs)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Parent Connection of SLO County"
+    ]
+  },
+  {
+    "id": "Parents-Helping-Parents",
+    "title": "Parents Helping Parents of SLO County",
+    "content": "parents helping parents of slo county\n\nwebsite: phpslo.org\n\n\n\n\n\nlocation\nhours\n\n\n\n7305 morro rd. #104a, atascadero map\nw 10am-1pm (by appointment)\n\n\n1146 farmhouse lane, slo map\nm-f 8am-4:30pm\n\n\n\nphone: 805-543-3277 \nemail: php@ucp-slo.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Parents Helping Parents of SLO County"
+    ]
+  },
+  {
+    "id": "Paso-Cares",
+    "title": "Paso Cares",
+    "content": "paso cares\n{ source: https://www.findhelp.org/paso-cares%2d%2dpaso-robles-ca%2d%2dfeeding-the-homeless/5153804446597120 }\n\nwebsite: pasocares.org\n\n\n\n\nlocation\nhours\n\n\n\nriverside & 24th st. parking lot, paso robles map\nm-f 5-6pm, su 4-5pm\n\n\n1335 oak st., paso robles map\nsa. noon-1pm\n\n\n\nphone: 805-591-0078 { source: https://www.pasocares.org/ and other pages on that site }\n{ 805-571-0078 source: https://www.pasocares.org/contact only (typo?) }\nemail: pasocares@gmail.com { source: https://www.pasocares.org/ }\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Paso Cares"
+    ]
+  },
+  {
+    "id": "Paso-Robles-Housing-Authority",
+    "title": "Paso Robles Housing Authority",
+    "content": "paso robles housing authority\n\nwebsite: pasoroblesha.org\nlocation: 901 30th street, paso robles map \nphone: 805-238-4015 \nemail: info@pasoroblesha.org \nhours: m-f 9am-4:30pm (closed noon-1pm) \nhow to access: call or email\nnotes:\noperates affordable housing properties including oak park 1-4 and sunrise villas \noffers community services including \"youth works\" program \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Paso Robles Housing Authority"
+    ]
+  },
+  {
+    "id": "Paso-Robles-Senior-Center",
+    "title": "Paso Robles Senior Center",
+    "content": "paso robles senior center\n\nwebsite: prcity.com/293/senior-services\nlocation: 270 scott st., paso robles map \nphone: 805-237-3880\nhours: m-f 8am-5pm \nfood pantry: second and fourth tuesdays of the month at 10am \n\n\nnotes:\na lunch service site for meals that connect \na slo food bank pantry & food box distribution site \nhosts hicap \nhosts senior legal services project \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Paso Robles Senior Center"
+    ]
+  },
+  {
+    "id": "Paso-Robles-Parks-and-Recreation",
+    "title": "Paso Robles Recreation Services",
+    "content": "paso robles recreation services\n\nwebsite: prcity.com/268/recreation-services\nlocation: centennial park, 600 nickerson dr., paso robles map \nphone: 805-237-3988 \nemail: recservices@prcity.com\nhours: m-th 12pm-5pm (registration desk) \nnote: offers scholarships to cover fees for its recreation activities; apply in person at the registration desk \n\n",
+    "type": "directory",
+    "aliases": [
+      "Paso Robles Recreation Services"
+    ]
+  },
+  {
+    "id": "PathPoint",
+    "title": "PathPoint",
+    "content": "pathpoint\n\nwebsite: pathpoint.org/locations/san-luis-obispo\n\n\n\n\n\nlocation\nphone\n\n\n\n775 w. grand ave. #c (grover beach) map\n805-473-9582\n\n\n11491 los osos valley rd. (slo) map\n805-782-8890\n\n\n\nemail: info@pathpoint.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "PathPoint"
+    ]
+  },
+  {
+    "id": "Peoples-Justice-Project",
+    "title": "People’s Justice Project",
+    "content": "people's justice project\n\nwebsite: peoplesjusticeproject.org\nlocation: 5708 hollister ave., ste. a #1033, goleta map \nphone: 805-242-6691 \nemail: legal@peoplesjusticeproject.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "People’s Justice Project"
+    ]
+  },
+  {
+    "id": "Peoples-Kitchen-GB",
+    "title": "People’s Kitchen (Grover Beach)",
+    "content": "people's kitchen (grover beach)\n\nwebsite: scpk.org\nlocation: 946 rockaway ave., grover beach map \nphone:\n805-266-1838 \n805-458-1992 \n\n\nemail:\nscpk5cities@gmail.com \ndnimwold@gmail.com \n\n\nhours: daily 11:30am-1pm \nnotes: hosted by house of god church \n\n",
+    "type": "directory",
+    "aliases": [
+      "People’s Kitchen (Grover Beach)"
+    ]
+  },
+  {
+    "id": "Peoples-Kitchen-SLO",
+    "title": "People’s Kitchen (SLO)",
+    "content": "people's kitchen (slo)\n\nsee also 40 prado homeless services center\n\n\nwebsite: slopeopleskitchen.org\nlocation: 43 prado road, slo map \nemail: mnparker539@gmail.com \nhours: daily at noon \nhow to access: come during serving time. \n\n",
+    "type": "directory",
+    "aliases": [
+      "People’s Kitchen (SLO)",
+      "**40 Prado Homeless Services Center**"
+    ]
+  },
+  {
+    "id": "Peoples-Self-Help-Housing",
+    "title": "Peoples’ Self-Help Housing",
+    "content": "peoples' self-help housing\n\nwebsite: pshhc.org\nlocation: 1060 kendall road, slo map \nphone: 805-781-3088 \nemail: info@pshhc.org \nhours: m-f 8am-5pm\nhow to access: submit a rental application at their website, or download it, complete it, and submit it by email, mail, or in person \nnotes:\noperates \"broad street place\"\noperates \"sea breeze apartments\"\noperates \"tiburon place\"\noperates \"villas at higuera\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Peoples’ Self-Help Housing"
+    ]
+  },
+  {
+    "id": "Pets-of-the-Homeless",
+    "title": "Pets of the Homeless",
+    "content": "pets of the homeless\n\nwebsite: petsofthehomeless.org\nmailing addresses: 710 w. washington st., carson city, nv 89703 \nphone: 775-841-7463 \nemergency veterinary care program: case managers available m-f 9am-3pm for new cases \n\n\nemail: info@petsofthehomeless.org \nnotes: has partner locations in slo including animal care clinic, mission animal hospital, and woods humane society \n\n",
+    "type": "directory",
+    "aliases": [
+      "Pets of the Homeless"
+    ]
+  },
+  {
+    "id": "Pismo-Beach-Athletic-Club",
+    "title": "Pismo Beach Athletic Club",
+    "content": "pismo beach athletic club\n\nwebsite: pbac.com\nlocation: 1751 price st., pismo beach map \nphone: 805-773-3011 \nhours: m-f 5:30am-9pm, sa-su 7am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Pismo Beach Athletic Club"
+    ]
+  },
+  {
+    "id": "Pismo-Beach-Recreation-Division",
+    "title": "Pismo Beach Recreation Division",
+    "content": "pismo beach recreation division\n\nwebsite: pismobeach.org/73/recreation\nlocation: 760 mattie rd., pismo beach map \nphone: 805-773-7063 \nemail: recreation@pismobeach.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Pismo Beach Recreation Division"
+    ]
+  },
+  {
+    "id": "Planned-Parenthood",
+    "title": "Planned Parenthood",
+    "content": "planned parenthood\n\nwebsite: plannedparenthood.org/planned-parenthood-california-central-coast\nlocation: 743 pismo st., slo map \nphone: 888-898-3806 \nemail: health.center@ppcentralcoast.org \nhours: m 9am-6pm, tu-sa 8am-5pm (closed some holidays) \nnotes: entry-point for \"familypact\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "Planned Parenthood"
+    ]
+  },
+  {
+    "id": "Port-San-Luis-Harbor-District",
+    "title": "Port San Luis Harbor District",
+    "content": "port san luis harbor district\n\nwebsite: portsanluis.com\nphone: 805-595-5400 \nhours (administrative): m-f 8am-4:30pm (closed noon-1pm) \ncoastal gateway multi-purpose room\nwebsite: portsanluis.com/2164/coastal-gateway-multi-purpose-room\nlocation: 3900 avila beach dr., avila beach map \n\n\nrv camping\nwebsite: portsanluis.com/2163/rv-camping\nphone: 805-305-4796\nemail: reservations@portsanluis.com \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Port San Luis Harbor District"
+    ]
+  },
+  {
+    "id": "Pregnancy-Parenting-Support",
+    "title": "Pregnancy & Parenting Support",
+    "content": "pregnancy & parenting support\n\nwebsite: www.ppsslo.org\nlocation: 3480 s. higuera #110, slo map \nphone: 805-541-3367, 805-541-3367 \nemail: info@ppsslo.org \nhours: m-f 10am-3pm \nhow to access: by appointment only; call or text to make an appointment \n\n",
+    "type": "directory",
+    "aliases": [
+      "Pregnancy & Parenting Support"
+    ]
+  },
+  {
+    "id": "Recovery-Dharma",
+    "title": "Recovery Dharma",
+    "content": "recovery dharma\n\nwebsite: recoverydharma.org\nlocation: 865 aerovista pl. #106, slo (aspire counseling service) map \nemail: tedrossini@gmail.com \nphone: 510-417-6162 \nhours: sa. 10:20-11:20am \n\n",
+    "type": "directory",
+    "aliases": [
+      "Recovery Dharma"
+    ]
+  },
+  {
+    "id": "Recuperative-Care-Program",
+    "title": "Recuperative Care Program",
+    "content": "recuperative care program\n\nwebsite: capslo.org/rcp\nlocation: 40 prado, slo map \nphone:\n805-458-2895 (ariana long) \n805-503-2984 (amy nielson, inquiries) \n\n\nemail: rcp40prado@capslo.org \nhours: 24/7 \nhow to access: must be referred by a medical professional \n\n",
+    "type": "directory",
+    "aliases": [
+      "Recuperative Care Program"
+    ]
+  },
+  {
+    "id": "Recycle-101",
+    "title": "Recycle 101",
+    "content": "recycle 101\n\nlocation: 1909 front st., oceano map \nphone: 805-363-1034 \nhours: w 9am-4pm, m/tu/th/f/sa 9am-noon, m/tu/th/f 12:30-4pm \nnotes: crv recycling for cash (5¢ for containers <24oz, 10¢ for ≥24oz)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Recycle 101"
+    ]
+  },
+  {
+    "id": "Red-Cross",
+    "title": "Red Cross",
+    "content": "red cross\n\nwebsite: redcross.org/local/california/central-california.html\nlocation: 225 prado rd. #a map \nphone:\nlocal office: 805-543-0696 \n24/7 national line: 800-733-2767\n\n\nhours: m-f 9am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Red Cross"
+    ]
+  },
+  {
+    "id": "Red-Rover-Relief",
+    "title": "Red Rover Relief",
+    "content": "red rover relief\n\nwebsite: redrover.org/relief\nmailing address: p.o. box 188890, sacramento, ca 95818 \nphone: 916-429-2457 \nemail: info@redrover.org \nhours: m-f 8:30am-4:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Red Rover Relief"
+    ]
+  },
+  {
+    "id": "Refuge-Church-Atascadero",
+    "title": "Refuge Church",
+    "content": "refuge church\n\nwebsite: refugechurch.info/connect/open-arms-ministry\nlocation: 6955 portola rd., atascadero map \nphone: 805-466-3554 \nemail: office@refugechurch.info \nhours:\nfood and clothing pantry: tu 5-6pm, w 6-6:30pm, or by appointment\nrefuge recovery (for anyone struggling with addiction): tu 6pm \nfree meals: tu 5pm/w 6pm dinner\noffice: m-f 8am-5pm\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Refuge Church"
+    ]
+  },
+  {
+    "id": "Renovate-Church",
+    "title": "Renovate Church",
+    "content": "renovate church\n\nwebsite: renovateslo.com\nlocation: 2075 johnson ave., slo map \nphone: 805-543-0945\nemail: office@renovateslo.com\nhours (food pantry): m 4-6pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Renovate Church"
+    ]
+  },
+  {
+    "id": "Restoration-Church",
+    "title": "Restoration Church",
+    "content": "restoration church\n\nlocation: 9333 santa barbara rd., atascadero map \nphone: 805-538-0449 \nhours (food pantry): first saturday of the month, 1-3pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Restoration Church"
+    ]
+  },
+  {
+    "id": "Restorative-Partners",
+    "title": "Restorative Partners",
+    "content": "restorative partners\n\nwebsite: restorativepartners.org\nlocation: 3380 south higuera st., slo map \nphone: 805-242-1272 \nemail: info@restorativepartners.org\nhours: m-f 9am-5pm \nnotes:\noperates healing and restoration campus \noperates \"the bridge cafe\" \nlocation: 1074 higuera st., slo \nphone: 805-439-1689 \nemail: info@thebridgecafe.org \nhours: m-f 7am-3pm \n\n\noperates a housing program (restorativepartners.org/housing):\nanna's home (paso robles): supports 5 women and their children with employment support, job management, financial literacy, life skills, and permanent housing goals \nhope house (los osos): for returning women, offers 24/7 supervision, transportation, 12-step meetings, life skills training, mentorship, outpatient treatment \nrapha house (los osos): 8-bed home for men focusing on recovery from addiction, restorative justice practices, clean and sober lifestyle \nlyonheart place (san luis obispo): men's state parolee reentry housing program with joseph house and francis house providing clinically structured and supportive environment \nphone: 805-234-9074\nemail: housing@restorativepartners.org \nhow to access: contact restorative partners to get on the waiting list\n\n\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Restorative Partners"
+    ]
+  },
+  {
+    "id": "Ride-On-Transportation",
+    "title": "Ride-On Transportation",
+    "content": "ride-on transportation\n\nwebsite: ride-on.org\nlocation: 3620 sacramento dr. #201, slo map \nphone: 805-541-8747 \nemail: contact@ride-on.org \nmedi-cal shuttle a.k.a. cencal health transportation\nphone: 855-659-4600 (ventura transit system) \n\n\nveterans express shuttle\nphone: 805-541-8747 \n\n\nhours: m-f 6:30am-5:00pm (phone hours) \nhow to access: call, or submit a ride request online\n\n",
+    "type": "directory",
+    "aliases": [
+      "Ride-On Transportation",
+      "[CenCal Health Transportation](https://www"
+    ]
+  },
+  {
+    "id": "Rotating-Overnight-Safe-Parking-Program",
+    "title": "Rotating Overnight Safe Parking Program",
+    "content": "rotating overnight safe parking program\n\nsee 40 prado homeless services center\n\n\nwebsite: capslo.org/safe-parking\nlocation: (various; apply at 40 prado rd., slo map)\nphone:\n805-544-4004 (main 40 prado)\n805-440-6168 (cecil hale, safe parking inquiries)\n\n\nhow to access: must first complete intake at 40 prado homeless services center, then you are referred to the rotating program on a case-by-case basis\nhours: 7pm-7am overnight only\n\n",
+    "type": "directory",
+    "aliases": [
+      "Rotating Overnight Safe Parking Program"
+    ]
+  },
+  {
+    "id": "RVs-for-Veterans",
+    "title": "RVs for Veterans",
+    "content": "rvs for veterans\n\nphone: 805-234-5478 \nnote: a project of hope's village\n\n",
+    "type": "directory",
+    "aliases": [
+      "RVs for Veterans"
+    ]
+  },
+  {
+    "id": "Second-Chances-Thrift-Store",
+    "title": "Second Chances Thrift Store",
+    "content": "second chances thrift store\n\nwebsite: captivehearts.org/second-chances-store.html\nlocation: 892 w. grand ave., grover beach map \nphone: 805-202-8800 \nhours: m-sa 10am-4:30pm \nnotes: operated by captive hearts \n\n",
+    "type": "directory",
+    "aliases": [
+      "Second Chances Thrift Store"
+    ]
+  },
+  {
+    "id": "SAFE-Family-Resource-Centers",
+    "title": "SAFE Family Resource Centers",
+    "content": "safe family resource centers\n\nwebsite: capslo.org/s-a-f-e-family-resource-centers\n\n\n\n\n\nlocation\nphone\n\n\n\n1511 19th st., oceano map\n805-474-3690\n\n\n1086 grand ave., arroyo grande map\n805-474-2105\n\n\n920 w. tefft st., nipomo map\n805-474-3000 x5147\n\n\n\nemail: southcountysafe@capslo.org \nhow to access: walk-ins ok; appointments preferred.\nnote:\noperated by community action partnership san luis obispo (capslo)\nsee also link family resource center\nsee also north county family resource center\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SAFE Family Resource Centers"
+    ]
+  },
+  {
+    "id": "St-Barnabas-Thrift-Shop",
+    "title": "St. Barnabas Thrift Shop",
+    "content": "st. barnabas thrift shop\n\nwebsite: saintbarnabas-ag.org/get-involved/thrift-shop\nlocation: 1328 grand ave. #f, grover beach map \nphone: 805-270-4023 \nemail: stbarnabasthriftstore@gmail.com \nhours: tu-f 10am-4pm, sa noon-4pm \n\"bag day\" sale on the last friday of the month\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "St. Barnabas Thrift Shop"
+    ]
+  },
+  {
+    "id": "St-Josephs-Church",
+    "title": "Saint Joseph’s Church",
+    "content": "saint joseph's church\n\nwebsite: stjosephcayucos.org\nlocation: 360 park ave., cayucos map \nphone: 805-995-3243 \nemail: stjosephcayucos@charter.net \nhours (food pantry): fridays 10am-noon, or thursdays by appointment\n\n",
+    "type": "directory",
+    "aliases": [
+      "Saint Joseph’s Church"
+    ]
+  },
+  {
+    "id": "St-Patricks-Church",
+    "title": "Saint Patrick’s Church",
+    "content": "saint patrick's church\n\nwebsite: stpatsag.org\nlocation: 501 fair oaks ave., arroyo grande map \nphone: 805-489-2680 \n\n\n\nemail: info@stpatsag.org \nhours:\noffice: m/tu/th 9am-5pm (closed noon-1:30pm), w 9:30am-5pm (closed noon-1:30pm) \nfood pantry: tu/w/th 4-5pm\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Saint Patrick’s Church"
+    ]
+  },
+  {
+    "id": "St-Patricks-Shamrock-Thrift",
+    "title": "St. Patrick’s Shamrock Thrift",
+    "content": "st. patrick's shamrock thrift\n\nlocation: 924 w. grand ave., grover beach map \nphone: 805-481-0612 \nhours: tu-sa 10am-4pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "St. Patrick’s Shamrock Thrift"
+    ]
+  },
+  {
+    "id": "Salvation-Army",
+    "title": "Salvation Army",
+    "content": "salvation army\n\nwebsite: salvationarmyusa.org/usa-western-territory\nsanluisobispo.salvationarmy.org\n\n\n\n\n\n\nlocation\nphone\nfood pantry\nnotes\n\n\n\n815 islay st., slo map \n805-544-2401 \nw/f 10am-noon, th. 2-4pm \noperates a \"rapid rehousing program\"\n\n\n1550 w. branch st., arroyo grande map \n805-481-0278 \nm/w/f 10am-2pm\n\n\n\n8420 el camino real map\n805-466-7201 \n\n\n\n\n540 quintana rd., morro bay map\n805-772-7062 \n\n(was temporarily closed as of september 2025) \n\n\n711 paso robles st., paso robles map \n805-238-9591 \n\n(was temporarily closed as of september 2025) \n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Salvation Army"
+    ]
+  },
+  {
+    "id": "San-Luis-Coastal-Adult-School",
+    "title": "San Luis Coastal Adult School",
+    "content": "san luis coastal adult school\n\nwebsite: ae.slcusd.org\nlocation: 1500 lizzie st., slo map \nphone: 805-549-1222 \nemail: adultschool@slcusd.org\nhow to access:\nregister for classes on-line at slcusd.asapconnected.com\nor, come to the office during business hours\nor, call during business hours\n\n\nnote:\nhosts \"san luis obispo family resource center\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "San Luis Coastal Adult School"
+    ]
+  },
+  {
+    "id": "SLO-College-of-Law-Legal-Clinic",
+    "title": "San Luis Obispo College of Law Legal Clinic",
+    "content": "san luis obispo college of law legal clinic\n\nwebsite: montereylaw.edu/clinics/indexslocl.html\nlocation: 4119 broad st. #200, slo map\nphone: 805-902-crla \nemail: mclworkshops@montereylaw.edu\nhours: m-th 9am-3pm (scheduling); consultations tu 4:30-6:30pm\nhow to access: telephone or zoom appointments only \n\n",
+    "type": "directory",
+    "aliases": [
+      "San Luis Obispo College of Law Legal Clinic"
+    ]
+  },
+  {
+    "id": "Cal-Poly-Community-Counseling-Service",
+    "title": "San Luis Obispo Counseling Service at Cal Poly",
+    "content": "san luis obispo counseling service at cal poly\n\nsee also community counseling center\n\n\nwebsite: slocounselingservice.calpoly.edu/about\nlocation: cotchett education bldg. 2, room 125, cal poly slo map \nphone: 805-756-1532 \nhow to access: no walk-ins; call to make an appointment. \n\n",
+    "type": "directory",
+    "aliases": [
+      "San Luis Obispo Counseling Service at Cal Poly",
+      "**Community Counseling Center**"
+    ]
+  },
+  {
+    "id": "SLO-Veterans-Services-Collaborative",
+    "title": "San Luis Obispo Veterans Services Collaborative",
+    "content": "san luis obispo veterans services collaborative\n\nwebsite: slocvsc.org\nphone:\n805-610-0934 { source: https://www.slocvsc.org/contact-us }\n805-270-2988 { source: https://www.facebook.com/slovsc/ }\n\n\nemail: slovsc1@gmail.com { source: https://www.facebook.com/slovsc/ }\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "San Luis Obispo Veterans Services Collaborative"
+    ]
+  },
+  {
+    "id": "Santa-Margarita-KOA-Holiday",
+    "title": "Santa Margarita KOA Holiday",
+    "content": "santa margarita koa holiday\n\nwebsite: koa.com/campgrounds/santa-margarita\nlocation: 4765 santa margarita lake rd., santa margarita map \nphone: 805-438-5618 \nemail: santamargarita@koa.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Santa Margarita KOA Holiday"
+    ]
+  },
+  {
+    "id": "Santa-Margarita-Lake-Recreation-Area",
+    "title": "Santa Margarita Lake Recreation Area",
+    "content": "santa margarita lake recreation area\n\nwebsite: slocountyparks.com/camp/santa-margarita-lake/\nphone: 805-788-2397 \nemail: sloparks@co.slo.ca.us\n\n",
+    "type": "directory",
+    "aliases": [
+      "Santa Margarita Lake Recreation Area"
+    ]
+  },
+  {
+    "id": "Santa-Margarita-Senior-Center",
+    "title": "Santa Margarita Area Senior Citizens Club",
+    "content": "santa margarita area senior citizens club\n\nlocation: 22202 \"h\" st., santa margarita map\nnote: some maps show the address as 2201 \"h\" st.\n\n\nphone:\n805-438-5854\n805-438-3482 \n\n\nnotes:\na lunch service site for meals that connect\na slo food bank neighborhood food distribution site\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Santa Margarita Area Senior Citizens Club"
+    ]
+  },
+  {
+    "id": "Santa-Maria-Valley-Hispanic-Church",
+    "title": "Santa Maria Valley Hispanic SDA Church",
+    "content": "santa maria valley hispanic sda church\n\nwebsite: santamariavalleyhispanicca.adventistchurch.org\nlocation: 1575 orchard rd., nipomo map \nphone: 805-929-5694 \nhours (food pantry): sa 11am-12:30pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Santa Maria Valley Hispanic SDA Church"
+    ]
+  },
+  {
+    "id": "Seneca-Central-Coast",
+    "title": "Seneca Central Coast",
+    "content": "seneca central coast\n\nwebsite: senecafoa.org/regions/central-coast\nlocation: 6850 morro rd., atascadero map \nphone: 805-434-2449 \nemail: info@senecacenter.org \nnotes:\nformerly called \"kinship center\"\noffers enhanced care management \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Seneca Central Coast"
+    ]
+  },
+  {
+    "id": "Senior-Connection",
+    "title": "Senior Connection",
+    "content": "senior connection\n\nwebsite: centralcoastseniors.org/senior-connection\nlocation: 528 s. broadway, santa maria map \nphone:\n800-510-2020 \n805-928-2552 \n805-928-9554 \n\n\nemail: info@centralcoastseniors.org\nhours: m-f 8am-5pm \nhow to access: walk-ins ok.\n\n",
+    "type": "directory",
+    "aliases": [
+      "Senior Connection"
+    ]
+  },
+  {
+    "id": "Senior-Go",
+    "title": "Senior Go!",
+    "content": "senior go!\n\nwebsite: sloseniorgo.org\nlocations: throughout slo county \nphone: 805-473-3333 \nhours: m-f 9am-5pm, sa 10am-3pm (closed major holidays) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Senior Go!"
+    ]
+  },
+  {
+    "id": "Senior-Legal-Services-Project",
+    "title": "Senior Legal Services Project",
+    "content": "senior legal services project\n\nlocation:\n3232 s. higuera st. #101d, slo map \n102 s. vine st. #c, paso robles map \nalso operates clinics at various senior centers and similar sites\n\n\nphone: 805-543-5140 \nemail: intake@slolaf.org \nhours: m-f 8:30am-5pm\nnote: a project of slo legal assistance foundation (slolaf)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Senior Legal Services Project"
+    ]
+  },
+  {
+    "id": "SESLOC-Credit-Union",
+    "title": "SESLOC Credit Union",
+    "content": "sesloc credit union\n\nwebsite: sesloc.org\nlocations:\n1399 grand ave., arroyo grande map \n8380 el camino real, atascadero map \n1 grand ave. bldg. 65, cal poly map (closed during academic break periods) \n705 golden hill rd., paso robles map \n3807 broad st., slo map \n\n\nphone: 805-543-1816 \nhours: m-f 9am-5pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "SESLOC Credit Union"
+    ]
+  },
+  {
+    "id": "Shower-the-People",
+    "title": "Shower the People",
+    "content": "shower the people\n\nwebsite: showerthepeopleslo.org\n\n\n\n\n\nlocation\nhours\n\n\n\n946 rockaway ave., grover beach map\nw 10am-1pm\n\n\n2201 lawton ave., slo           map\ntu & th 10am-1pm\n\n\n11245 los osos valley rd., slo  map\nsa 10am-1pm\n\n\n995 palm st., slo               map\nsu 12:30-3:30pm\n\n\n\nemail: showerthepeopleslo@gmail.com\nnote: hosted by lifepoint church and unitarian universalists san luis obispo among others\n\n",
+    "type": "directory",
+    "aliases": [
+      "Shower the People"
+    ]
+  },
+  {
+    "id": "Silver-City-Resort",
+    "title": "Silver City Resort",
+    "content": "silver city resort\n\nwebsite: silvercitymorrobay.com\nlocation: 500 atascadero rd., morro bay map \nphone: 805-772-7478 \nemail: silvercity@dmhllc.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "Silver City Resort"
+    ]
+  },
+  {
+    "id": "SLO4Home",
+    "title": "SLO for HOME",
+    "content": "slo for home\n\nwebsite: sloforhome.org\nmailing address: p.o. box 3901, slo, ca 93403 \nemail: info@sloforhome.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO for HOME"
+    ]
+  },
+  {
+    "id": "SLO-Bangers",
+    "title": "SLO Bangers",
+    "content": "slo bangers\n\nwebsite: slobangers.com\n\n\n\n\n\nlocation\nhours\n\n\n\n6370 atascadero ave., atascadero map\nsu 4-6pm\n\n\n760 morro bay blvd., morro bay map\nm 2-4pm\n\n\n1134 black oak dr., paso robles map\ntu 4:30-5:30pm\n\n\n2191 johnson ave., slo map\nw 5:30-8:15pm\n\n\n\nphone: 805-458-0123 \nemail: slobangers07@gmail.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Bangers"
+    ]
+  },
+  {
+    "id": "SLO-Cal-Careers-Center",
+    "title": "SLO Cal Careers Center",
+    "content": "slo cal careers center\n\nwebsite: slocalcareers.org\nlocations:\n3563 empleo street, slo map\nyouth services: 3450 broad st. #103a, slo map\n\n\nphone: 805-439-2557\nemail:\nslocal@eckerd.org\ninfo@slocalcareers.org\n\n\nhours: m-f 9am-4pm\nnotes:\na.k.a. \"america's job center of california\"\nformerly \"business and career one stop\"\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Cal Careers Center",
+      "“America’s Job Center of California”"
+    ]
+  },
+  {
+    "id": "SLOCOG",
+    "title": "SLO Council of Governments (SLOCOG)",
+    "content": "slo council of governments (slocog)\n\nwebsite: slocog.org\nlocation: 1114 marsh street, slo map { source: https://www.slocog.org/ }\nphone: 805-781-4219 { source: https://www.slocog.org/contact-page }\nemail: slocog@slocog.org { source: https://www.slocog.org/contact-page }\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Council of Governments (SLOCOG)"
+    ]
+  },
+  {
+    "id": "SLO-County-Animal-Services",
+    "title": "SLO County Animal Services",
+    "content": "slo county animal services\n\nwebsite: slocounty.ca.gov/departments/health-agency/animal-services\nlocation: 885 oklahoma ave., slo map \nphone:\n805-781-4400 (main office) \n805-781-4407 (found animal recording) \n\n\nhours:\noffice: m/tu/th/f 8am-5pm, w 8am-7pm; sa 9am-5pm \nkennel: m/tu/th/f/sa 1pm-5pm; w 1pm-7pm \n\n\nhow to access: call to make an appointment\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Animal Services"
+    ]
+  },
+  {
+    "id": "SLO-County-Bar-Association",
+    "title": "SLO County Bar Association Lawyer Referral and Information Service",
+    "content": "slo county bar association lawyer referral and information service\n\n\nwebsite: slobarlris.org\nmailing address: p.o. box 585, slo, ca 93406 \nphone: 805-541-5502 \nemail: lris@slobar.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Bar Association Lawyer Referral and Information Service"
+    ]
+  },
+  {
+    "id": "SLO-County-Behavioral-Health",
+    "title": "SLO County Behavioral Health",
+    "content": "slo county behavioral health\n\nwebsite: slocounty.ca.gov/departments/health-agency/behavioral-health\nlocations:\nmain office: 2180 johnson ave., slo map - 800-838-1381 \narroyo grande: 1350 grand ave. map - 805-474-2154 \nservices affirming family empowerment: 1086 e. grand ave., arroyo grande map - 805-474-2105 \n\n\natascadero health campus: 5575 hospital dr. map - 805-461-6060 (adult mental health), 805-461-6113 (youth mental health), 805-461-6080 (adult drug and alcohol services) \ngrover beach:\nyouth & adult drug and alcohol services: 1523 longbranch ave. map - 805-473-7080 \nyouth mental health services: 1666 ramona ave. map - 805-473-7060 \n\n\npaso robles health campus: 805 4th st. map - 805-237-3090 (adult mental health), 805-237-3070 (youth mental health), 805-226-3200 (adult drug and alcohol services) \nslo:\nadult drug and alcohol services: 2180 johnson ave. map - 805-781-4275 \nadult mental health services: 2178 johnson ave. map - 805-781-4700 \nyouth drug and alcohol services: 277 south st. #t, slo map - 805-781-4754 \nyouth mental health services: 2975 mcmillan suite 160 map - 805-781-4179 \npsychiatric health facility: 2178 johnson ave. map - 800-838-1381 \nmartha's place children's center (ages 0-5): 2925 mcmillan ave. suite 108 map - 805-781-4948 \nprevention and outreach services: 277 south st. #t, slo map - 805-781-4754 \nslo sobering center: 2180 johnson ave. map - 820-280-0415 \n\n\n\n\nphone:\nbehavioral health access line: 800-838-1381 \nlocal mental health crisis hotline: 800-783-0607 \npatient's rights advocate: 805-781-4738\n\n\nhours: m-f 8am-5pm (closed noon-1pm for lunch) \ncost: \"no clients are denied access to services due to inability to pay. discounted fees and sliding fee schedules are available based on family size and income.\" \nnotes:\noperates slo county drug and alcohol services\ngenoa pharmacy is the on-site pharmacy for slo county behavioral health\ncan refer you to the \"supported employment\" program\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Behavioral Health"
+    ]
+  },
+  {
+    "id": "SLO-County-Clerk-Recorder",
+    "title": "SLO County Clerk-Recorder",
+    "content": "slo county clerk-recorder\n\nwebsite: slocounty.ca.gov/departments/clerk-recorder\nlocations:\n6565 capistrano ave., second floor, atascadero map \n1055 monterey st. #d120, slo map \n\n\nphone:\n805-781-5080 \n805-461-6041 (north county office) \n\n\nhours: slo office only: m/tu/th/f 8am-5pm, w 8am-4pm (transactions end 30 minutes before closing) \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Clerk-Recorder"
+    ]
+  },
+  {
+    "id": "SLO-County-Department-of-Social-Services",
+    "title": "SLO County Department of Social Services",
+    "content": "slo county department of social services\n\nwebsite: slocounty.ca.gov/departments/social-services\n\n\n\n\n\nlocation\nphone\n\n\n\n1086 e. grand ave., arroyo grande map\n805-474-2000\n\n\n9630 el camino real, atascadero map\n805-461-6000\n\n\n600 quintana rd., morro bay map\n805-772-6405\n\n\n681 w. tefft st. #1, nipomo map\n805-931-1800\n\n\n406 spring st., paso robles map\n805-237-3110\n\n\n3433 s. higuera, slo map\n805-781-1600\n\n\n\nhours: m-f 8am-5pm (4pm-5pm by appointment only) \nnotes:\noperates calworks homeless assistance program\noperates \"general assistance disabled program\"\noperates \"general relief / general assistance\"\noperates \"temporary assistance for needy families (tanf)\"\nentry-point for \"calfresh / ebt (food stamps)\"\nentry-point for the coordinated entry system (ces)\nentry-point for the housing support program (hsp)\nentry-point for the medically fragile homeless program\ncan refer you to the child care resource connection\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Department of Social Services"
+    ]
+  },
+  {
+    "id": "SLO-County-Drug-and-Alcohol-Services",
+    "title": "SLO County Drug and Alcohol Services",
+    "content": "slo county drug and alcohol services\n\nwebsite: slocounty.ca.gov/departments/health-agency/behavioral-health/drug-and-alcohol-services\n\n\n\n\n\nlocation\nphone\nwalk-in hours\n\n\n\n1523 longbranch ave., grover beach map\n805-473-7080 or 805-473-7081\nmo,fr 8am-11am; tu 2:30-5:30pm\n\n\n805 e. 4th street, paso robles map\n805-226-3200\nmo,th 8am-11am; tu 2:30-5:30pm\n\n\n2180 johnson ave., slo map - for adults\n805-781-4275\ntu,we 8am-11am; th 2:30-5:30pm\n\n\n277 south st. #t, slo map - for youth & veterans\n805-781-4754\nm-f 8am-5pm\n\n\n\n\n\nphone: 800-838-1381 (main access line)\nhours: m-f 8am-5pm\nhow to access: walk-ins ok (see hours above), or call the main access line to make an appointment\nnotes:\noperated by slo county behavioral health\natascadero clinic closed as of july 1, 2025 (use paso robles clinic instead)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Drug and Alcohol Services"
+    ]
+  },
+  {
+    "id": "SLO-County-Health-Department",
+    "title": "SLO County Health Department",
+    "content": "slo county health department\n\nsee also slo county public health department\n\n\nnote: entry-point for the coordinated entry system (ces)\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Health Department",
+      "**SLO County Public Health Department**"
+    ]
+  },
+  {
+    "id": "SLO-County-Law-Library",
+    "title": "SLO County Law Library",
+    "content": "slo county law library\n\nwebsite: slocll.org\nlocation: 1050 monterey st., room 125, slo map \nphone: 805-781-5855 \nemail: info@slocll.org \nhours: m-w 9am-4pm, th.-f 8:30am-1:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Law Library"
+    ]
+  },
+  {
+    "id": "SLO-County-Mental-Health-Services",
+    "title": "SLO County Mental Health Services",
+    "content": "slo county mental health services\n\nwebsite: slocounty.ca.gov/departments/health-agency/behavioral-health\n\n\n\n\n\nserves\nlocation\nphone\n\n\n\nadults\n1350 e. grand ave. , arroyo grandemap\n805-474-2154\n\n\nyouths\n354 s. halcyon rd., arroyo grande map\n805-473-7060\n\n\nyouths\n1666 ramona ave., grover beach map\n805-473-7060\n\n\nadults\n2178 johnson ave., slo map\n805-781-4700\n\n\nyouths\n2975 mcmillan ave. suite 160, slo map\n805-781-4179\n\n\nchildren\n2925 mcmillan ave. suite 108, slo map\n805-781-4948\n\n\n\nphone: 800-838-1381 (24hr) / 805-540-6500\nhours: m-f 8am-5pm\nhow to access:\nwalk-ins ok at the arroyo grande adult clinic m/w 9-11am and at the slo adult clinic tu/th 1-4:30pm \nfor youths and children, call to make an appointment\n\n\nnotes:\ncentral access point for all medi-cal mental health services\ncan refer you to the \"supported employment\" program\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Mental Health Services"
+    ]
+  },
+  {
+    "id": "SLO-County-Office-of-Emergency-Services",
+    "title": "SLO County Office of Emergency Services",
+    "content": "slo county office of emergency services\n\nwebsite: slocounty.ca.gov/departments/administrative-office/office-of-emergency-services\nlocation: 1055 monterey st. #d430, slo map \nphone: 805-781-5678 \nemail: oes@co.slo.ca.us \nnotes: for emergency alert signup, visit alertslo.org or prepareslo.org\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Office of Emergency Services"
+    ]
+  },
+  {
+    "id": "SLO-County-Parks",
+    "title": "SLO County Parks",
+    "content": "slo county parks\n\nwebsite: slocountyparks.com\nlocation: 1144 monterey st. #a, slo map \nphone: 805-781-5930 \nemail: sloparks@co.slo.ca.us \nsee also:\ncoastal dunes rv park & campground\nel chorro regional park campground\nlopez lake recreation area\noceano campground\nsanta margarita lake recreation area\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Parks"
+    ]
+  },
+  {
+    "id": "SLO-County-Public-Health-Department",
+    "title": "SLO County Public Health Department",
+    "content": "slo county public health department\n\nsee also slo county health department\n\n\nwebsite: slocounty.ca.gov/departments/health-agency/public-health\nlocation:\n2180 johnson ave, slo map \n2191 johnson ave, slo map \n805 4th st., paso robles map \n\n\nphone:\n805-788-2903 (24-hour info line) \n805-781-5506 (to make an appointment) \n805-237-3050 (paso robles) \n\n\nhours: m-f 8am-5pm (closed noon-1pm) \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Public Health Department",
+      "**SLO County Health Department**"
+    ]
+  },
+  {
+    "id": "SLO-County-Public-Libraries",
+    "title": "SLO County Public Libraries",
+    "content": "slo county public libraries\n\nwebsite: slolibrary.org\n\n\n\n\nlocation\nphone\nhours\n\n\n\narroyo grande: 800 w. branch st. map \n805-473-7161\ntu/w 1-6pm, f/sa 1-5pm\n\n\natascadero: 6555 capistrano ave. map\n805-461-6161\ntu/w 10am-6pm, th/sa 9am-5pm, f 1-5pm\n\n\ncambria: 1043 main st. map\n805-927-4336\ntu/w 10am-6pm, th 9am-5pm, f 1-5pm, sa 9am-1pm\n\n\ncayucos: 310 b st. map\n805-995-3312\ntu/w 9am-5pm (closed noon-1pm)\n\n\ncreston: 6290 adams st. map\n805-237-3010\ntu 1-6pm, w/th noon-5pm\n\n\nlos osos: 2075 palisades ave. map\n805-528-1862\ntu/w 10am-6pm, th 9am-5pm, f/sa 1-5pm\n\n\nmorro bay: 625 harbor st. map\n805-772-6394\ntu/w 10am-6pm, th 9am-5pm, f 1-5pm, sa 9am-1pm\n\n\nnipomo: 918 w. tefft st. map\n805-929-3994\ntu/w/th 10am-6pm, f/sa 10am-5pm\n\n\noceano: 1511 19th st. map\n805-474-7478\ntu/w/th 9am-1pm and 2-5pm\n\n\nslo: 995 palm st. map\n805-781-5991\ntu/w 10am-6pm, th/sa 9am-5pm, f 1-5pm\n\n\nsan miguel: 254 13th st. map\n805-467-3224\nw 11am-6pm (closed 12:30-1pm), th 10am-5pm (closed 12:30-1pm), f 1-5pm, sa 10am-5pm (closed 12:30-1pm)\n\n\nsanta margarita: 9630 murphy ave. map\n805-438-5622\ntu/w 10am-6pm (closed 12:30-1pm), sa 9am-5pm (closed 12:30-1pm)\n\n\nshandon: 195 n. 2nd st. map\n805-237-3009\ntu/w 10am-6pm (closed 12:30-1pm), sa 9am-5pm (closed 12:30-1pm)\n\n\nshell beach: 230 leeward ave. map\n805-773-2263\ntu/w 10am-1pm and 2-6pm, sa 9am-5pm\n\n\n\nnote: transitions mental health association (tmha) has a \"library outreach team\" that connects library patrons who are experiencing homelessness with a social worker and case manager to help them overcome barriers to accessing crucial social services. you can meet the library outreach team at the following library branches (this schedule is subject to change; contact mvargas@t-mha.org for the most up-to-date schedule):\n\natascadero: w 10:30am-noon\narroyo grande: th 9:30-11am\nlos osos: f 1-2:30pm\nmorro bay: th. 12:30-2pm\nslo: tu 10-11:30am & 2:30-4pm\n\nyou can also make an appointment to meet with the team by calling 805-540-0057\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Public Libraries"
+    ]
+  },
+  {
+    "id": "SLO-County-Small-Claims-Advisor",
+    "title": "SLO County Small Claims Advisor",
+    "content": "slo county small claims advisor\n\nlocation: county government center room 223, slo map\nphone: 805-781-5856\nhours: m-f 9am-12pm\nhow to access: no appointment necessary\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County Small Claims Advisor"
+    ]
+  },
+  {
+    "id": "SLO-County-UndocuSupport",
+    "title": "SLO County UndocuSupport",
+    "content": "slo county undocusupport\n\nwebsite: sloundocusupport.org\nlocation: 981 marsh st., slo map\nphone:\n805-543-5451\n805-549-8989 (hotline)\n\n\nemail: undocusupport@cfsloco.org\nhours: w 1-4:15pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County UndocuSupport"
+    ]
+  },
+  {
+    "id": "SLO-County-YMCA",
+    "title": "SLO County YMCA",
+    "content": "slo county ymca\n\nwebsite: ciymca.org/locations/san-luis-obispo-county-ymca\nopen doors scholarship application for people with low incomes\n\n\nlocation: 1020 southwood dr., slo map \nphone: 805-543-8235 \nemail: slo.info@ciymca.org\nhours: m-th 5:30am-9pm, f 5:30am-7pm, sa 7am-5pm, su closed \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO County YMCA"
+    ]
+  },
+  {
+    "id": "SLO-Court-Self-Help-Services",
+    "title": "SLO Court Self-Help Services",
+    "content": "slo court self-help services\n\nwebsite: slo.courts.ca.gov/self-help\nlocation: 1050 monterey st., room 220, slo map\nphone: 805-706-3617 \nhours: m-f 8:30am-4:30pm \nhow to access: phone, or make an appointment at calendly.com/self-help-center \nnotes: includes \"family law facilitator\" and \"self-help center\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Court Self-Help Services"
+    ]
+  },
+  {
+    "id": "SLO-Credit-Union",
+    "title": "SLO Credit Union",
+    "content": "slo credit union\n\nwebsite: slocu.com\nlocation: 1220 osos st., slo map \nphone: 805-543-5839 \nhours: m-f 9am-4:30pm (lobby closed noon-2pm) \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Credit Union"
+    ]
+  },
+  {
+    "id": "SLO-Food-Bank",
+    "title": "SLO Food Bank",
+    "content": "slo food bank\n\nwebsite: slofoodbank.org\nlocation: 1180 kendall rd., slo map \nalso has many food distribution sites around slo county\n\n\nphone: 805-238-4664 \nhours: m-f 9:30am-4pm \nfood pantry: m/w/f noon-5pm \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Food Bank"
+    ]
+  },
+  {
+    "id": "SLO-Grassroots",
+    "title": "SLO Grassroots",
+    "content": "slo grassroots\n\nwebsite: slograssroots.org\nphone: 805-540-1455 \nemail: info@slograssroots.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Grassroots"
+    ]
+  },
+  {
+    "id": "SLO-Hub",
+    "title": "SLO Hub",
+    "content": "slo hub\n\nsee also: 40 prado homeless services center\n\n\nwebsite: capslo.org/slo-hub\nlocation: 40 prado rd., slo map\nphone: 805-441-6589 \nemail: sreyes@capslo.org \nhours: m-f 9am-5pm\nhow to access: by appointment only\nnotes: a collaboration between capslo and restorative partners \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Hub"
+    ]
+  },
+  {
+    "id": "SLO-Legal-Assistance-Foundation",
+    "title": "SLO Legal Assistance Foundation (SLOLAF)",
+    "content": "slo legal assistance foundation (slolaf)\n\nwebsite: slolaf.org\nlocations:\n3232 s. higuera st. #101d, slo map \n102 s. vine st. #c, paso robles map \n\n\nphone: 805-543-5140 \nemail: info@slolaf.org \nnotes:\noperates senior legal services project\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Legal Assistance Foundation (SLOLAF)"
+    ]
+  },
+  {
+    "id": "SLO-Noor-Foundation",
+    "title": "SLO Noor Foundation",
+    "content": "slo noor foundation\n\nwebsite: slonoorfoundation.org\nprimary clinics\nlocations:\n1428 phillips lane #203, slo map \n400 oak hill rd., paso robles map\n\n\nphone: 805-439-1797 \nemail: info@slonoorfoundation.org \nhours: slo m-th 8am-5pm; paso robles w 8am-5pm \n\n\nvision clinic\nlocation: 1428 phillips lane #203, slo map \nphone: 805-439-1797 \nemail: info@slonoorfoundation.org \n\n\ndental care clinic\nlocation: 3071 s. higuera st. #110, slo map \nphone: 805-592-2240 \nemail: dental@slonoorfoundation.org \n\n\nwomen's mobile health unit\nphone: 805-756-5089 \nemail: ccmacedo@calpoly.edu \n\n\nprimary mobile health unit\nphone: 805-439-1797 \nlocations: atascadero, nipomo, oceano, paso robles \n\n\nhow to access:\nby appointment only\nbring proof of income and a copy of your most recent income tax return to your first appointment\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Noor Foundation"
+    ]
+  },
+  {
+    "id": "SLO-Partners",
+    "title": "SLO Partners",
+    "content": "slo partners\n\nwebsite: slopartners.org\nlocation: 3350 education dr. slo map \nphone: 805-782-7372 \nemail: info@slopartners.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Partners"
+    ]
+  },
+  {
+    "id": "SLO-Public-Defenders",
+    "title": "SLO Public Defenders",
+    "content": "slo public defenders\n\nwebsite: slodefend.com\nlocation: 991 osos street #a, slo map \nphone: 805-541-5715 \nhours: m-th 8:30am-noon & 1pm-5pm; f 8:30am-noon & 1pm-4pm \nhow to access: appear at first court hearing and ask judge to appoint attorney; meetings by appointment only\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Public Defenders"
+    ]
+  },
+  {
+    "id": "SLO-RTA",
+    "title": "SLO Regional Transit Authority",
+    "content": "slo regional transit authority\n\nwebsite: slorta.org\nlocation: 253 elks lane, slo map (offices) \nphone: 805-781-4472\ninfo/dispatch: 805-541-2228 \naccess program (reduced fares for people with low incomes): 805-541-8797\nrunabout paratransit: 805-781-4833\n\n\nemail: info@slorta.org \nhours (office): m-th 8am-4pm; friday by appointment only \nnotes: also operates \"runabout paratransit,\" senior go! shuttle, and \"dial-a-ride\"\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Regional Transit Authority"
+    ]
+  },
+  {
+    "id": "SLO-Senior-Center",
+    "title": "SLO Senior Center",
+    "content": "slo senior center\n\n\nwebsite: slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs\nlocation: 1445 santa rosa st., slo map \nphone: 805-781-7306 \nhours: m-f 9am-4pm \nmembership: open to slo city residents 55+; includes monthly newsletter, center access, free coffee\nnotes:\npart of city of slo parks and recreation\nhosts hicap (thursdays noon-3:30pm by appointment)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Senior Center"
+    ]
+  },
+  {
+    "id": "SLO-Sobering-Center",
+    "title": "SLO Sobering Center",
+    "content": "slo sobering center\n\nwebsite: slocounty.gov/soberingcenter\nlocation: 2180 johnson ave., slo map \nphone: 820-280-0415 \nhours: 24/7 \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Sobering Center"
+    ]
+  },
+  {
+    "id": "SLO-Superior-Court",
+    "title": "SLO Superior Court",
+    "content": "slo superior court\n\nwebsite: slo.courts.ca.gov\nlocations:\ncivil & family law branch: 1050 monterey st. rm 220, slo map \ncriminal branch: 1050 monterey st. rm 220, slo map \ngrover beach branch: 214 s. 16th st., grover beach map \njuvenile services center: 1050 monterey st., slo map \njuvenile justice (delinquency): 1065 kansas ave., slo map \npaso robles branch: 901 park st., paso robles map \nveteran's memorial branch: 801 grand ave., slo map (temporarily closed as of december 2025) \n\n\nphone: 805-706-3600 (civil & family law branch and criminal branch)\nhours:\nphone: m-f 8:30am-noon\ncounter: m-th 8:30am-noon (juvenile justice, m 8am only; paso robles branch w/f 8:30am-noon)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Superior Court"
+    ]
+  },
+  {
+    "id": "SLO-Thrift",
+    "title": "SLO Thrift",
+    "content": "slo thrift\n\nwebsite: slothrift.com\nlocation: 445 higuera st., slo map \nphone: 805-439-4434 \nhours: m-sa 9am-5pm \nnote: not yet open as of november 2025 (being remodeled)\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Thrift"
+    ]
+  },
+  {
+    "id": "SLO-Transit",
+    "title": "SLO Transit",
+    "content": "slo transit\n\nwebsite: slocity.org/government/department-directory/public-works/slo-transit-bus\nlocation (office): 1260 chorro st. #b, slo map \nphone:\n805-594-8090 (main office) \n805-541-2877 (dispatch) \n\n\nemail: slotransit@slocity.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Transit"
+    ]
+  },
+  {
+    "id": "SLO-Vet-Center",
+    "title": "SLO Vet Center",
+    "content": "slo vet center\n\nwebsite: va.gov/san-luis-obispo-vet-center\nlocation: 1070 southwood dr., slo map \nphone: 805-782-9101 \n24/7: 877-927-8387 \n\n\nhours: m-f 8am-4:30pm \nhow to access: call to make an appointment\n\n",
+    "type": "directory",
+    "aliases": [
+      "SLO Vet Center"
+    ]
+  },
+  {
+    "id": "SmartShare-Housing-Solutions",
+    "title": "SmartShare Housing Solutions",
+    "content": "smartshare housing solutions\n\nwebsite: smartsharehousingsolutions.org\nmailing address: po box 15034, slo, ca 93406 \nphone: 805-215-5474 \nemail: info@smartsharehousingsolutions.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "SmartShare Housing Solutions"
+    ]
+  },
+  {
+    "id": "Social-Security-Administration",
+    "title": "Social Security Administration",
+    "content": "social security administration\n\nwebsite: ssa.gov\nlocation: 3240 s. higuera st., slo map \nphone: 855-207-4865 (tty: 800-325-0778)\nhours: m-f 9am-4pm \nhow to access: call to schedule an appointment\n\n",
+    "type": "directory",
+    "aliases": [
+      "Social Security Administration"
+    ]
+  },
+  {
+    "id": "Society-of-St-Vincent-de-Paul",
+    "title": "Society of Saint Vincent de Paul",
+    "content": "society of saint vincent de paul\n\nlocation: 751 palm st., slo map \nphone: 805-544-7041 \nhours:\ntuesdays at prado center (43 prado rd., slo map): 2-3:30pm \nthursdays at mission san luis obispo (751 palm st., slo map): by appointment only \n\n\nhow to access: drop-in at prado, or call to schedule an appointment at the mission\n\n",
+    "type": "directory",
+    "aliases": [
+      "Society of Saint Vincent de Paul"
+    ]
+  },
+  {
+    "id": "South-Bay-Community-Center",
+    "title": "South Bay Community Center",
+    "content": "south bay community center\n\nwebsite: southbaycommunitycenter.com\nlocation: 2180 palisades ave., los osos map\nphone: 805-528-4169 \nemail: sbcc@sbcommunitycenter.net \nhours: m/tu/f 1-4pm (office) \nnotes:\nhosts early risers a.a. meetings \nhosts meals that connect senior nutrition program \nhosts los osos cares community dinner \nsouth bay seniors people helping people operates their food bank and medical equipment loan program from this facility (m/w/f 9am-1pm) \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "South Bay Community Center"
+    ]
+  },
+  {
+    "id": "South-Bay-Seniors-People-Helping-People",
+    "title": "South Bay Seniors People Helping People",
+    "content": "south bay seniors people helping people\n\nwebsite: southbayseniorspeoplehelpingpeople.com\nlocation: 2180 palisades ave., los osos map \nphone: 805-528-2626 \nhours: m/w/f 9am-1pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "South Bay Seniors People Helping People"
+    ]
+  },
+  {
+    "id": "Steves-Recycling",
+    "title": "Steve’s Recycling",
+    "content": "steve's recycling\n\n\n\nlocation: 1130 los osos valley rd., los osos map \nphone: 805-801-1627 \nhours: sa 9am-11am \nnotes: crv recycling for cash (5¢ for containers <24oz, 10¢ for ≥24oz)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Steve’s Recycling"
+    ]
+  },
+  {
+    "id": "Sunny-Acres",
+    "title": "Sunny Acres",
+    "content": "sunny acres\n\"sunny acres\" may refer to two different locations in the city of slo:\n\na former orphanage in the hills above johnson avenue that is now \"bishop street studios\" operated by transitions mental health association (tmha)\na former sober living compound near laguna lake that is now the healing and restoration campus operated by restorative partners\n\n",
+    "type": "directory",
+    "aliases": [
+      "Sunny Acres"
+    ]
+  },
+  {
+    "id": "Sun-Street-Centers",
+    "title": "Sun Street Centers",
+    "content": "sun street centers\n\nwebsite: sunstreetcenters.org/counseling/san-luis-obispo-residential-program\nlocation: 34 prado rd., slo map \nphone: 805-457-3331 / 805-457-5150 \nemail: atorrente@sunstreet.org \nhours: 24/7 (intake: m-f 8am-5pm) \nhow to access: get a referral from slo county behavioral health, from your healthcare provider, or from your health insurer; you can also refer yourself \n\n",
+    "type": "directory",
+    "aliases": [
+      "Sun Street Centers"
+    ]
+  },
+  {
+    "id": "Supportive-Services-for-Veteran-Families",
+    "title": "Supportive Services for Veteran Families",
+    "content": "supportive services for veteran families\n\n\n5 cities:\nwebsite: 5chc.org/programs/ssvf-supportive-services-for-veteran-families\nlocation: 150 s. 6th st. #a-b, grover beach map \n\n \n\nphone: 805-574-1638 \nphone: 805-202-3056 \n\n\nnorth county:\nlocation: 935 riverside ave. #6, paso robles map \nphone: 805-237-0352 \nemail: jrogers@capslo.org\n\n\nslo:\nwebsite: capslo.org/ssvf\nlocation: 265 south st. #h, slo map \nphone: 805-534-1698 \nemail: jerwin@capslo.org\n\n\nnotes:\noperated by community action partnership san luis obispo \noperated by 5cities homeless coalition with good samaritan shelter\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Supportive Services for Veteran Families"
+    ]
+  },
+  {
+    "id": "Teen-Wellness",
+    "title": "Teen Wellness",
+    "content": "teen wellness\n\nwebsite: capslo.org/teen-programs-2\nphone: 805-602-2883 \nemail: teenwellness@capslo.org \nnotes:\na program of community action partnership san luis obispo (capslo)\nfocus on enhancing youth mental health in slo and northern santa barbara counties\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Teen Wellness"
+    ]
+  },
+  {
+    "id": "Templeton-Adult-School",
+    "title": "Templeton Adult School",
+    "content": "templeton adult school\n\nwebsite: templetonusd.org/schools/tae/tas\nlocation: 964 old country road, templeton map \nphone: 805-434-5827 \nemail: clondon@templetonusd.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Templeton Adult School"
+    ]
+  },
+  {
+    "id": "TMHA",
+    "title": "Transitions Mental Health Association (TMHA)",
+    "content": "transitions mental health association (tmha)\n\nwebsite: www.t-mha.org\n\n\n\n\noffice\nlocation\nphone\n\n\n\nmain\n784 high street, slo map \n805-540-6500 \n\n\nslo\n1306 nipomo st. map\n805-541-6813 / 805-801-3536\n\n\narroyo grande\n203 bridge st. map\n805-305-3724\n\n\n\nphone: 805-540-6500\n800-783-0607 (24/7 crisis line) \n805-540-0057 (library outreach team)\n805-540-6576 (behavioral health care system navigation help)\n805-540-6551 (supported employment program)\n\n\nemail: info@t-mha.org \nmmurchison@t-mha.org (supported employment program)\n\n\nhours: m-f 8am-5pm\nnotes:\nalso runs \"wellness centers\" with a variety of programs \nsee t-mha.org/wellness-calendars.php for a schedule:\n\n\noperates behavioral health bridge housing (bhbh) program\noperates \"bishop street studios\" \noperates \"growing grounds downtown,\" \"growing grounds farm,\" and \"growing grounds nursery\" \noperates \"library outreach team\" (see slo county public libraries)\noperates the \"supported employment\" program \noperates \"t-mha community residential housing\" \noperates \"vetwell\"\nentry-point for the coordinated entry system (ces)\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Transitions Mental Health Association (TMHA)"
+    ]
+  },
+  {
+    "id": "Tri-Counties-Regional-Center",
+    "title": "Tri Counties Regional Center",
+    "content": "tri counties regional center\n\nwebsite: tri-counties.org\n\n\n\n\n\nlocation\nphone\n\n\n\n(main office) 520 e. montecito st., santa barbara map\n805-962-7881\n\n\n7305 morro rd. #101, atascadero map\n805-461-7402\n\n\n1146 farmhouse ln., slo map\n805-543-2833\n\n\n\nhours: m-f 8:30am-5pm \nhow to access: apply at tri-counties.org/our-services/apply/\n\n",
+    "type": "directory",
+    "aliases": [
+      "Tri Counties Regional Center"
+    ]
+  },
+  {
+    "id": "Trinity-United-Methodist-Church",
+    "title": "Trinity United Methodist Church (Los Osos)",
+    "content": "trinity united methodist church (los osos)\n\nwebsite: trinitylososos.org\nlocation: 490 los osos valley rd., los osos map \nphone: 805-528-1649 \nemail: church@trinitylososos.org \nhours (food pantry): tu/f 10am-noon \n\n",
+    "type": "directory",
+    "aliases": [
+      "Trinity United Methodist Church (Los Osos)"
+    ]
+  },
+  {
+    "id": "Tri-County-GLAD",
+    "title": "Tri-County GLAD",
+    "content": "tri-county glad\n\nwebsite: tcglad.org\nlocation: 702 county square dr. #101, ventura map \nphone:\n805-256-1053 (videophone) \n805-644-6323 (tty) \n805-644-6322 (voice)\n\n\nemail: info@tcglad.org \nhours: m-f 8:30am-5pm (closed noon-1pm) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Tri-County GLAD"
+    ]
+  },
+  {
+    "id": "TranzCentralCoast",
+    "title": "TranzCentralCoast",
+    "content": "tranzcentralcoast\n\nwebsite: tranzcentralcoast.org {not working as of 2 dec 2025}\nlocation: 1060 palm st., slo map\nphone: 805-242-3821 { source: https://www.facebook.com/tranz.coast/ }\nemail: tranzcentralcoast@gmail.com { source: https://www.facebook.com/tranz.coast/ }\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "TranzCentralCoast"
+    ]
+  },
+  {
+    "id": "UC-Cooperative-Extension",
+    "title": "U.C. Cooperative Extension — SLO County",
+    "content": "u.c. cooperative extension - slo county\n\nwebsite: cesanluisobispo.ucanr.edu\nlocation: 2156 sierra way #c, slo map \nphone: 805-781-5940 \nnotes: research-based educational programs including master gardener program, master food preserver program, forest stewardship workshops, agriculture, and horticulture; cost varies by program\n\n",
+    "type": "directory",
+    "aliases": [
+      "U.C. Cooperative Extension — SLO County"
+    ]
+  },
+  {
+    "id": "UUSLO",
+    "title": "Unitarian Universalists San Luis Obispo",
+    "content": "unitarian universalists san luis obispo\n\nwebsite: uuslo.org\nlocation: 2201 lawton avenue map \nphone: 805-439-0188 \nemail: minister.uuslo@gmail.com \nhours:\nwe care foodshare food pantry: w 3-4:30pm \nrefugee and immigrant services education: first & third sunday each month, 12:30-2:30pm \n\n\nhow to access:\nwe care foodshare food pantry: arrive during hours of operation \nminister's discretionary fund: email with a specific request \nrefugee and immigrant services education: arrive during hours of operation (no appointment necessary) \n\n\nnotes:\noperates the \"minister's discretionary fund,\" \"refugee and immigrant services education,\" and \"we care foodshare\" \nhosts shower the people on tuesdays and thursdays \n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Unitarian Universalists San Luis Obispo"
+    ]
+  },
+  {
+    "id": "UnitedHealthcare-Childrens-Foundation",
+    "title": "UnitedHealthcare Children’s Foundation",
+    "content": "unitedhealthcare children's foundation\n\nwebsite: uhccf.org\nphone: 855-698-4223 \nemail: uhccfcustomerservice@uhc.com \n\n",
+    "type": "directory",
+    "aliases": [
+      "UnitedHealthcare Children’s Foundation"
+    ]
+  },
+  {
+    "id": "United-Voluntary-Services-Thrift",
+    "title": "United Voluntary Services Thrift",
+    "content": "united voluntary services thrift\n\nlocation: 474 marsh st., slo map \nphone: 805-543-1545 \nhours: m-sa 11am-3pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "United Voluntary Services Thrift"
+    ]
+  },
+  {
+    "id": "United-Way",
+    "title": "United Way",
+    "content": "united way\n\nwebsite: unitedwayslo.org\ntax return assistance program\n\n\nlocation: 1288 morro st. #10, slo map \nphone: 805-541-1234 \nemail: info@unitedwayslo.org \ntax return assistance program: taxes@unitedwayslo.org\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "United Way"
+    ]
+  },
+  {
+    "id": "Urgent-Care",
+    "title": "Urgent Care",
+    "content": "urgent care\nthere are several urgent care options, including:\n\ncommunity health center (arroyo grande)\ncarbon health urgent care (atascadero)\ndignity health urgent care (atascadero)\nurgent care of atascadero\nurgent care of morro bay\ncarbon health urgent care (paso robles)\ncommunity health center (paso robles)\nnorth county care minor emergency services (paso robles)\ndignity health urgent care (pismo beach)\nurgent care pismo beach\ncottage urgent care (slo)\nfamily and industrial medical center (slo)\nmedstop (slo)\ncommunity health center (templeton)\n\n",
+    "type": "directory",
+    "aliases": [
+      "Urgent Care"
+    ]
+  },
+  {
+    "id": "Urgent-Care-of-Atascadero",
+    "title": "Urgent Care of Atascadero",
+    "content": "urgent care of atascadero\n\nlocation: 9700 el camino real #100, atascadero map \nphone: 805-466-1330 \nhours: m-sa 7am-6:30pm, su 8am-3:30pm \nhow to access: walk-ins accepted until 30 minutes before closing\nnotes: accepts medicare and medi-cal; most insurances accepted - call to verify coverage\n\n",
+    "type": "directory",
+    "aliases": [
+      "Urgent Care of Atascadero"
+    ]
+  },
+  {
+    "id": "Urgent-Care-of-Morro-Bay",
+    "title": "Urgent Care of Morro Bay",
+    "content": "urgent care of morro bay\n\nlocation: 783 quintana rd., morro bay map \nphone: 805-771-0108 \nhours: m-sa 7am-6:30pm, su 8am-3:30pm \nnotes: accepts medicare and medi-cal\n\n",
+    "type": "directory",
+    "aliases": [
+      "Urgent Care of Morro Bay"
+    ]
+  },
+  {
+    "id": "Urgent-Care-Pismo-Beach",
+    "title": "Urgent Care Pismo Beach",
+    "content": "urgent care pismo beach\n\nlocation: 2 james way #214, pismo beach map \nphone: 805-295-6594 \nhours: m-sa. 7am-6:30pm, su. 8am-3:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Urgent Care Pismo Beach"
+    ]
+  },
+  {
+    "id": "Veterans-Administration-Outpatient-Clinic",
+    "title": "Veterans Administration Outpatient Clinic",
+    "content": "veterans administration outpatient clinic\n\nwebsite: va.gov/greater-los-angeles-health-care/locations/san-luis-obispo-va-clinic\nlocation: 1288 morro st. #200, slo map \nphone:\n805-543-1233 (main) \n877-252-4866 (va health connect) \n877-251-7295 (mental health) \n\n\nhours: m-f 8am-4:30pm \n\n",
+    "type": "directory",
+    "aliases": [
+      "Veterans Administration Outpatient Clinic"
+    ]
+  },
+  {
+    "id": "Veterans-Services",
+    "title": "Veterans Services (SLO County)",
+    "content": "veterans services (slo county)\n\n\nwebsite: slocounty.ca.gov/departments/veterans-services\nlocations:\n800 west branch st., arroyo grande map (currently closed for renovations) \n240 scott st., paso robles map (tu-th 8am-5pm) \n801 grand ave., slo map (daily 8am-5pm) \n\n\nphone: 805-781-5766 \nemail: slovets@co.slo.ca.us\nhow to access: in-person and phone appointments only; no walk-ins; book appointments online or by phone\nnotes: slo office has a small food pantry\n\n",
+    "type": "directory",
+    "aliases": [
+      "Veterans Services (SLO County)"
+    ]
+  },
+  {
+    "id": "Veterans-Transportation-Service",
+    "title": "Veterans Transportation Service",
+    "content": "veterans transportation service\n\nwebsite: vetride.va.gov\nphone: 805-543-1233\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Veterans Transportation Service"
+    ]
+  },
+  {
+    "id": "Veterans-Volunteer-Services",
+    "title": "Veterans Volunteer Services",
+    "content": "veterans volunteer services\n\nlocation: arroyo grande map\nphone: 805-481-2622\nhow to access: no walk-ins; call to make an appointment\n-->\n\n",
+    "type": "directory",
+    "aliases": [
+      "Veterans Volunteer Services"
+    ]
+  },
+  {
+    "id": "Victim-Witness-Assistance-Program",
+    "title": "Victim Witness Assistance Program",
+    "content": "victim witness assistance program\n\nwebsite: slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center\nlocation: 1050 monterey st. (courthouse annex room 384), slo map \nphone: 805-781-5821 (toll-free: 866-781-5821) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Victim Witness Assistance Program"
+    ]
+  },
+  {
+    "id": "Vituity-Cares-Mobile-Clinic",
+    "title": "Vituity Cares Mobile Clinic",
+    "content": "vituity cares mobile clinic\n\nwebsite: vituitycares.org\nlocation: 995 palm st., slo map\nphone: 480-828-4319 \nemail: vituitycares@gmail.com \nhours: second sunday of the month, 12:30-3:30 pm\n\n",
+    "type": "directory",
+    "aliases": [
+      "Vituity Cares Mobile Clinic"
+    ]
+  },
+  {
+    "id": "Helping-Friends-Program",
+    "title": "Voice for the Animals Helping Friends Program",
+    "content": "voice for the animals helping friends program\n\nwebsite: www.vftafoundation.org/helping_friends\nphone: 310-392-5153 \nemail: info@vftafoundation.org \n\n",
+    "type": "directory",
+    "aliases": [
+      "Voice for the Animals Helping Friends Program"
+    ]
+  },
+  {
+    "id": "Womenade",
+    "title": "Womenade",
+    "content": "womenade\n\n\n\nlocation\nwebsite\nlocation\nphone\nemail\n\n\n\nslo city\nwomenadeslo.org\n6099 marshall way, slo map\n805-674-9450\nelaine@womenadeslo.org\n\n\nsouth slo county\nsslocw.org\n1793 farroll road, grover beach map\n\nsslocwomenade@gmail.com\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Womenade"
+    ]
+  },
+  {
+    "id": "Waterman-Village",
+    "title": "Waterman Village",
+    "content": "waterman village\n\nwebsite: smartsharehousingsolutions.org/co-living-collaborative\nlocation: 466 dana st., slo map \nphone: 805-215-5474 \nnotes: a project of smartshare housing solutions\n\n",
+    "type": "directory",
+    "aliases": [
+      "Waterman Village"
+    ]
+  },
+  {
+    "id": "Welcome-Home-Village",
+    "title": "Welcome Home Village",
+    "content": "welcome home village\n\n\nwebsite: slocounty.ca.gov/welcomehomevillage\nlocation: health agency campus, intersection of johnson ave. & bishop st., slo map \nphone: 805-591-4544 (margaret shepard-moore, program manager) \nemail: mshepard-moore@co.slo.ca.us \nhow to access: through the coordinated entry system (ces) or contact city of slo homelessness response team for outreach\nnotes:\noperated by good samaritan shelter\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Welcome Home Village"
+    ]
+  },
+  {
+    "id": "WIC",
+    "title": "Women, Infants, and Children (WIC)",
+    "content": "women, infants, and children (wic)\n\nwebsite: slocountygov/wic\n\n\n\n\n\nlocation\nphone\n\n\n\natascadero: 5575 hospital dr. map\n805-237-3065 or 805-781-5570\n\n\ngrover beach: 286 s. 16th st. #b map\n805-473-7130\n\n\npaso robles: 805 4th st. #b map\n805-237-3065\n\n\nslo: 2191 johnson ave. map\n805-781-5570\n\n\n\nphone:\n805-781-5570 \ntext: 888-417-6180 \n\n\nhours: m-th 8am-5pm; fri. 8am-4:30pm (closed on the last wednesday of the month) \nhow to access: by appointment only (call or text to make an appointment) \neligibility: this program is restricted to people for whom both of the following requirements are true:\nyou are pregnant, breastfeeding, gave birth or had a pregnancy loss in the past six months, or you care for a child under the age of five\nand you live in california and have income below a certain threshold, or receive medi-cal, calworks, or calfresh benefits.\n\n\n\n",
+    "type": "directory",
+    "aliases": [
+      "Women, Infants, and Children (WIC)"
+    ]
+  },
+  {
+    "id": "Woods-Humane-Society",
+    "title": "Woods Humane Society",
+    "content": "woods humane society\n\nwebsite: woodshumanesociety.org\npet pantry\n\n\n\n\n\n\n\nlocation\nphone\n\n\n\n2300 ramona rd., atascadero map\n805-466-5403\n\n\n875 oklahoma ave, slo map\n805-543-9316\n\n\n\nemail: rcoleman@woodshumanesociety.org (robin coleman, community engagement manager)\nhours: (adoption) daily 11am-4pm (atascadero) or daily noon-4pm (slo) \n\n",
+    "type": "directory",
+    "aliases": [
+      "Woods Humane Society"
+    ]
+  },
+  {
+    "id": "Zion-Lutheran-Church",
+    "title": "Zion Lutheran Church",
+    "content": "zion lutheran church\n\nwebsite: zionslo.com\nlocation: 1010 foothill blvd., slo map \nphone: 805-543-8327 \nemail: zion@zionslo.com \nhours (food pantry): w 9:30-11:30am \n\n",
+    "type": "directory",
+    "aliases": [
+      "Zion Lutheran Church"
+    ]
+  }
+]

--- a/web-app/scripts/preprocess-content.js
+++ b/web-app/scripts/preprocess-content.js
@@ -1,0 +1,691 @@
+#!/usr/bin/env node
+
+/**
+ * Pre-process content at build time
+ *
+ * This script converts markdown to HTML and performs all processing
+ * that would otherwise happen at runtime, significantly improving
+ * initial page load performance.
+ *
+ * Outputs:
+ * - public/processed/resources.html
+ * - public/processed/directory.html
+ * - public/processed/about.html
+ * - public/processed/directory-entries.json
+ * - public/processed/search-index.json
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { marked } from 'marked';
+import { JSDOM } from 'jsdom';
+import createDOMPurify from 'dompurify';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Setup DOMPurify with jsdom
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
+
+// Paths
+const ROOT_DIR = join(__dirname, '../..');
+const WEB_APP_DIR = join(__dirname, '..');
+const OUTPUT_DIR = join(WEB_APP_DIR, 'public', 'processed');
+
+// Configure marked with custom renderer
+const renderer = {
+  heading({ tokens, depth }) {
+    const text = this.parser.parseInline(tokens);
+    return `<h${depth}><span>${text}</span></h${depth}>\n`;
+  }
+};
+marked.use({ renderer });
+
+console.log('🔄 Pre-processing content...\n');
+
+// Ensure output directory exists
+mkdirSync(OUTPUT_DIR, { recursive: true });
+
+// Read source files
+console.log('📖 Reading source files...');
+const resourcesMarkdown = readFileSync(join(ROOT_DIR, 'Resource guide.md'), 'utf-8');
+const directoryMarkdown = readFileSync(join(ROOT_DIR, 'Directory.md'), 'utf-8');
+const aboutMarkdown = readFileSync(join(ROOT_DIR, 'About.md'), 'utf-8');
+
+/**
+ * Extract directory entries from Directory.md content
+ * Returns a Map of id -> { title, content, aliases }
+ */
+function extractDirectoryEntries(directoryMarkdown) {
+  const entries = new Map();
+  const h2Regex = /^##\s+.*/gm;
+  let match;
+  const positions = [];
+
+  // Find all h2 headings and extract all anchor IDs from each
+  while ((match = h2Regex.exec(directoryMarkdown)) !== null) {
+    const headerLine = match[0];
+    const headerStart = match.index;
+    const headerEnd = headerStart + headerLine.length;
+
+    // Extract all <a id="...">...</a> tags from this heading
+    const anchorRegex = /<a\s+id="([^"]+)"[^>]*>([^<]+)<\/a>/g;
+    let anchorMatch;
+    const anchorIds = [];
+
+    while ((anchorMatch = anchorRegex.exec(headerLine)) !== null) {
+      anchorIds.push({
+        id: anchorMatch[1],
+        title: anchorMatch[2].trim()
+      });
+    }
+
+    if (anchorIds.length > 0) {
+      positions.push({
+        ids: anchorIds,
+        primaryTitle: anchorIds[0].title,
+        start: headerStart,
+        headerEnd: headerEnd
+      });
+    }
+  }
+
+  // Extract content for each entry
+  positions.forEach((pos, index) => {
+    const nextPos = positions[index + 1];
+    const maxEnd = nextPos ? nextPos.start : directoryMarkdown.length;
+
+    let rawContent = directoryMarkdown.slice(pos.headerEnd, maxEnd);
+
+    // Stop at the first h2 header (##) that appears in the content
+    const h2Match = rawContent.match(/\n## /);
+    let content = rawContent;
+    if (h2Match) {
+      content = rawContent.slice(0, h2Match.index);
+    }
+
+    content = content.trim();
+
+    // Extract aliases
+    const aliases = extractAliases(content, pos.primaryTitle);
+
+    // Create an entry for each anchor ID
+    pos.ids.forEach(anchor => {
+      entries.set(anchor.id, {
+        title: anchor.title,
+        content: `## ${anchor.title}\n\n${content}`,
+        aliases
+      });
+    });
+  });
+
+  return entries;
+}
+
+/**
+ * Extract aliases (alternative names) for an entry
+ */
+function extractAliases(content, mainTitle) {
+  const aliases = [mainTitle];
+
+  // Look for "a.k.a." or "also known as"
+  const akaRegex = /(?:a\.k\.a\.|also known as|formerly known as)\s*["""]?([^""".\n]+)["""]?/gi;
+  let match;
+
+  while ((match = akaRegex.exec(content)) !== null) {
+    const alias = match[1].trim();
+    if (alias && !aliases.includes(alias)) {
+      aliases.push(alias);
+    }
+  }
+
+  // Look for alternative format: > *See also [Name]*
+  const seeAlsoRegex = />\s*\*See also \[([^\]]+)\]/gi;
+  while ((match = seeAlsoRegex.exec(content)) !== null) {
+    const alias = match[1].trim();
+    if (alias && !aliases.includes(alias)) {
+      aliases.push(alias);
+    }
+  }
+
+  return aliases;
+}
+
+/**
+ * Convert anchor links to directory modal links
+ */
+function convertAnchorLinksToDirectoryLinks(html, directoryEntries) {
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  const links = document.querySelectorAll('a[href*="#"]');
+  let convertedCount = 0;
+  const brokenLinks = [];
+
+  links.forEach(link => {
+    const href = link.getAttribute('href');
+
+    // Determine if this is a directory link
+    const isDirectoryLink = href.includes('Directory.md') ||
+                           (href.startsWith('#') && /^#[A-Z0-9]/.test(href));
+
+    if (!isDirectoryLink) {
+      return; // Skip Resource Guide internal links
+    }
+
+    // Extract the entry ID
+    let entryId = null;
+    if (href.includes('#')) {
+      entryId = href.split('#')[1];
+    }
+
+    if (!entryId) {
+      return;
+    }
+
+    // Check if this is a directory entry (case-insensitive)
+    let actualEntryId = null;
+    if (directoryEntries.has(entryId)) {
+      actualEntryId = entryId;
+    } else {
+      const lowerEntryId = entryId.toLowerCase();
+      for (const [key] of directoryEntries) {
+        if (key.toLowerCase() === lowerEntryId) {
+          actualEntryId = key;
+          break;
+        }
+      }
+    }
+
+    if (actualEntryId) {
+      link.setAttribute('href', '#');
+      link.setAttribute('data-directory-link', actualEntryId);
+      link.setAttribute('aria-label', `View directory entry for ${link.textContent}`);
+      convertedCount++;
+    } else {
+      brokenLinks.push({
+        href: href,
+        entryId: entryId,
+        linkText: link.textContent.substring(0, 50)
+      });
+    }
+  });
+
+  // Output warnings for broken directory links
+  if (brokenLinks.length > 0) {
+    console.warn('\n⚠️  BROKEN DIRECTORY LINKS FOUND:');
+    console.warn(`Found ${brokenLinks.length} link(s) pointing to non-existent directory entries:\n`);
+    brokenLinks.forEach(link => {
+      console.warn(`  • Link text: "${link.linkText}"`);
+      console.warn(`    Target ID: "${link.entryId}" (from href="${link.href}")`);
+      console.warn(`    → This ID does not exist in Directory.md\n`);
+    });
+    console.warn('Please check Resource guide.md for typos in directory link IDs.\n');
+  }
+
+  return dom.serialize();
+}
+
+/**
+ * Enhance phone links - add aria-labels and convert plain phone numbers
+ */
+function enhancePhoneLinks(document) {
+  // Enhance existing tel: links
+  const phoneLinks = document.querySelectorAll('a[href^="tel:"]');
+  phoneLinks.forEach(link => {
+    link.setAttribute('aria-label', `Call ${link.textContent.trim()}`);
+
+    const href = link.getAttribute('href');
+    if (!href.startsWith('tel:+1') && !href.includes(';ext')) {
+      const cleanNumber = href.replace('tel:', '').replace(/\D/g, '');
+      if (cleanNumber.length === 10) {
+        link.setAttribute('href', `tel:+1-${cleanNumber}`);
+      }
+    }
+  });
+
+  // Convert plain phone numbers to links
+  const phoneRegex = /\b\d{3}-\d{3}-\d{4}\b/g;
+
+  function walkTextNodes(node, callback) {
+    if (node.nodeType === 3) { // TEXT_NODE
+      callback(node);
+    } else {
+      for (let child of Array.from(node.childNodes)) {
+        walkTextNodes(child, callback);
+      }
+    }
+  }
+
+  function isInsideLink(node) {
+    let current = node.parentNode;
+    while (current) {
+      if (current.tagName === 'A') {
+        return true;
+      }
+      current = current.parentNode;
+    }
+    return false;
+  }
+
+  walkTextNodes(document.body, (textNode) => {
+    const text = textNode.textContent;
+    const matches = text.match(phoneRegex);
+
+    if (matches && !isInsideLink(textNode)) {
+      const parent = textNode.parentNode;
+      const fragment = document.createDocumentFragment();
+      let lastIndex = 0;
+
+      text.replace(phoneRegex, (match, offset) => {
+        if (offset > lastIndex) {
+          fragment.appendChild(
+            document.createTextNode(text.slice(lastIndex, offset))
+          );
+        }
+
+        const link = document.createElement('a');
+        const cleanNumber = match.replace(/\D/g, '');
+        link.href = `tel:+1-${cleanNumber}`;
+        link.textContent = match;
+        link.setAttribute('aria-label', `Call ${match}`);
+        fragment.appendChild(link);
+
+        lastIndex = offset + match.length;
+        return match;
+      });
+
+      if (lastIndex < text.length) {
+        fragment.appendChild(
+          document.createTextNode(text.slice(lastIndex))
+        );
+      }
+
+      parent.replaceChild(fragment, textNode);
+    }
+  });
+}
+
+/**
+ * Enhance email links
+ */
+function enhanceEmailLinks(document) {
+  const emailLinks = document.querySelectorAll('a[href^="mailto:"]');
+  emailLinks.forEach(link => {
+    link.setAttribute('aria-label', `Email ${link.textContent.trim()}`);
+  });
+}
+
+/**
+ * Enhance external links - mark them (runtime will add target based on hostname)
+ */
+function markExternalLinks(document) {
+  const links = document.querySelectorAll('a[href^="http"]');
+  links.forEach(link => {
+    // Add a data attribute to mark as external - runtime will check hostname
+    link.setAttribute('data-external-link', 'true');
+  });
+}
+
+/**
+ * Enhance tables for mobile responsiveness
+ */
+function enhanceTables(document) {
+  const tables = document.querySelectorAll('table');
+
+  tables.forEach(table => {
+    const headers = Array.from(table.querySelectorAll('thead th')).map(th =>
+      th.textContent.trim()
+    );
+
+    const rows = table.querySelectorAll('tbody tr');
+    rows.forEach(row => {
+      const cells = row.querySelectorAll('td');
+      cells.forEach((cell, index) => {
+        if (headers[index]) {
+          cell.setAttribute('data-label', headers[index]);
+        }
+      });
+    });
+  });
+}
+
+/**
+ * Transform TOC into icon lozenges
+ */
+function transformTOCToLozenges(document) {
+  const tocAnchor = document.querySelector('a[id="table-of-contents"]');
+  if (!tocAnchor) return;
+
+  const tocHeading = tocAnchor.closest('h2');
+  if (!tocHeading) return;
+
+  let currentElement = tocHeading.nextElementSibling;
+  let tocList = null;
+
+  while (currentElement) {
+    if (currentElement.tagName === 'OL') {
+      tocList = currentElement;
+      break;
+    }
+    if (currentElement.tagName === 'H2') {
+      break;
+    }
+    currentElement = currentElement.nextElementSibling;
+  }
+
+  if (!tocList) return;
+
+  // Extract section links
+  const links = Array.from(tocList.querySelectorAll('a[href^="#"]'));
+  const sections = links.map(link => ({
+    href: link.getAttribute('href'),
+    text: link.textContent.trim()
+  }));
+
+  // Icon mapping - keys should match (case-insensitive) the actual TOC link text
+  const iconMap = {
+    'hotlines': '📞',
+    'emergencies': '📞',
+    'self-advocacy': '🗣️',
+    'advocacy': '🗣️',
+    'shelter': '🏠',
+    'housing': '🏠',
+    'property storage': '📦',
+    'storage': '📦',
+    'food': '🍎',
+    'water': '💧',
+    'transportation': '🚌',
+    'clothing': '👕',
+    'laundry': '🧺',
+    'showers': '🚿',
+    'hygiene': '🚿',
+    'health': '⚕️',
+    'medical': '⚕️',
+    'drug': '🪷',
+    'recovery': '🪷',
+    'tattoo': '✨',
+    'end-of-life': '🕊️',
+    'safety': '🛡️',
+    'legal': '⚖️',
+    'ids': '🪪',
+    'documents': '🪪',
+    'mail': '📬',
+    'banking': '💰',
+    'money': '💰',
+    'tax': '📋',
+    'financial': '💵',
+    'social security': '🏛️',
+    'employment': '💼',
+    'job': '💼',
+    'education': '📚',
+    'training': '📚',
+    'phones': '📱',
+    'internet': '💻',
+    'email': '💻',
+    'charging': '🔌',
+    'children': '🚸',
+    'youth': '🚸',
+    'parents': '🚸',
+    'peer support': '🤝🏽',
+    'recreation': '🏓',
+    'fitness': '🏓',
+    'pet': '🐾',
+    'disaster': '🌪️',
+    'advocacy & organizing': '📢',
+    'organizing': '📢',
+    'free': '🎁',
+    'guides': '📖',
+    'directory': '📇'
+  };
+
+  // Create lozenges
+  const wrapper = document.createElement('div');
+  wrapper.className = 'toc-section-wrapper';
+  wrapper.setAttribute('role', 'navigation');
+  wrapper.setAttribute('aria-label', 'Table of contents with visual icons');
+
+  const grid = document.createElement('div');
+  grid.className = 'toc-lozenge-grid';  // Match CSS class name
+
+  sections.forEach(section => {
+    const lozenge = document.createElement('a');
+    lozenge.href = section.href;
+    lozenge.className = 'toc-lozenge';
+    lozenge.setAttribute('aria-label', section.text);
+
+    const lowerText = section.text.toLowerCase();
+    let icon = '📄';
+    for (const [key, value] of Object.entries(iconMap)) {
+      if (lowerText.includes(key)) {
+        icon = value;
+        break;
+      }
+    }
+
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'toc-lozenge-icon';  // Match CSS class name
+    iconSpan.setAttribute('aria-hidden', 'true');
+    iconSpan.textContent = icon;
+
+    const textSpan = document.createElement('span');
+    textSpan.className = 'toc-lozenge-text';  // Match CSS class name
+    textSpan.textContent = section.text;
+
+    lozenge.appendChild(iconSpan);
+    lozenge.appendChild(textSpan);
+    grid.appendChild(lozenge);
+  });
+
+  // Add Directory link as the last item in TOC
+  const directoryLozenge = document.createElement('a');
+  directoryLozenge.href = '?section=directory';
+  directoryLozenge.className = 'toc-lozenge';
+  directoryLozenge.setAttribute('aria-label', 'Directory');
+
+  const directoryIcon = document.createElement('span');
+  directoryIcon.className = 'toc-lozenge-icon';
+  directoryIcon.setAttribute('aria-hidden', 'true');
+  directoryIcon.textContent = iconMap['directory'] || '📇';
+
+  const directoryText = document.createElement('span');
+  directoryText.className = 'toc-lozenge-text';
+  directoryText.textContent = 'Directory';
+
+  directoryLozenge.appendChild(directoryIcon);
+  directoryLozenge.appendChild(directoryText);
+  grid.appendChild(directoryLozenge);
+
+  wrapper.appendChild(grid);
+  tocList.parentNode.replaceChild(wrapper, tocList);
+}
+
+/**
+ * Process markdown to fully enhanced HTML
+ */
+function processMarkdown(markdown, directoryEntries, options = {}) {
+  console.log(`  Converting ${options.name || 'content'} to HTML...`);
+
+  // Convert markdown to HTML
+  let html = marked.parse(markdown);
+
+  // Parse into DOM for manipulation
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  // Convert directory links if entries provided
+  if (directoryEntries && directoryEntries.size > 0) {
+    console.log(`  Converting directory anchor links...`);
+    html = convertAnchorLinksToDirectoryLinks(html, directoryEntries);
+    // Re-parse after link conversion
+    dom.window.document.body.innerHTML = html;
+  }
+
+  // Enhance phone links
+  console.log(`  Enhancing phone links...`);
+  enhancePhoneLinks(dom.window.document);
+
+  // Enhance email links
+  console.log(`  Enhancing email links...`);
+  enhanceEmailLinks(dom.window.document);
+
+  // Mark external links
+  console.log(`  Marking external links...`);
+  markExternalLinks(dom.window.document);
+
+  // Enhance tables
+  console.log(`  Enhancing tables...`);
+  enhanceTables(dom.window.document);
+
+  // Transform TOC if this is resources
+  if (options.transformTOC) {
+    console.log(`  Transforming TOC to lozenges...`);
+    transformTOCToLozenges(dom.window.document);
+  }
+
+  // Get final HTML
+  html = dom.window.document.body.innerHTML;
+
+  // Sanitize HTML
+  console.log(`  Sanitizing HTML...`);
+  html = DOMPurify.sanitize(html, {
+    ADD_ATTR: ['data-directory-link', 'data-lat', 'data-lon', 'data-zoom', 'data-label', 'data-bounds', 'data-external-link']
+  });
+
+  return html;
+}
+
+/**
+ * Build search index from markdown content
+ */
+function buildSearchIndex(resourcesMarkdown, directoryEntries) {
+  console.log('🔍 Building search index...');
+  const searchIndex = [];
+
+  // Normalize text for search
+  function normalizeForSearch(text) {
+    return text
+      .replace(/[\u2018\u2019]/g, "'")
+      .replace(/[\u201C\u201D]/g, '"')
+      .replace(/[\u2013\u2014]/g, '-')
+      .toLowerCase();
+  }
+
+  // Index resource sections
+  const sectionRegex = /^(#{1,3})\s*<a\s+id="([^"]+)"[^>]*>([^<]+)<\/a>/gm;
+  let match;
+  const sections = [];
+
+  while ((match = sectionRegex.exec(resourcesMarkdown)) !== null) {
+    const level = match[1].length;
+    sections.push({
+      level: level,
+      id: match[2],
+      title: match[3].trim(),
+      start: match.index,
+      headerEnd: match.index + match[0].length
+    });
+  }
+
+  sections.forEach((section, index) => {
+    let nextSameOrHigher = null;
+    for (let i = index + 1; i < sections.length; i++) {
+      if (sections[i].level <= section.level) {
+        nextSameOrHigher = sections[i];
+        break;
+      }
+    }
+
+    const contentEnd = nextSameOrHigher ? nextSameOrHigher.start : resourcesMarkdown.length;
+    const content = resourcesMarkdown.slice(section.headerEnd, contentEnd);
+
+    // Convert to text
+    const dom = new JSDOM(DOMPurify.sanitize(marked.parse(content)));
+    const contentText = normalizeForSearch(dom.window.document.body.textContent);
+
+    searchIndex.push({
+      id: section.id,
+      title: section.title,
+      content: contentText,
+      type: 'resource-section',
+      level: section.level
+    });
+  });
+
+  // Index directory entries
+  directoryEntries.forEach((entry, id) => {
+    const dom = new JSDOM(DOMPurify.sanitize(marked.parse(entry.content)));
+    const contentText = normalizeForSearch(dom.window.document.body.textContent);
+
+    searchIndex.push({
+      id: id,
+      title: entry.title,
+      content: contentText,
+      type: 'directory',
+      aliases: entry.aliases
+    });
+  });
+
+  console.log(`  Indexed ${searchIndex.length} items (${sections.length} sections + ${directoryEntries.size} directory entries)`);
+
+  return searchIndex;
+}
+
+// Main processing
+console.log('\n1️⃣  Extracting directory entries...');
+const directoryEntries = extractDirectoryEntries(directoryMarkdown);
+console.log(`  Found ${directoryEntries.size} directory entries`);
+
+console.log('\n2️⃣  Processing Resources...');
+const resourcesHTML = processMarkdown(resourcesMarkdown, directoryEntries, {
+  name: 'Resources',
+  transformTOC: true
+});
+
+console.log('\n3️⃣  Processing Directory...');
+const directoryHTML = processMarkdown(directoryMarkdown, directoryEntries, {
+  name: 'Directory'
+});
+
+console.log('\n4️⃣  Processing About...');
+const aboutHTML = processMarkdown(aboutMarkdown, null, {
+  name: 'About'
+});
+
+console.log('\n5️⃣  Building search index...');
+const searchIndex = buildSearchIndex(resourcesMarkdown, directoryEntries);
+
+// Convert directory entries Map to JSON-serializable format with HTML content
+console.log('\n6️⃣  Preparing directory entries for export...');
+const directoryEntriesObj = {};
+directoryEntries.forEach((entry, id) => {
+  // Convert entry content (markdown) to HTML
+  const entryHTML = processMarkdown(entry.content, directoryEntries, { name: `Directory entry: ${entry.title}` });
+
+  directoryEntriesObj[id] = {
+    title: entry.title,
+    content: entryHTML,  // Store as HTML, not markdown
+    aliases: entry.aliases
+  };
+});
+
+// Write output files
+console.log('\n7️⃣  Writing output files...');
+writeFileSync(join(OUTPUT_DIR, 'resources.html'), resourcesHTML, 'utf-8');
+console.log('  ✅ resources.html');
+
+writeFileSync(join(OUTPUT_DIR, 'directory.html'), directoryHTML, 'utf-8');
+console.log('  ✅ directory.html');
+
+writeFileSync(join(OUTPUT_DIR, 'about.html'), aboutHTML, 'utf-8');
+console.log('  ✅ about.html');
+
+writeFileSync(join(OUTPUT_DIR, 'directory-entries.json'), JSON.stringify(directoryEntriesObj, null, 2), 'utf-8');
+console.log('  ✅ directory-entries.json');
+
+writeFileSync(join(OUTPUT_DIR, 'search-index.json'), JSON.stringify(searchIndex, null, 2), 'utf-8');
+console.log('  ✅ search-index.json');
+
+console.log('\n✨ Pre-processing complete!\n');

--- a/web-app/vite.config.js
+++ b/web-app/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
-import minifyMarkdown from './vite-plugin-minify-markdown.js';
 
 export default defineConfig({
   base: './',
@@ -9,19 +8,17 @@ export default defineConfig({
     assetsDir: 'assets',
     sourcemap: false,
     target: 'esnext',
-    // Allow importing markdown files as raw text
     assetsInlineLimit: 0,
     rollupOptions: {
       output: {
         manualChunks: {
           // Split vendor dependencies into separate chunk
-          'vendor': ['marked', 'dompurify'],
+          'vendor': ['dompurify'],
         }
       }
     }
   },
   plugins: [
-    minifyMarkdown(),
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png', 'icon-192-maskable.png', 'icon-512-maskable.png'],


### PR DESCRIPTION
This eliminates the slow initial page load caused by client-side markdown parsing and DOM manipulation. All content processing now happens during the build, generating pre-processed HTML files that are ready to display.

Changes:
- Add preprocess-content.js script to convert markdown to HTML at build-time
- Generate 5 processed files: resources.html, directory.html, about.html, directory-entries.json, search-index.json
- Rewrite main.js to fetch pre-processed HTML instead of parsing markdown
- Move marked and jsdom to devDependencies (build-time only)
- Remove marked from runtime bundle, reducing JS size from ~90KB to 56KB
- Update About.md and THIRD_PARTY_LICENSES.md to document jsdom dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)