### PR TITLE
Fix pre-commit hook to accept user input

### DIFF
--- a/.github/pre-commit-hook
+++ b/.github/pre-commit-hook
@@ -36,7 +36,7 @@ if [ -n "$SYNC_WARNINGS" ]; then
   echo ""
   echo "  Consider updating Spanish translations."
   echo "  Continue anyway? (y/n)"
-  read -r response
+  read -r response </dev/tty
   if [[ ! "$response" =~ ^[Yy]$ ]]; then
     echo "Commit aborted."
     exit 1
@@ -51,7 +51,7 @@ if echo "$STAGED_FILES" | grep -q '\.md$'; then
       echo ""
       echo "  ⚠️  Markdown linting errors found"
       echo "  Continue anyway? (y/n)"
-      read -r response
+      read -r response </dev/tty
       if [[ ! "$response" =~ ^[Yy]$ ]]; then
         echo "Commit aborted."
         exit 1
@@ -67,7 +67,7 @@ if [ -f "spell-check.cjs" ]; then
     echo ""
     echo "  ⚠️  Spelling errors found"
     echo "  Continue anyway? (y/n)"
-    read -r response
+    read -r response </dev/tty
     if [[ ! "$response" =~ ^[Yy]$ ]]; then
       echo "Commit aborted."
       exit 1


### PR DESCRIPTION
The pre-commit hook was failing immediately when prompting for user input instead of waiting for a response. This was because git hooks run with stdin redirected from /dev/null by default, causing the read command to fail, which triggered immediate exit due to set -e.

Fixed by redirecting stdin from /dev/tty for all read commands, allowing users to actually respond to y/n prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #136 