### PR TITLE
fix word-breaks in phone number and email links

### DIFF
--- a/web-app/src/style.css
+++ b/web-app/src/style.css
@@ -400,6 +400,7 @@ a[href^="tel:"] {
   cursor: pointer;
   line-height: inherit;
   white-space: normal;
+  word-break: keep-all;
 }
 
 a[href^="tel:"]::before {
@@ -431,6 +432,7 @@ a[href^="mailto:"] {
   cursor: pointer;
   line-height: inherit;
   white-space: normal;
+  word-break: keep-all;
 }
 
 a[href^="mailto:"]::before {


### PR DESCRIPTION
Some phone numbers e.g. in table cells were breaking in the middle of the number, e.g.

> 805-555-12
> 12

This fixes that.