### PR TITLE
fixes #161 (replace text description with Apple share icon SVG)

### DIFF
--- a/About.md
+++ b/About.md
@@ -45,12 +45,12 @@ You can install this resource guide as an app on your phone, tablet, or computer
 ### If You See the Install Button
 
 If you see an “Install App” button (as shown in the table above) in the bottom-right corner of the screen, just tap it!
-The button appears when your browser supports direct installation.
+The button appears only if your browser supports direct installation.
 
 ### iPhone or iPad (Safari)
 
-1. Open this page in Safari (the default web browser).
-2. Tap the share button (the square with an up arrow) at the bottom of the screen.
+1. Open VivaSLO.org in Safari (the default web browser).
+2. Tap the share button (<svg style="display:inline-block;vertical-align:middle;width:1.2em;height:1.2em;" viewBox="0 0 20 22" fill="currentColor"><path d="M9 3C9 2.44772 9.44772 2 10 2C10.5523 2 11 2.44772 11 3L11 13.5C11 14.0523 10.5523 14.5 10 14.5C9.44772 14.5 9 14.0523 9 13.5L9 3Z"/><path d="M10.6402 2.76826C11.0645 2.41469 11.1218 1.78413 10.7682 1.35985C10.4147 0.935575 9.7841 0.878251 9.35982 1.23181L6.35982 3.73181C5.93554 4.08538 5.87822 4.71594 6.23178 5.14022C6.58535 5.5645 7.21591 5.62182 7.64019 5.26826L10.6402 2.76826Z"/><path d="M9.35981 2.76826C8.93553 2.41469 8.87821 1.78413 9.23177 1.35985C9.58534 0.935575 10.2159 0.878251 10.6402 1.23181L13.6402 3.73181C14.0645 4.08538 14.1218 4.71594 13.7682 5.14022C13.4147 5.5645 12.7841 5.62182 12.3598 5.26826L9.35981 2.76826Z"/><path d="M13 9C12.4477 9 12 8.55228 12 8C12 7.44772 12.4477 7 13 7H14C15.6233 7 17 8.16491 17 9.69231V17.3077C17 18.8351 15.6233 20 14 20L6 20C4.37672 20 3 18.8351 3 17.3077L3 9.69231C3 8.16491 4.37672 7 6 7H7C7.55228 7 8 7.44772 8 8C8 8.55228 7.55228 9 7 9H6C5.41414 9 5 9.35043 5 9.69231L5 17.3077C5 17.6496 5.41414 18 6 18L14 18C14.5859 18 15 17.6496 15 17.3077L15 9.69231C15 9.35043 14.5859 9 14 9L13 9Z"/></svg>) at the bottom of the screen.
 3. Scroll down and tap **Add to Home Screen**.
 4. Tap **Add** in the top right corner.
 

--- a/About_es.md
+++ b/About_es.md
@@ -45,14 +45,14 @@ Puedes instalar esta guía de recursos como aplicación en tu teléfono, tableta
 ### Si Ves el Botón de Instalación
 
 Si ves el botón “Instalar aplicación” (como se muestra en la tabla anterior) en la esquina inferior derecha de la pantalla, ¡simplemente tócalo!
-El botón aparece cuando tu navegador admite la instalación directa.
+El botón solo aparece si su navegador admite la instalación directa.
 
 ### iPhone o iPad (Safari)
 
-1. Abre esta página en Safari (el navegador web predeterminado).
-2. Toca el botón para compartir (el cuadrado con una flecha hacia arriba) en la parte inferior de la pantalla.
-3. Desplázate hacia abajo y toca **Añadir a la pantalla de inicio**.
-4. Toca **Añadir** en la esquina superior derecha.
+1. Abre VivaSLO.org en Safari (el navegador web predeterminado).
+2. Toca el botón para compartir (<svg style="display:inline-block;vertical-align:middle;width:1.2em;height:1.2em;" viewBox="0 0 20 22" fill="currentColor"><path d="M9 3C9 2.44772 9.44772 2 10 2C10.5523 2 11 2.44772 11 3L11 13.5C11 14.0523 10.5523 14.5 10 14.5C9.44772 14.5 9 14.0523 9 13.5L9 3Z"/><path d="M10.6402 2.76826C11.0645 2.41469 11.1218 1.78413 10.7682 1.35985C10.4147 0.935575 9.7841 0.878251 9.35982 1.23181L6.35982 3.73181C5.93554 4.08538 5.87822 4.71594 6.23178 5.14022C6.58535 5.5645 7.21591 5.62182 7.64019 5.26826L10.6402 2.76826Z"/><path d="M9.35981 2.76826C8.93553 2.41469 8.87821 1.78413 9.23177 1.35985C9.58534 0.935575 10.2159 0.878251 10.6402 1.23181L13.6402 3.73181C14.0645 4.08538 14.1218 4.71594 13.7682 5.14022C13.4147 5.5645 12.7841 5.62182 12.3598 5.26826L9.35981 2.76826Z"/><path d="M13 9C12.4477 9 12 8.55228 12 8C12 7.44772 12.4477 7 13 7H14C15.6233 7 17 8.16491 17 9.69231V17.3077C17 18.8351 15.6233 20 14 20L6 20C4.37672 20 3 18.8351 3 17.3077L3 9.69231C3 8.16491 4.37672 7 6 7H7C7.55228 7 8 7.44772 8 8C8 8.55228 7.55228 9 7 9H6C5.41414 9 5 9.35043 5 9.69231L5 17.3077C5 17.6496 5.41414 18 6 18L14 18C14.5859 18 15 17.6496 15 17.3077L15 9.69231C15 9.35043 14.5859 9 14 9L13 9Z"/></svg>) en la parte inferior de la pantalla.
+3. Desplázate hacia abajo y toca **Agregar a pantalla de inicio**.
+4. Toca **Agregar** en la esquina superior derecha.
 
 *Nota: En iPhone/iPad, debes usar Safari para que esta función funcione.
 Otros navegadores como Chrome o Firefox no admiten la instalación de aplicaciones web en iOS.*


### PR DESCRIPTION
Replace text descriptions "the square with an up arrow" with accurate SVG representation of iOS share button in installation instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)