### PR TITLE
Switch feedback email to showerthepeopleslo@gmail.com

### DIFF
--- a/FEEDBACK-IMPLEMENTATION.md
+++ b/FEEDBACK-IMPLEMENTATION.md
@@ -41,7 +41,7 @@ Implemented a server-side email sending system using **Cloudflare Email Routing*
 └────────┬────────────────────┘
          │
          ↓
-    moorlock@gmail.com
+    showerthepeopleslo@gmail.com
 ```
 
 ## Files Created
@@ -110,7 +110,7 @@ The three map pages now share a single feedback library (`map-feedback.js`), mak
 
 ### Prerequisites (One-time setup)
 1. Enable Email Routing for vivaslo.org domain in Cloudflare dashboard
-2. Verify moorlock@gmail.com as a destination address
+2. Verify showerthepeopleslo@gmail.com as a destination address
 3. Deploy the Email Sender Worker
 4. Configure service binding in Pages project settings
 
@@ -141,7 +141,7 @@ The three map pages now share a single feedback library (`map-feedback.js`), mak
 - [ ] Name/email fields are optional
 - [ ] Feedback message is required
 - [ ] Success message displays after submission
-- [ ] Email arrives at moorlock@gmail.com
+- [ ] Email arrives at showerthepeopleslo@gmail.com
 - [ ] Error handling works when service is unavailable
 
 ## Benefits

--- a/web-app/functions/_worker-email-sender/README.md
+++ b/web-app/functions/_worker-email-sender/README.md
@@ -15,7 +15,7 @@ Before deploying this Worker, you must:
    - Follow the setup wizard to enable Email Routing
 
 2. **Verify destination email address**
-   - Add and verify `moorlock@gmail.com` as a destination address
+   - Add and verify `showerthepeopleslo@gmail.com` as a destination address
    - You'll receive a verification email that must be confirmed
 
 3. **Configure DNS for sending**
@@ -74,7 +74,7 @@ To test the email functionality:
 2. Click the feedback button (💬)
 3. Fill out the form with test data
 4. Submit
-5. Check that you receive the email at moorlock@gmail.com
+5. Check that you receive the email at showerthepeopleslo@gmail.com
 
 ## Troubleshooting
 
@@ -117,7 +117,7 @@ Email Sender Worker (this worker)
     ↓ (Email Routing Binding)
 Cloudflare Email Routing
     ↓
-moorlock@gmail.com
+showerthepeopleslo@gmail.com
 ```
 
 ## Configuration

--- a/web-app/functions/_worker-email-sender/wrangler.toml
+++ b/web-app/functions/_worker-email-sender/wrangler.toml
@@ -15,4 +15,4 @@ compatibility_flags = ["nodejs_compat"]
 [[send_email]]
 name = "EMAIL"
 # destination_address restricts sending to only this verified address
-destination_address = "moorlock@gmail.com"
+destination_address = "showerthepeopleslo@gmail.com"

--- a/web-app/functions/api/feedback.js
+++ b/web-app/functions/api/feedback.js
@@ -32,7 +32,7 @@ export async function onRequestPost(context) {
     // Note: The EMAIL_SENDER binding must be configured in the Cloudflare dashboard
     // under Pages project Settings > Functions > Service bindings
     const emailResponse = await sendEmail(env, {
-      to: 'moorlock@gmail.com',
+      to: 'showerthepeopleslo@gmail.com',
       subject: `Feedback (${data.type}) - VivaSLO`,
       content: emailContent,
       replyTo: data.email && isValidEmail(data.email) ? data.email : null

--- a/web-app/public/map-feedback.js
+++ b/web-app/public/map-feedback.js
@@ -107,7 +107,7 @@ export function initMapFeedback(config) {
 
     } catch (error) {
       console.error('Error sending feedback:', error);
-      alert('There was an error sending your feedback. Please try again or email us directly at moorlock@gmail.com');
+      alert('There was an error sending your feedback. Please try again or email us directly at showerthepeopleslo@gmail.com');
     } finally {
       // Re-enable submit button
       feedbackSubmit.disabled = false;

--- a/web-app/src/feedback.js
+++ b/web-app/src/feedback.js
@@ -5,7 +5,7 @@ export class FeedbackSystem {
   constructor() {
     this.feedbackButton = null;
     this.feedbackModal = null;
-    this.recipientEmail = 'moorlock@gmail.com';
+    this.recipientEmail = 'showerthepeopleslo@gmail.com';
     this.strings = getStrings();
   }
 


### PR DESCRIPTION
Update recipient email address from moorlock@gmail.com to showerthepeopleslo@gmail.com in all code files and documentation.

Before merging this change:
1. Complete the email routing change authentication handshake with CloudFlare via email.
1. Redeploy the Email Sender Worker (to pick up the new `destination_address` in `wrangler.toml`):
   ```                                                            
   cd web-app/functions/_worker-email-sender
   wrangler deploy
   ```
1. Test the feedback mechanism on the staging site to make sure the emails get through

Fixes #215