### PR TITLE
Fix map pin captions to show street addresses

### DIFF
--- a/web-app/public/little-free-libraries-data.js
+++ b/web-app/public/little-free-libraries-data.js
@@ -6,1015 +6,1015 @@ export const locations = [
     "lat": 35.11409,
     "lon": -120.593823,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "330 Alder St."
   },
   {
     "lat": 35.119917,
     "lon": -120.575391,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "121 Allen St."
   },
   {
     "lat": 35.073182,
     "lon": -120.586066,
     "zoom": 16,
-    "label": "Little Free Library"
+    "label": "Amarillo Dr."
   },
   {
     "lat": 35.073411,
     "lon": -120.580329,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2510 Appaloosa Way"
   },
   {
     "lat": 35.117185,
     "lon": -120.604837,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Corner of Cedar & Boysenberry"
   },
   {
     "lat": 35.121326,
     "lon": -120.570416,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "529 E. Cherry Ave."
   },
   {
     "lat": 35.122401,
     "lon": -120.568374,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "615 E. Cherry Ave."
   },
   {
     "lat": 35.087336,
     "lon": -120.56393,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2385 Clarkie Way"
   },
   {
     "lat": 35.065912,
     "lon": -120.572875,
     "zoom": 16,
-    "label": "Little Free Library"
+    "label": "Cypress Ridge Pkwy."
   },
   {
     "lat": 35.055285,
     "lon": -120.581134,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "485 Dorothy Ln."
   },
   {
     "lat": 35.123058,
     "lon": -120.600336,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "303 N. Elm St."
   },
   {
     "lat": 35.110289,
     "lon": -120.600857,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "512 S. Elm St."
   },
   {
     "lat": 35.089684,
     "lon": -120.578772,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "282 Gait Way"
   },
   {
     "lat": 35.117013,
     "lon": -120.598429,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1146 Maple St."
   },
   {
     "lat": 35.116732,
     "lon": -120.597214,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Maple St. @ Walnut St."
   },
   {
     "lat": 35.123681,
     "lon": -120.575667,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "127 S. Mason St."
   },
   {
     "lat": 35.118206,
     "lon": -120.578403,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "328 Orchard St."
   },
   {
     "lat": 35.119016,
     "lon": -120.603324,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1270 Poplar St."
   },
   {
     "lat": 35.118284,
     "lon": -120.60329,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1260 Sage St."
   },
   {
     "lat": 35.126825,
     "lon": -120.603753,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1414 Sierra Dr."
   },
   {
     "lat": 35.131236,
     "lon": -120.564362,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "494 Stagecoach Rd."
   },
   {
     "lat": 35.108422,
     "lon": -120.59327,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "958 Sycamore Dr."
   },
   {
     "lat": 35.126572,
     "lon": -120.581547,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "250 Wesley St."
   },
   {
     "lat": 35.439074,
     "lon": -120.615227,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "9481 Carmel Rd."
   },
   {
     "lat": 35.472397,
     "lon": -120.673113,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "8505 Carmelita Ave."
   },
   {
     "lat": 35.506468,
     "lon": -120.690123,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3155 El Camino Real"
   },
   {
     "lat": 35.518062,
     "lon": -120.682527,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2720 Ferrocarril Rd."
   },
   {
     "lat": 35.480842,
     "lon": -120.652139,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "8934 Junipero Ave."
   },
   {
     "lat": 35.49402,
     "lon": -120.672484,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Mariquita Ave."
   },
   {
     "lat": 35.466434,
     "lon": -120.665097,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "9125 Mountain View Dr."
   },
   {
     "lat": 35.493723,
     "lon": -120.675068,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "5265 Palma Ave."
   },
   {
     "lat": 35.420287,
     "lon": -120.628037,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "14985 Powerline Rd."
   },
   {
     "lat": 35.513614,
     "lon": -120.722312,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "8155 San Gregorio Rd."
   },
   {
     "lat": 35.463859,
     "lon": -120.699431,
     "zoom": 16,
-    "label": "Little Free Library"
+    "label": "10675 San Marcos Rd."
   },
   {
     "lat": 35.503843,
     "lon": -120.725162,
     "zoom": 16,
-    "label": "Little Free Library"
+    "label": "13400 Santa Ana Rd."
   },
   {
     "lat": 35.483352,
     "lon": -120.669031,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "6605 Santa Ynez Ave."
   },
   {
     "lat": 35.487968,
     "lon": -120.655054,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "7310 Sonora Ave."
   },
   {
     "lat": 35.476039,
     "lon": -120.647912,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "8437 Vaquero Ln."
   },
   {
     "lat": 35.50706,
     "lon": -120.669193,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "4555 Viscano Ave."
   },
   {
     "lat": 35.193967,
     "lon": -120.715208,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1401 San Luis Bay Dr."
   },
   {
     "lat": 35.180624,
     "lon": -120.733256,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "191 San Miguel St."
   },
   {
     "lat": 35.194958,
     "lon": -120.681242,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "259 Squire Canyon Rd."
   },
   {
     "lat": 35.574393,
     "lon": -121.098921,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "6404 Buckley Dr."
   },
   {
     "lat": 35.548281,
     "lon": -121.091709,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "701 Drake St."
   },
   {
     "lat": 35.564578,
     "lon": -121.102896,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "521 Hastings St."
   },
   {
     "lat": 35.547895,
     "lon": -121.074863,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2750 Holden Pl."
   },
   {
     "lat": 35.547507,
     "lon": -121.09486,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "383 Orlando Dr."
   },
   {
     "lat": 35.541138,
     "lon": -121.073378,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1176 Pineridge Dr."
   },
   {
     "lat": 35.571884,
     "lon": -121.107462,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "365 Weymouth St."
   },
   {
     "lat": 35.441637,
     "lon": -120.891423,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "84 13th St."
   },
   {
     "lat": 35.441671,
     "lon": -120.893139,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1175 Cass Ave."
   },
   {
     "lat": 35.448532,
     "lon": -120.90174,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "151 F St."
   },
   {
     "lat": 35.448889,
     "lon": -120.910614,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "517 Lucerne Rd."
   },
   {
     "lat": 35.445027,
     "lon": -120.896035,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "625 S. Ocean Ave."
   },
   {
     "lat": 35.124773,
     "lon": -120.627183,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "338 N. 3rd St."
   },
   {
     "lat": 35.120202,
     "lon": -120.62667,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "251 S. 4th St."
   },
   {
     "lat": 35.123621,
     "lon": -120.62491,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "266 N. 5th St."
   },
   {
     "lat": 35.108002,
     "lon": -120.609531,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "240 Anita Ave."
   },
   {
     "lat": 35.115854,
     "lon": -120.616578,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1230 Trouville Ave."
   },
   {
     "lat": 35.115683,
     "lon": -120.611738,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1624 Trouville Ave."
   },
   {
     "lat": 35.321573,
     "lon": -120.839052,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1643 4th St."
   },
   {
     "lat": 35.330479,
     "lon": -120.835297,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1182 7th St."
   },
   {
     "lat": 35.317787,
     "lon": -120.835598,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1855 7th St."
   },
   {
     "lat": 35.330435,
     "lon": -120.833012,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1180 9th St."
   },
   {
     "lat": 35.328834,
     "lon": -120.830823,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1257 11th St."
   },
   {
     "lat": 35.325639,
     "lon": -120.825394,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1426 16th St."
   },
   {
     "lat": 35.323582,
     "lon": -120.823474,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1539 18th St."
   },
   {
     "lat": 35.321708,
     "lon": -120.823474,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1639 18th St."
   },
   {
     "lat": 35.310294,
     "lon": -120.820349,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2130 Andre Ave."
   },
   {
     "lat": 35.309403,
     "lon": -120.833878,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2315 Bayview Heights Dr."
   },
   {
     "lat": 35.311895,
     "lon": -120.834482,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2148 Bush Dr."
   },
   {
     "lat": 35.307316,
     "lon": -120.811683,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2149 Lariat Dr."
   },
   {
     "lat": 35.317673,
     "lon": -120.843891,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "561 Loma St."
   },
   {
     "lat": 35.312628,
     "lon": -120.825568,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1351 Los Olivos Ave."
   },
   {
     "lat": 35.31172,
     "lon": -120.831102,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1078 Los Osos Valley Rd."
   },
   {
     "lat": 35.31485,
     "lon": -120.826659,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2003 Lost Oak Dr."
   },
   {
     "lat": 35.310765,
     "lon": -120.83872,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "732 Manzanita Dr."
   },
   {
     "lat": 35.307342,
     "lon": -120.825877,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2345 Oak Ridge Dr."
   },
   {
     "lat": 35.314075,
     "lon": -120.851884,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2100 Pecho Rd."
   },
   {
     "lat": 35.328212,
     "lon": -120.83461,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "948 Santa Maria Ave."
   },
   {
     "lat": 35.330164,
     "lon": -120.821371,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1188 Scenic Way"
   },
   {
     "lat": 35.307885,
     "lon": -120.826553,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2340 Tierra Dr."
   },
   {
     "lat": 35.355395,
     "lon": -120.843558,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "720 Cabrillo Pl."
   },
   {
     "lat": 35.390449,
     "lon": -120.861604,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Cloisters Community Park"
   },
   {
     "lat": 35.361721,
     "lon": -120.844277,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "482 Estero Ave."
   },
   {
     "lat": 35.387703,
     "lon": -120.853193,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2401 Ironwood Ave."
   },
   {
     "lat": 35.361784,
     "lon": -120.850224,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "495 Main St."
   },
   {
     "lat": 35.394094,
     "lon": -120.857676,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "450 San Jacinto St."
   },
   {
     "lat": 35.016626,
     "lon": -120.511421,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "421 N. Las Flores Dr."
   },
   {
     "lat": 35.044438,
     "lon": -120.516232,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "789 Live Oak Ridge Rd."
   },
   {
     "lat": 35.044833,
     "lon": -120.493745,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "525 Sandydale Dr."
   },
   {
     "lat": 35.105805,
     "lon": -120.611494,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1341 18th St."
   },
   {
     "lat": 35.102689,
     "lon": -120.603769,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1501 24th St."
   },
   {
     "lat": 35.685885,
     "lon": -120.949099,
     "zoom": 15,
-    "label": "Little Free Library"
+    "label": "14140 Chimney Rock Rd."
   },
   {
     "lat": 35.675182,
     "lon": -120.599488,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "5090 Deer Creek Way"
   },
   {
     "lat": 35.626407,
     "lon": -120.70174,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1130 Merry Hill Rd."
   },
   {
     "lat": 35.63788,
     "lon": -120.693794,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2247 Oak St."
   },
   {
     "lat": 35.635204,
     "lon": -120.689301,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2004 Pine St."
   },
   {
     "lat": 35.635204,
     "lon": -120.689301,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3773 Ruth Way #A"
   },
   {
     "lat": 35.625533,
     "lon": -120.692883,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1103 Spring St."
   },
   {
     "lat": 35.620405,
     "lon": -120.668131,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "539 Veronica Dr."
   },
   {
     "lat": 35.636053,
     "lon": -120.695039,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2105 Vine St."
   },
   {
     "lat": 35.626666,
     "lon": -120.657874,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "904 Vista Cerro Dr."
   },
   {
     "lat": 35.141748,
     "lon": -120.619004,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "28 El Viento"
   },
   {
     "lat": 35.134519,
     "lon": -120.616391,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "224 Irish Way"
   },
   {
     "lat": 35.143482,
     "lon": -120.641506,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "990 Price St."
   },
   {
     "lat": 35.14881,
     "lon": -120.651196,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2411 Price St."
   },
   {
     "lat": 35.149153,
     "lon": -120.653452,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2555 Price St."
   },
   {
     "lat": 35.136528,
     "lon": -120.606985,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "995 Skyline Dr."
   },
   {
     "lat": 35.750082,
     "lon": -120.698097,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1197 L St."
   },
   {
     "lat": 35.394411,
     "lon": -120.600808,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "22070 H St."
   },
   {
     "lat": 35.735801,
     "lon": -120.607985,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3120 Ranchita Canyon Rd."
   },
   {
     "lat": 35.156784,
     "lon": -120.677138,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "302 Cuyama Ave."
   },
   {
     "lat": 35.155398,
     "lon": -120.673018,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "262 Esparto Ave."
   },
   {
     "lat": 35.247297,
     "lon": -120.629542,
     "zoom": 16,
-    "label": "Little Free Library"
+    "label": "1330 Alder St."
   },
   {
     "lat": 35.263063,
     "lon": -120.687116,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1378 Avalon St. (@ Oceanaire Dr.)"
   },
   {
     "lat": 35.291125,
     "lon": -120.670781,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "79 Benton Way"
   },
   {
     "lat": 35.261906,
     "lon": -120.655375,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Bluerock Drive near Stoneridge Park"
   },
   {
     "lat": 35.276596,
     "lon": -120.662295,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1410 Broad St. @ Pacific"
   },
   {
     "lat": 35.287044,
     "lon": -120.667729,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Center St. between Chorro and Lincoln"
   },
   {
     "lat": 35.295083,
     "lon": -120.677927,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "171 Cerro Romauldo Ave."
   },
   {
     "lat": 35.33188,
     "lon": -120.728717,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3450 Dairy Creek Rd. (SLO Botanical Garden)"
   },
   {
     "lat": 35.27014,
     "lon": -120.64913,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "2378 Boulevard Del Campo"
   },
   {
     "lat": 35.265559,
     "lon": -120.698268,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1295 Descanso St."
   },
   {
     "lat": 35.236681,
     "lon": -120.675588,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "107 Earthwood Ln."
   },
   {
     "lat": 35.255055,
     "lon": -120.695018,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1595 Eto Circle"
   },
   {
     "lat": 35.257552,
     "lon": -120.699459,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1383 Fairway Dr."
   },
   {
     "lat": 35.29891,
     "lon": -120.684954,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "157 Fel Mar Dr."
   },
   {
     "lat": 35.264175,
     "lon": -120.638396,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1348 Fernwood Dr."
   },
   {
     "lat": 35.27452,
     "lon": -120.654666,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1011 George St."
   },
   {
     "lat": 35.122113,
     "lon": -120.634064,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1 Grand Ave."
   },
   {
     "lat": 35.264324,
     "lon": -120.635237,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3440 Gregory Ct."
   },
   {
     "lat": 35.284846,
     "lon": -120.654559,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1415 Higuera St."
   },
   {
     "lat": 35.276876,
     "lon": -120.658486,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Morro St. and Islay St."
   },
   {
     "lat": 35.278313,
     "lon": -120.655482,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1121 Islay St."
   },
   {
     "lat": 35.269615,
     "lon": -120.647253,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1215 Joyce Ct."
   },
   {
     "lat": 35.253618,
     "lon": -120.636411,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3962 Kilbern Way"
   },
   {
     "lat": 35.293831,
     "lon": -120.682958,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "10 La Entrada Ave."
   },
   {
     "lat": 35.26421,
     "lon": -120.659173,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "286 Lawrence Dr."
   },
   {
     "lat": 35.263965,
     "lon": -120.653293,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "655 Lawrence Dr."
   },
   {
     "lat": 35.27791,
     "lon": -120.654495,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1148 Leff St."
   },
   {
     "lat": 35.260531,
     "lon": -120.695661,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "11245 Los Osos Valley Road"
   },
   {
     "lat": 35.259926,
     "lon": -120.699974,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1708 Lynn"
   },
   {
     "lat": 35.285083,
     "lon": -120.66009,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Corner of Mill & Toro"
   },
   {
     "lat": 35.288367,
     "lon": -120.651308,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1815 Monterey at Grand"
   },
   {
     "lat": 35.260767,
     "lon": -120.63661,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1430 Noveno Ave."
   },
   {
     "lat": 35.260794,
     "lon": -120.68482,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1552 Oceanaire Dr. (near Atascadero St.)"
   },
   {
     "lat": 35.255958,
     "lon": -120.684262,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1906 Oceanaire Dr. (near Pinecove Dr.)"
   },
   {
     "lat": 35.282736,
     "lon": -120.654597,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "Pacific between Johnson & Pepper"
   },
   {
     "lat": 35.255695,
     "lon": -120.688071,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1768 Pereira Dr."
   },
   {
     "lat": 35.246714,
     "lon": -120.629867,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1358 Purple Sage Ln."
   },
   {
     "lat": 35.255406,
     "lon": -120.663539,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "333 Sage St."
   },
   {
     "lat": 35.255423,
     "lon": -120.661865,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "373 Sage St."
   },
   {
     "lat": 35.192977,
     "lon": -120.715295,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1401 San Luis Bay Dr."
   },
   {
     "lat": 35.286554,
     "lon": -120.650418,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1739 San Luis Dr."
   },
   {
     "lat": 35.269203,
     "lon": -120.642908,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1391 San Marcos Ct."
   },
   {
     "lat": 35.276342,
     "lon": -120.656708,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1703 Santa Barbara Ave."
   },
   {
     "lat": 35.24186,
     "lon": -120.676929,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "South Higuera & Los Osos Valley Road"
   },
   {
     "lat": 35.248051,
     "lon": -120.674354,
     "zoom": 16,
-    "label": "Little Free Library"
+    "label": "3960 S. Higuera St. #34"
   },
   {
     "lat": 35.264981,
     "lon": -120.635355,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "3396 Southwood Dr."
   },
   {
     "lat": 35.264823,
     "lon": -120.629282,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1767 Southwood Dr."
   },
   {
     "lat": 35.247748,
     "lon": -120.627995,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "4475 Wavertree St."
   },
   {
     "lat": 35.267197,
     "lon": -120.656072,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "637 Woodbridge"
   },
   {
     "lat": 35.540835,
     "lon": -120.71779,
     "zoom": 18,
-    "label": "Little Free Library"
+    "label": "785 Ashley Ln."
   },
   {
     "lat": 35.549455,
     "lon": -120.709426,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "620 Old Country Rd."
   },
   {
     "lat": 35.553923,
     "lon": -120.73008,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "308 Puffin Way"
   },
   {
     "lat": 35.5509,
     "lon": -120.703762,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "215 S. Main St."
   },
   {
     "lat": 35.542668,
     "lon": -120.722494,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "1027 Santa Rita Rd."
   },
   {
     "lat": 35.555604,
     "lon": -120.706229,
     "zoom": 17,
-    "label": "Little Free Library"
+    "label": "158 Wessels Way"
   }
 ];
 

--- a/web-app/public/little-free-pantries-data.js
+++ b/web-app/public/little-free-pantries-data.js
@@ -6,217 +6,217 @@ export const locations = [
     "lat": 35.11768,
     "lon": -120.591688,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "132 South Halcyon Rd."
   },
   {
     "lat": 35.064428,
     "lon": -120.51708,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "268 Summit Station Rd."
   },
   {
     "lat": 35.491538,
     "lon": -120.647313,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "9557 Curbaril Ave."
   },
   {
     "lat": 35.449172,
     "lon": -120.633742,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "9333 Santa Barbara Rd."
   },
   {
     "lat": 35.120336,
     "lon": -120.621656,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "202 S. 8th St. / 770 Rockaway Ave."
   },
   {
     "lat": 35.124713,
     "lon": -120.611462,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "393 N. 16th St."
   },
   {
     "lat": 35.125591,
     "lon": -120.619581,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "925 Newport Ave."
   },
   {
     "lat": 35.323564,
     "lon": -120.837615,
     "zoom": 16,
-    "label": "Little Free Pantry"
+    "label": "1500 block of 5th St."
   },
   {
     "lat": 35.323314,
     "lon": -120.832444,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "1559 10th St."
   },
   {
     "lat": 35.313346,
     "lon": -120.845536,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "490 Los Osos Valley Rd."
   },
   {
     "lat": 35.396754,
     "lon": -120.857001,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "3000 Hemlock Ave."
   },
   {
     "lat": 35.39242,
     "lon": -120.857967,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "397 San Joaquin St."
   },
   {
     "lat": 35.041418,
     "lon": -120.477533,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "181 W Tefft St."
   },
   {
     "lat": 35.03995,
     "lon": -120.47934,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "267 W Tefft St."
   },
   {
     "lat": 35.105814,
     "lon": -120.604037,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "1322 24th St."
   },
   {
     "lat": 35.102703,
     "lon": -120.603613,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "1501 24th St."
   },
   {
     "lat": 35.099906,
     "lon": -120.610517,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "1930 Ocean St."
   },
   {
     "lat": 35.107217,
     "lon": -120.624337,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "615 Pier Ave."
   },
   {
     "lat": 35.62228,
     "lon": -120.694835,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "8th St. and Olive St."
   },
   {
     "lat": 35.648648,
     "lon": -120.694685,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "3301 Oak St."
   },
   {
     "lat": 35.606196,
     "lon": -120.643111,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "1003 Pioneer Trail Rd."
   },
   {
     "lat": 35.135993,
     "lon": -120.610013,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "206 Margo Way"
   },
   {
     "lat": 35.392602,
     "lon": -120.606745,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "22210 El Camino Real"
   },
   {
     "lat": 35.386645,
     "lon": -120.606553,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "22495 K St."
   },
   {
     "lat": 35.260531,
     "lon": -120.643519,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "3320 Bullock Ln."
   },
   {
     "lat": 35.271279,
     "lon": -120.657976,
     "zoom": 18,
-    "label": "Little Free Pantry"
+    "label": "2021 Broad St."
   },
   {
     "lat": 35.295416,
     "lon": -120.673839,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "226 Ferrini Rd."
   },
   {
     "lat": 35.27205,
     "lon": -120.665095,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "335 High St."
   },
   {
     "lat": 35.276312,
     "lon": -120.6483,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "2075 Johnson Ave."
   },
   {
     "lat": 35.260575,
     "lon": -120.695157,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "11245 Los Osos Valley Rd."
   },
   {
     "lat": 35.27646,
     "lon": -120.66708,
     "zoom": 18,
-    "label": "Little Free Pantry"
+    "label": "474 Marsh St."
   },
   {
     "lat": 35.276676,
     "lon": -120.66418,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "1306 Nipomo St."
   },
   {
     "lat": 35.276376,
     "lon": -120.662522,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "695 Pismo St."
   },
   {
     "lat": 35.269527,
     "lon": -120.652344,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "corner of San Carlos and Bushnell"
   },
   {
     "lat": 35.291537,
     "lon": -120.683366,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "193 San Jose Ct."
   },
   {
     "lat": 35.547338,
     "lon": -120.71044,
     "zoom": 17,
-    "label": "Little Free Pantry"
+    "label": "806 Old Country Rd."
   }
 ];
 


### PR DESCRIPTION
 ## Summary

  - Modified the map data extraction script to display actual street addresses instead of repetitive text
  - Little Free Pantries map pins now show addresses like "132 South Halcyon Rd." instead of "Little Free Pantry / Little Free Pantry"
  - Little Free Libraries map pins now show addresses like "330 Alder St." instead of "Little Free Library / Little Free Library"

  ## Changes

  - Updated `scripts/extract-map-data.js` to extract street addresses from link text
  - Regenerated map data files for Little Free Libraries (169 locations) and Little Free Pantries (36 locations)

  ## Test plan

  - [ ] Visit the Little Free Pantries map and verify pins show street addresses
  - [ ] Visit the Little Free Libraries map and verify pins show street addresses
  - [ ] Verify the Naloxone map still works correctly (unchanged)

  Fixes #156
