### PR TITLE
Fix dev server auto-refresh for external markdown files

### DIFF
--- a/web-app/vite.config.js
+++ b/web-app/vite.config.js
@@ -4,6 +4,17 @@ import minifyMarkdown from './vite-plugin-minify-markdown.js';
 
 export default defineConfig({
   base: './',
+  server: {
+    watch: {
+      // Watch parent directory for markdown file changes
+      ignored: ['!**/node_modules/**', '!**/.git/**'],
+      usePolling: false,
+    },
+    // Add parent directory to watch list
+    fs: {
+      allow: ['..']
+    }
+  },
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
Configure Vite's development server to watch files in the parent directory. This enables hot module reloading when markdown source files (Resource guide.md, Directory.md, etc.) are modified, which was previously not working because these files are outside the web-app project root.

Changes:
- Add server.watch configuration to monitor parent directory
- Add server.fs.allow to permit access to parent directory files

🤖 Generated with [Claude Code](https://claude.com/claude-code)