### PR TITLE
Fix Spanish language mode layout issues and SMS link wrapping

### DIFF
--- a/web-app/src/style.css
+++ b/web-app/src/style.css
@@ -133,14 +133,12 @@ input:focus {
 .app-nav {
   display: flex;
   justify-content: space-around;
-  flex: 1 1 auto;
-  min-width: 0;
+  flex: 1;
   gap: 0.25rem;
 }
 
 .nav-btn {
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 1;
   padding: 0.75rem 0.25rem;
   font-size: 1rem;
   font-family: 'Montserrat Alternates', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;


### PR DESCRIPTION
Fixes #97: Spanish language mode layout issues
- Fix language dropdown positioning by keeping position:relative on mobile
- Improve flex layout to prevent nav buttons from overflowing
- Add flex-shrink:0 to language switcher to prevent compression

Fixes #99: SMS link text word breaking
- Change white-space from nowrap to normal for tel/mailto/sms links
- Add overflow-wrap and word-break to SMS links to break at spaces but not hyphens

🤖 Generated with [Claude Code](https://claude.com/claude-code)