### PR TITLE
add QR code feature for cross-platform link sharing

### DIFF
--- a/web-app/ARCHITECTURE.md
+++ b/web-app/ARCHITECTURE.md
@@ -172,20 +172,34 @@ Email delivered to recipient
 
 ### 5. shareButton.js - Share Functionality
 
-**Purpose**: Enables sharing of pages and entries
+**Purpose**: Enables sharing of pages and entries with QR code support
 
 **Key Functions**:
 
 - `initShareButton()`: Sets up global share button
 - `createSectionShareButton()`: Inline share for sections
-- `createDirectoryShareButton()`: Share specific entries
-- `copyToClipboard()`: Falls back if Web Share API unavailable
+- `showNotification()`: Displays copy confirmation with QR code option
+- `showQrCodeModal()`: Shows QR code modal for the copied link
+- `hideQrCodeModal()`: Closes the QR code modal
+- `downloadQrCode()`: Downloads QR code as PNG image
 
 **Share Behavior**:
 
 - Uses Web Share API on mobile
 - Falls back to clipboard copy on desktop
 - Generates shareable URLs with hash fragments
+- Shows notification toast after successful copy
+- Provides "View QR Code" button in notification for cross-platform sharing
+- QR codes generated using qr-creator library (4.75kB gzipped)
+
+**QR Code Modal Features**:
+
+- Displays QR code (256×256px with rounded corners)
+- Shows the full URL for reference
+- Download button to save QR code as PNG
+- Accessible keyboard navigation (Escape to close)
+- Click overlay to close
+- High error correction level (H) for reliability
 
 ### 6. installPrompt.js - PWA Installation
 
@@ -957,6 +971,15 @@ See README.md for Apache/Nginx configs
 - Removes dangerous tags/attributes
 - Used after markdown parsing
 - Used in: `markdownParser.js`
+
+#### qr-creator (1.0.0)
+
+- Lightweight QR code generator (4.75kB gzipped)
+- No external dependencies
+- Supports gradient fills and rounded corners
+- Generates QR codes on HTML5 canvas
+- High error correction levels (L, M, Q, H)
+- Used in: `shareButton.js`
 
 #### vite (6.0.5)
 

--- a/web-app/README.md
+++ b/web-app/README.md
@@ -18,6 +18,8 @@ homelessness in San Luis Obispo County.
   Little Free Pantries, and Naloxone locations
 - **State persistence** - Returns users to their previous location
 - **Search functionality** - Find resources quickly
+- **Share functionality** - Share pages and sections with QR code support
+  for easy cross-device sharing
 - **Accessibility features**:
   - Adjustable font size (80%–150%)
   - OpenDyslexic font option for dyslexia support

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -10,7 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "dompurify": "^3.2.2",
-        "marked": "^14.1.3"
+        "marked": "^14.1.3",
+        "qr-creator": "^1.0.0"
       },
       "devDependencies": {
         "html-validate": "^10.4.0",
@@ -5196,6 +5197,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qr-creator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/qr-creator/-/qr-creator-1.0.0.tgz",
+      "integrity": "sha512-C0cqfbS1P5hfqN4NhsYsUXePlk9BO+a45bAQ3xLYjBL3bOIFzoVEjs79Fado9u9BPBD3buHi3+vY+C8tHh4qMQ==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "dompurify": "^3.2.2",
-    "marked": "^14.1.3"
+    "marked": "^14.1.3",
+    "qr-creator": "^1.0.0"
   },
   "devDependencies": {
     "html-validate": "^10.4.0",

--- a/web-app/src/main.js
+++ b/web-app/src/main.js
@@ -4,7 +4,7 @@ import DOMPurify from 'dompurify';
 import { enhanceLinks } from './linkEnhancer.js';
 import { parseMarkdown, extractDirectoryEntries } from './markdownParser.js';
 import { initFeedback } from './feedback.js';
-import { initShareButton, createSectionShareButton } from './shareButton.js';
+import { initShareButton, createSectionShareButton, showNotification } from './shareButton.js';
 import { initFontSizeControl } from './fontSizeControl.js';
 import { initInstallPrompt } from './installPrompt.js';
 import { getStrings, getCurrentLanguage } from './strings.js';
@@ -33,46 +33,14 @@ function copyToClipboard(text, successMessage) {
   if (navigator.clipboard && navigator.clipboard.writeText) {
     navigator.clipboard.writeText(text)
       .then(() => {
-        showNotification(successMessage || strings.share.notifications.linkCopied);
+        showNotification(successMessage || strings.share.notifications.linkCopied, text);
       })
       .catch(() => {
-        showNotification(strings.share.notifications.copyFailedShort);
+        showNotification(strings.share.notifications.copyFailedShort, null);
       });
   } else {
-    showNotification(strings.share.notifications.copyFailedShort);
+    showNotification(strings.share.notifications.copyFailedShort, null);
   }
-}
-
-// Helper function to show notifications
-function showNotification(message) {
-  // Remove any existing notification
-  const existing = document.getElementById('share-notification');
-  if (existing) {
-    existing.remove();
-  }
-
-  // Create notification element
-  const notification = document.createElement('div');
-  notification.id = 'share-notification';
-  notification.className = 'share-notification';
-  notification.textContent = message;
-  notification.setAttribute('role', 'status');
-  notification.setAttribute('aria-live', 'polite');
-
-  document.body.appendChild(notification);
-
-  // Trigger animation
-  setTimeout(() => {
-    notification.classList.add('show');
-  }, 10);
-
-  // Remove after 3 seconds
-  setTimeout(() => {
-    notification.classList.remove('show');
-    setTimeout(() => {
-      notification.remove();
-    }, 300);
-  }, 3000);
 }
 
 // App State

--- a/web-app/src/strings.js
+++ b/web-app/src/strings.js
@@ -97,7 +97,15 @@ const strings = {
         sectionLinkCopied: 'Section link copied to clipboard!',
         entryLinkCopied: 'Directory entry link copied to clipboard!',
         copyFailed: 'Unable to copy link. Please copy manually from address bar.',
-        copyFailedShort: 'Unable to copy link.'
+        copyFailedShort: 'Unable to copy link.',
+        viewQrCode: 'View QR Code'
+      },
+      qrModal: {
+        title: 'QR Code',
+        close: 'Close',
+        download: 'Download QR Code',
+        linkLabel: 'Link:',
+        closeAriaLabel: 'Close QR code dialog'
       }
     },
 
@@ -347,7 +355,15 @@ const strings = {
         sectionLinkCopied: '¡Enlace de la sección copiado al portapapeles!',
         entryLinkCopied: '¡Enlace de la entrada del directorio copiado al portapapeles!',
         copyFailed: 'No se puede copiar el enlace. Por favor, cópielo manualmente de la barra de direcciones.',
-        copyFailedShort: 'No se puede copiar el enlace.'
+        copyFailedShort: 'No se puede copiar el enlace.',
+        viewQrCode: 'Ver código QR'
+      },
+      qrModal: {
+        title: 'Código QR',
+        close: 'Cerrar',
+        download: 'Descargar código QR',
+        linkLabel: 'Enlace:',
+        closeAriaLabel: 'Cerrar diálogo de código QR'
       }
     },
 

--- a/web-app/src/style.css
+++ b/web-app/src/style.css
@@ -1733,11 +1733,157 @@ body.opendyslexic-enabled .toc-lozenge-text {
   opacity: 0;
   transition: all 0.3s ease;
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  max-width: 90vw;
 }
 
 .share-notification.show {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
+}
+
+/* QR Code button in notification */
+.qr-code-btn {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.qr-code-btn:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.qr-code-btn:active {
+  transform: scale(0.95);
+}
+
+/* QR Code Modal */
+.qr-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  padding: 1rem;
+}
+
+.qr-modal-overlay.show {
+  opacity: 1;
+}
+
+.qr-modal-content {
+  background-color: white;
+  border-radius: 12px;
+  padding: 2rem;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+.qr-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.qr-modal-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--primary-color);
+}
+
+.qr-modal-close {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  line-height: 1;
+  color: #666;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s ease;
+}
+
+.qr-modal-close:hover {
+  color: #000;
+}
+
+.qr-code-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  min-height: 256px;
+}
+
+.qr-code-container canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.qr-link-display {
+  background-color: #f5f5f5;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  word-break: break-all;
+}
+
+.qr-link-display strong {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--primary-color);
+}
+
+.qr-link-text {
+  font-size: 0.875rem;
+  color: #555;
+  line-height: 1.4;
+}
+
+.qr-download-btn {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.qr-download-btn:hover {
+  background-color: var(--secondary-color);
+}
+
+.qr-download-btn:active {
+  transform: scale(0.98);
 }
 
 /* Section share buttons (smaller, inline) */


### PR DESCRIPTION
Add QR code generation to share functionality, allowing users to generate QR codes for any shared link (pages, sections, directory entries). Provides browser-independent alternative to Brave's native QR code feature.

Features:
- QR code button appears in share notification toast
- Modal displays scannable QR code with download option
- Lightweight qr-creator library (4.75kB gzipped)
- Supports keyboard navigation and click-outside-to-close
- Bilingual support (English and Spanish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #87 