### PR TITLE
Remove pull request trigger from link checker workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -5,12 +5,6 @@ on:
     # Run every Monday at 9:00 AM UTC (1:00 AM PST)
     - cron: '0 9 * * 1'
   workflow_dispatch: # Allow manual trigger
-  pull_request:
-    paths:
-      - '**.md'
-      - 'scripts/extract-urls.js'
-      - 'scripts/check-links.js'
-      - '.github/workflows/check-links.yml'
 
 jobs:
   check-links:


### PR DESCRIPTION
The link checker now runs only on schedule (weekly on Mondays) and via manual trigger, preventing it from blocking pull requests with its 20+ minute runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)