### PR TITLE
Remove superfluous resource-guide group tag from all entries

### DIFF
--- a/monitoring/changedetection-config.json
+++ b/monitoring/changedetection-config.json
@@ -221,9 +221,64 @@
       "url": "https://5chc.org/sites/default/files/2024-02/New%20Warming%20Center%20Talking%20Points.pdf"
     },
     "01604da8-029a-4805-91a3-689914fa347e": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -339,9 +394,64 @@
       "url": "https://www.thediscipleshiphome.com/contact-us"
     },
     "03469950-9ddc-4802-a201-595d2f90af48": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -648,9 +758,64 @@
       "url": "https://slocountyparks.com/camp/coastal-dunes/"
     },
     "04b33283-2972-4fc3-8563-91dfaf9cc236": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -666,9 +831,64 @@
       "url": "https://sloalanoclub.org/meeting-schedule"
     },
     "051ce725-446f-454b-bc77-bd3ec6b21dc1": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -937,9 +1157,64 @@
       "url": "https://centerforautism.com/locations/san-luis-obispo-california/"
     },
     "07e2b547-aa96-4d96-85e2-212daecf6ae8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#block-views-block-get-help-categories-block-1"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -955,12 +1230,70 @@
       "url": "https://www.slolaf.org/housing"
     },
     "0870eccf-ef2d-49b1-a33a-051f9bfda099": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "h4.wp-block-heading"
+      ],
       "url": "https://atascadero-ca.toysfortots.org/"
     },
     "087dc643-0d6c-4af5-82ae-719aef788925": {
@@ -1028,6 +1361,58 @@
       "url": "https://tolosachildrensdental.org/"
     },
     "08b9c8fd-3f3c-46c0-851a-c0722b87962c": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
@@ -1037,9 +1422,64 @@
       "url": "https://atascaderoseniorcenter.org/activities"
     },
     "08dcd048-5c2d-42d3-9630-6de9a3b9660b": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.col-sm-12:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -1159,9 +1599,64 @@
       "url": "https://www.ciymca.org/financial-assistance"
     },
     "0a56d218-ac7d-4843-8b63-493827828d3d": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -1478,9 +1973,67 @@
       "url": "https://koa.com/campgrounds/santa-margarita/"
     },
     "0b253f74-0bf0-4aab-98bc-00ff5c32bad5": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#block-aboutcrladescription",
+        "#block-aboutcrladonatesection",
+        "#block-mission",
+        "#block-vision"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -1551,9 +2104,64 @@
       "url": "https://5chc.org/community-services/domestic-violence"
     },
     "0c643d0d-4e60-4d5b-9897-0011cc90d85a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -1643,9 +2251,65 @@
       "url": "https://calpoison.org/"
     },
     "0d3afcf1-cff7-4924-a007-0af44f532c42": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.x-sm:nth-child(1)",
+        "div.x-sm:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -1716,18 +2380,128 @@
       "url": "https://cdss.ca.gov/inforesources/safely-surrendered-baby/surrender-sites"
     },
     "0da4c1a3-a706-46df-ac9a-fd389a94f12e": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262841564&unit_list=0&akaSort=0&query=%20&simple_query=&code=LL&limit=&name="
     },
     "0dc2f429-5862-4f37-8a67-5fc228b72527": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#result-rows-wrapper"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -1909,9 +2683,64 @@
       "url": "https://www.slonoorfoundation.org/dental"
     },
     "0fa951e4-19b5-4864-aa2c-e46ccc5cfa3a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".cta1-wrap"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -2002,9 +2831,65 @@
       "url": "https://travel.state.gov/content/travel/en/passports/how-apply/photos.html"
     },
     "10df4fe5-a716-4e59-8e0a-94af953ea55a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".site-content-contain",
+        ".lower-footer > div:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -2371,9 +3256,64 @@
       "url": "https://www.caljobs.ca.gov/vosnet/LoginIntro2.aspx"
     },
     "137087a9-2ee3-48b9-9106-221f2726c097": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -2803,7 +3743,7 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        ".vc_general"
+        "#\\31 603302191846-0d88dd41-feca"
       ],
       "method": "GET",
       "notification_format": "System default",
@@ -3035,9 +3975,64 @@
       "url": "https://www.bellavistabythesea.com/"
     },
     "178180f6-470b-45a5-8044-9446c7df9112": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -3155,9 +4150,64 @@
       "url": "https://www.volunteerslo.org/agency/detail/?agency_id=31613"
     },
     "18d83f6f-ec60-4dcd-b61e-b000e8e1636f": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -3325,18 +4375,129 @@
       "url": "https://www.slocounty.ca.gov/departments/clerk-recorder/forms-documents/fees/fee-schedule-effective-1-1-2024"
     },
     "19e9463d-fdaf-48f5-802f-697e5b8a1cd5": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".page__blocks"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://alffoodpantry.org/"
     },
     "1a05cf05-0604-4b4e-8be1-4cafe853708f": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.columns:nth-child(2)",
+        "div.column:nth-child(11)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -3416,9 +4577,64 @@
       "url": "https://www.modestneeds.org/mn/about-us"
     },
     "1a981f61-f7c9-4335-b89b-0ec0d87c8a1f": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".custom-body-container"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -3490,9 +4706,64 @@
       "url": "https://restorativepartners.org/workforce-development/"
     },
     "1ae9473f-c195-41b2-9ceb-c26cbc7c2291": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -4021,9 +5292,64 @@
       "url": "https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide/senior-programs"
     },
     "1f84914c-bb05-4272-a305-f0995f717f37": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -4104,9 +5430,65 @@
       "url": "https://santamariavalleyhispanicca.adventistchurch.org/"
     },
     "2014974e-abd9-4e80-b93a-88c1416107f8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#fsEl_8163",
+        "#fsEl_5396 > div:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -4458,6 +5840,10 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main",
+        "#custom_post_widget-4"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -5097,9 +6483,64 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=DD-1800"
     },
     "25a7ad52-494b-43f8-a3d4-8f4399d68db0": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -5172,9 +6613,64 @@
       "url": "https://www.hpcn.org/contact"
     },
     "262fbed9-e26c-4513-b61d-44da355a41ef": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -5285,9 +6781,65 @@
       "url": "https://storage.googleapis.com/t-mha-org/uploads/WC%20In%20Person%20Group%20Flyer%20All2.pdf"
     },
     "278be7ae-7395-403c-8e3c-74f3cb4405c2": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "body > div:nth-child(2)",
+        ".md\\:space-x-8 > div:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -5595,9 +7147,64 @@
       "url": "https://www.cityfarmslo.org/farmstand"
     },
     "2a72005a-2e8d-415c-ad76-e28c3bd15377": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -5695,9 +7302,64 @@
       "url": "https://pasoroblesha.org/community-services/youth-works/"
     },
     "2b29a093-30c8-482b-a1bb-18bb68f2d7f0": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -5798,9 +7460,64 @@
       "url": "https://www.t-mha.org/program-details.php?id=20"
     },
     "2c762d80-ed9a-45fa-8287-024483028af6": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#result-rows-wrapper"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -6151,9 +7868,64 @@
       "url": "https://www.communityhealthcenters.org/locations/"
     },
     "2e72183b-d53f-46b4-947f-12199b559aa0": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -6244,9 +8016,64 @@
       "url": "https://www.slocounty.ca.gov/departments/district-attorney/adult-prosecutions/veterans-treatment-court"
     },
     "2fdd3986-cedb-4c19-b054-13ee814db0bb": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".MuiContainer-root"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -6605,9 +8432,64 @@
       "url": "https://www.google.com/maps/d/u/0/viewer?mid=1KVbOaPBP2Xh1zk59DS9nI-BjjYnrwtwD&hl=en_US&ll=35.27874180000001%2C-120.6579635&z=8"
     },
     "33f1d86e-f4a2-43ea-ae0f-2f5b2a2b1792": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.x-container:nth-child(4)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -6853,21 +8735,134 @@
       "url": "https://travel.state.gov/content/travel/en/passports/have-passport/lost-stolen.html"
     },
     "347845f5-8ba0-41cc-938e-89d2421f9671": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=8&search_history_id=262842494&unit_list=0&akaSort=0&query=%20&simple_query=&code=TJ-3000&limit=&name="
     },
     "347d3ad1-1fc1-4853-85d1-85bf97e3abde": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "trigger_text": [
+        "Services:"
+      ],
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=NS"
     },
     "34eef24d-7d54-4b32-890a-b468785c478b": {
@@ -6935,6 +8930,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#\\31 755192260681-29f97bf4-933c"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -7720,58 +9718,61 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".col-lg-9"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -8344,9 +10345,64 @@
       "url": "http://luciamarschools.org/251185_2"
     },
     "3f4ddbd8-474f-4370-aa11-baaed4a7b956": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -8380,9 +10436,64 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=FT-4800"
     },
     "406debb6-02a9-4878-b5ed-5a685d2c369d": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -8434,18 +10545,128 @@
       "url": "https://www.calfreshcalpoly.org/"
     },
     "4264b3a9-681e-42ad-87a8-29c6d84fe631": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BD-5000.3500"
     },
     "4298c225-8988-4f41-8374-d9eb2e2e23ff": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -9069,9 +11290,64 @@
       "url": "https://www.atascadero.org/service/crime-reporting"
     },
     "467af216-2632-41f0-96db-2f1c58e64057": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -9208,9 +11484,64 @@
       "url": "https://fcni.org/what-we-do/"
     },
     "4743495b-cfe6-4a2f-9b22-267354f60319": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -9301,9 +11632,64 @@
       "url": "https://docs.google.com/forms/d/e/1FAIpQLSd0dB-A6zwwnTexekCxR4uoPS_QrnglZJ4fS4YwCgmaUSMFzw/viewform"
     },
     "478d589e-5414-4c54-a93c-79c2daeda703": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".col-md-9"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -9392,9 +11778,64 @@
       "url": "https://www.slonoorfoundation.org/womensmobilehealthunit"
     },
     "491d32dd-3a8a-4b3f-a1b5-407781bc7946": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -9850,15 +12291,25 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "lottie-player"
+      ],
       "include_filters": [
         "#brxe-umjxke",
         "#brxe-2824d9",
         "#brxe-bqpprj",
-        "#brx-footer"
+        "#brx-footer",
+        "#brxe-psztyr"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "#menu-footer-nav",
+        "#brxe-djfahy",
+        "#brxe-dugasc",
+        "#brxe-angryb"
+      ],
       "url": "https://pinnacletreatment.com/location/california/san-luis-obispo/aegis-san-luis-obispo-med-unit/"
     },
     "4b148cab-0b5f-46cc-a791-93d72c2a82f1": {
@@ -9944,58 +12395,63 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.uk-section-default:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)",
+        "div.uk-section-default:nth-child(8) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)",
+        "div.uk-text-primary:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -10278,58 +12734,61 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.et_pb_section:nth-child(3)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -11012,7 +13471,7 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "article"
+        ".wp-block-heading"
       ],
       "method": "GET",
       "notification_format": "System default",
@@ -11316,18 +13775,128 @@
       "url": "https://www.plannedparenthood.org/health-center/california/san-luis-obispo/93401/san-luis-obispo-health-center-2252-90170#hours-walk-ins"
     },
     "536c8913-4ff4-450b-85a0-d3886f2c86d7": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=FN-1500"
     },
     "537ba714-5438-429d-8e16-bad8e0278a86": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "h3"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -11426,9 +13995,64 @@
       "url": "https://www.slocounty.ca.gov/departments/social-services/workforce-development-board/forms-documents/job-seeker-resource-guide"
     },
     "541f9bda-854e-4478-8cc0-f592440a0081": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -11968,6 +14592,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -12318,9 +14945,64 @@
       "url": "https://ilshealth.com/calaim-resources/"
     },
     "565319b8-94a0-4d28-8876-6d889b90e341": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -12391,58 +15073,61 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -12712,12 +15397,70 @@
       "url": "https://petsofthehomeless.org/get-help/how-we-help/"
     },
     "58ee0f61-5005-4ede-8e84-3585911daca6": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".Dq4amc"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "noscript"
+      ],
       "url": "https://docs.google.com/forms/d/e/1FAIpQLScDFqtdG77YXPshx4OSOw8GaYUSudizOLA1JeYVb7UCC9l-Ag/viewform"
     },
     "593256e0-b56b-4eaf-9526-0e4ffe266a6d": {
@@ -12918,6 +15661,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -13016,18 +15762,129 @@
       "url": "https://sloiwma.recyclist.co/guide/soda-cans/?embeddedguide=true"
     },
     "5b0270d3-de85-400e-8a4d-33ac8ec00bea": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/community-services/financial-assistance"
     },
     "5b11abbf-6ffb-4132-9593-6f071fa671c0": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".d-none",
+        ".py-5"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -13098,9 +15955,64 @@
       "url": "https://tcglad.org/mental-health/"
     },
     "5bac473d-e576-412a-83f2-18aa5fa04c6b": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#mainContentBlock"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -13163,11 +16075,14 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "div.entry-content"
+        "main"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "h4.wp-block-heading"
+      ],
       "url": "https://atascadero-ca.toysfortots.org/local-coordinator-sites/lco-sites/local-contact-us.aspx"
     },
     "5bc023c3-e616-4ec6-b654-9f28d0a56864": {
@@ -13236,9 +16151,64 @@
       "url": "https://restorativepartners.org/contact/"
     },
     "5c6292e7-5609-4f41-9769-325685cc16a3": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -13393,9 +16363,65 @@
       "url": "https://www.vetride.va.gov/app/home"
     },
     "5e03b2d5-913b-4649-87f1-caabbcd93eb6": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#leftContentColumn",
+        "#mainContentBlock > h3:nth-child(4)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -13738,18 +16764,128 @@
       "url": "https://petsofthehomeless.org/get-help/"
     },
     "609cd5d3-47de-469f-a752-6311afed071d": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=LH-5000"
     },
     "60fce347-0c72-42fe-98f7-a845a97a9a9b": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -14423,18 +17559,128 @@
       "url": "https://211slo.org/"
     },
     "63cb586b-7dee-4d50-9f61-d6c2518eb61a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=LT"
     },
     "6441832b-f275-49c7-96c1-8be56d4cf5a4": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -14657,9 +17903,64 @@
       "url": "https://docs.google.com/document/d/17-ZYN4uYV-PNWLGu2QAZXMv6wQItZGcsZfpBLysbL70/mobilebasic"
     },
     "65b3fa1e-3cdd-43c5-a5a1-6348ac4bf544": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -14742,9 +18043,65 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262841467&unit_list=0&akaSort=0&query=%20&simple_query=&code=LH-2700&limit=&name="
     },
     "66862e2c-d91a-4e79-927f-2929fd511345": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main",
+        "div.sqs-col-4:nth-child(3)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -14850,58 +18207,63 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".sit-top-bar",
+        "#post-14",
+        ".textwidget"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -15183,9 +18545,64 @@
       "url": "https://www.slo.courts.ca.gov/general-information/location-contact-info"
     },
     "6a459818-45dd-4f7b-b79e-a0c9273cf16c": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#leftContentColumn"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -15256,9 +18673,64 @@
       "url": "https://www.slocity.org/government/department-directory/public-works/slo-transit/discount-programs"
     },
     "6a8fb0d6-0819-4ce2-a290-9954098a4ab8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "body > div:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -15349,18 +18821,128 @@
       "url": "https://landing.brainfuse.com/authenticate.asp?u=main.sloh.ca.brainfuse.com"
     },
     "6b72dcd5-08ea-4612-bc16-7d2fe5d1dfaa": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=4&search_history_id=262841874&unit_list=0&akaSort=0&query=%20&simple_query=&code=PL&limit=&name="
     },
     "6bcfabb9-642c-4aeb-bf0e-5d5907c42114": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.x-container:nth-child(4)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -15442,9 +19024,64 @@
       "url": "https://admissions.centerforautism.com/"
     },
     "6c604047-92fb-4650-a066-4c477025cc2c": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -15577,9 +19214,64 @@
       "url": "https://restorativepartners.org/about/"
     },
     "6d5e48a7-0904-4d15-9b11-dcf8ff67d38e": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -15935,9 +19627,64 @@
       "url": "https://www.joslynrec.org/CAN/index.html"
     },
     "6eb4fe2c-9da2-49c5-aba2-cc6d0186de5c": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -16078,6 +19825,9 @@
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "app-modal"
+      ],
       "url": "https://www.alz.org/cacentralcoast/support/supportgroups"
     },
     "6f24696b-3163-48f5-a85d-a5e692755bb8": {
@@ -16913,9 +20663,64 @@
       "url": "https://northcountyconnection.org/"
     },
     "74171265-011a-4189-ae47-ac27b33a53e9": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -16986,9 +20791,64 @@
       "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/resource-center"
     },
     "756f7235-16aa-4906-9484-0ec82d5f5dbf": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -17498,18 +21358,128 @@
       "url": "https://calfresh.guide/verifications-the-calfresh-office-requires/"
     },
     "77987fc8-e760-4f29-9acf-597f46a10c7d": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".pages-left-column-wrapper"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.omsslo.org/apps/pages/index.jsp?uREC_ID=3643070&type=d&pREC_ID=2413322"
     },
     "77bfd3cf-95de-4f48-9788-8c1561489a50": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -17709,9 +21679,64 @@
       "url": "https://capslo.org/energy-services/"
     },
     "77fa5c36-d2d1-4aaa-87e3-3567414ba369": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -18082,9 +22107,64 @@
       "url": "https://cfsslo.org/north-county-neighboraid/"
     },
     "79248a14-b1e3-49cb-a388-5285891dca24": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -18936,9 +23016,64 @@
       "url": "https://nche.ed.gov/mckinney-vento-definition/"
     },
     "7d2deecd-2a05-402b-8bb3-8e8f6dbc9d82": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -19106,9 +23241,64 @@
       "url": "https://www.rooseveltfamilyapts.com/"
     },
     "7f056f67-2cdd-42af-9d17-9426f4437ea8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -19395,9 +23585,64 @@
       "url": "https://apameds.org/what-we-do/"
     },
     "80edeb2e-a084-4adf-9375-68e1a4a52ac5": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -19486,9 +23731,64 @@
       "url": "https://dreamcenter.calpoly.edu/LegalServices"
     },
     "81591e61-0c63-45fb-9f26-1925ef2f08b6": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -19795,9 +24095,64 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=FT-4500"
     },
     "834d8368-e71b-4bed-ab0b-70a70c919044": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div#main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -19813,9 +24168,64 @@
       "url": "https://iafdb.travel.state.gov/"
     },
     "84051e0b-d506-45f3-8ec5-c7e67ab38f6a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -19895,16 +24305,15 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
-      "ignore_text": [
-        "Open now",
-        "Closed now"
-      ],
       "include_filters": [
         "#location-and-hours"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".open-status__09f24__YH9PK"
+      ],
       "url": "https://www.yelp.com/biz/california-cool-thrift-store-grover-beach#location-and-hours"
     },
     "84f1aaa9-bb61-4d55-b127-f136ed93f36c": {
@@ -20070,58 +24479,61 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#result-rows-wrapper"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -20331,12 +24743,73 @@
       "url": "https://careerservices.calpoly.edu/explore-services"
     },
     "8786bce9-bb1b-4154-b356-f01b233c1b9f": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".row-contact",
+        "#services",
+        "div.contact"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "ul.socials",
+        "ul.badges"
+      ],
       "url": "https://www.t-mha.org/"
     },
     "879d4706-a353-460a-b204-143f8e982f84": {
@@ -20559,9 +25032,64 @@
       "url": "https://www.t-mha.org/central-coast-hotline.php"
     },
     "8a7c11ad-c33a-494b-b5f1-2950b6492027": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -20670,9 +25198,64 @@
       "url": "https://luminaalliance.org/get-help-now#services"
     },
     "8beaf953-4fbe-4710-a770-2243ffd6b194": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -20959,18 +25542,131 @@
       "url": "https://5chc.org/community-services/social-services"
     },
     "8d4f01e8-7680-441b-b3d4-1edb6b0cdc82": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "section.py-5:nth-child(3)",
+        "#root-main > app-main:nth-child(3) > blade-3steps:nth-child(4)",
+        "#root-main > app-main:nth-child(3) > blade-apply-reqs:nth-child(5)",
+        "#root-main > app-main:nth-child(3) > blade-legal:nth-child(6)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.californialifeline.com/"
     },
     "8d8fd3c1-a368-4824-a0e4-d59970b5c593": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -21115,9 +25811,64 @@
       "url": "https://www.hardshiptools.org/MyApp/Apply.aspx"
     },
     "8df7a612-1ec8-43a6-808d-ca558b0d7937": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -21199,18 +25950,128 @@
       "url": "https://www.slocounty.ca.gov/departments/clerk-recorder/all-services/vital-records-(births,-deaths,-marriages)/marriage-certificates"
     },
     "8ea00a37-ac61-4133-9333-b4e3e81dd9dd": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-3300.3100"
     },
     "8ea2bd38-8ebb-4a54-bed1-bc5fcc3cd16f": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -21502,9 +26363,64 @@
       "url": "https://www.grover.org/652/Report-an-Issue"
     },
     "91634458-787c-4050-b5ce-46c40387e4fc": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -21643,9 +26559,64 @@
       "url": "https://en.wikipedia.org/wiki/SMART_criteria"
     },
     "920a010a-5276-4114-90af-31efb0ff9886": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -21727,9 +26698,64 @@
       "url": "https://krittercare.org/contact-us"
     },
     "92b856a9-f61c-4b1e-96c0-f2912b454352": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -21791,6 +26817,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "805-"
+      ],
       "include_filters": [
         ".nav-info"
       ],
@@ -22438,9 +27467,64 @@
       "url": "https://www.va.gov/health-care/health-needs-conditions/substance-use-problems/"
     },
     "9717deb1-a522-4776-bc70-8dc55761e82a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -22602,27 +27686,192 @@
       "url": "https://www.pshhc.org/apply/"
     },
     "99858993-4868-43bf-a41f-05af15d6f8ea": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#center-right-container > div:nth-child(1)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cancer.org/about-us/online-help/contact-us.html"
     },
     "99b7baf9-4250-4c45-9ab8-6b8cc40577af": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/community-services/clothing"
     },
     "99d22837-2a47-459d-ad65-b6b705c0e419": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -22761,9 +28010,64 @@
       "url": "https://centralcoasthomehealth.com/index.php/support-groups/"
     },
     "9a1173cd-920b-433a-bb55-f95afa932ddb": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -23139,6 +28443,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".elementor-element-3fccfc0 > div:nth-child(1)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -23288,13 +28595,72 @@
       "url": "https://www.prtoybank.org/copy-of-family-registration"
     },
     "9da8d8ce-ecc1-4b35-bfcb-31b1d4e4c76e": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".col-10",
+        ".bg-gradient-linear-tan-horizontal-rtl",
+        "section.container",
+        ".bg-teal-light",
+        "div.col-11:nth-child(3)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://accesscentralcoast.org/about-us/contact-information.php"
+      "url": "https://accesscentralcoast.org/about-us/contact-us.php"
     },
     "9db392dc-02b7-49fb-86d3-006d504aaebf": {
       "browser_steps": [
@@ -23762,9 +29128,64 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=LR"
     },
     "9fce450e-5cb8-45b5-b474-53e739069f4e": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -23917,9 +29338,64 @@
       "url": "https://www.atascadero.org/recreation"
     },
     "a0874db3-b514-46a0-9e19-97d7511ebaa7": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -23935,9 +29411,64 @@
       "url": "https://www.slohealthaccess.org/no-insurance.html"
     },
     "a0eee78a-ee27-4cc5-91be-15eac8ea1c57": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.container-fluid:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -24073,9 +29604,64 @@
       "url": "https://www.slocounty.ca.gov/departments/social-services/calfresh/services/calfresh-food-assistance"
     },
     "a198dd56-0a50-45c1-b618-4bc254be28e0": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -24393,27 +29979,192 @@
       "url": "https://www.slocounty.ca.gov/departments/child-support"
     },
     "a3b76159-98c0-408d-9283-1c1cfa998dc3": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262842419&unit_list=0&akaSort=0&query=%20&simple_query=&code=RP-1400&limit=&name="
     },
     "a3bb74a6-b3d4-4b0a-9ad7-76a68db91589": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262841591&unit_list=0&akaSort=0&query=%20&simple_query=&code=LN&limit=&name="
     },
     "a4035487-8a54-465d-9d72-95f383747272": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -24671,9 +30422,64 @@
       "url": "https://partnersincaring.org/"
     },
     "a664d2d6-19d6-4fd4-a40b-ce96e1980481": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -24735,6 +30541,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Next Meeting:"
+      ],
       "include_filters": [
         "#content-main"
       ],
@@ -24875,11 +30684,14 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "div.entry-content"
+        "main"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        "h4.wp-block-heading"
+      ],
       "url": "https://atascadero-ca.toysfortots.org/local-coordinator-sites/lco-sites/local-toy-request-single-form.aspx"
     },
     "a79ad668-7434-4855-9333-8369dc073cee": {
@@ -24892,9 +30704,65 @@
       "url": "https://www.dor.ca.gov/Home/ContactUs"
     },
     "a7a6c024-a574-41a1-a741-4242807d42ec": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.fs-5",
+        "div.text-lg-start:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -25318,9 +31186,64 @@
       "url": "https://www.slocountyfarmers.org/snap"
     },
     "aa1cb722-0d6a-48aa-844d-a6dba890e920": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -25391,9 +31314,64 @@
       "url": "https://www.cde.ca.gov/ls/nu/sf/index.asp"
     },
     "aafa56d3-af2c-4839-ae71-e25d42c92f04": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".accessibility"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -25491,9 +31469,67 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=NL"
     },
     "ac9b6db6-593d-4c55-ab04-9152a69f3ddc": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#s-5363cd57-8c51-4612-a086-56985f284ab4",
+        "#s-8a57da3f-ba0d-4264-a403-7b93d2b4215e > div:nth-child(1) > div:nth-child(2) > div:nth-child(3)",
+        "#s-8a57da3f-ba0d-4264-a403-7b93d2b4215e > div:nth-child(1) > div:nth-child(2) > div:nth-child(4)",
+        "#s-8a57da3f-ba0d-4264-a403-7b93d2b4215e > div:nth-child(1) > div:nth-child(2) > div:nth-child(5)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -25564,9 +31600,64 @@
       "url": "https://friendsof40prado.org/safe-parking-program-expanded/"
     },
     "ad2840f9-ea55-4fbf-9584-829a361bd029": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -26012,6 +32103,58 @@
       "url": "https://www.slo.courts.ca.gov/self-help/family-law"
     },
     "b08bbade-bdf3-45dc-a642-31437e79a000": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
@@ -26998,9 +33141,64 @@
       "url": "https://www.cancer.org/support-programs-and-services/road-to-recovery.html"
     },
     "b6d383e5-ee0b-4361-9dbf-9729d4b42718": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -27476,9 +33674,64 @@
       "url": "https://www.cuesta.edu/"
     },
     "b8f4156b-5a5f-46d2-bde1-5a4b9b2ebfc8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -27810,6 +34063,9 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -27954,9 +34210,64 @@
       "url": "https://5chc.org/community-services/food-distribution"
     },
     "bd60af2a-5376-4c85-98a8-a4dc2858bee3": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -28386,9 +34697,64 @@
       "url": "https://www.slocounty.ca.gov/departments/public-works/services/programs-outreach/los-osos-low-income-financial-assistance-program"
     },
     "c094233d-baa3-4284-940f-cf18ee974c42": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#collapse0"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -28450,6 +34816,11 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".fusion-header-content-3-wrapper",
+        "div.fusion-fullwidth:nth-child(2) > div:nth-child(1)",
+        ".fusion-columns"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -28807,9 +35178,64 @@
       "url": "https://www.t-mha.org/san-luis-obispo-programs.php"
     },
     "c2b43b37-9b1d-45ca-bd8c-6344d498de57": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#moduleContent"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -28880,9 +35306,64 @@
       "url": "https://carbonhealth.com/en/locations/paso-robles-ca"
     },
     "c2fa7d3e-13d7-47d4-be51-e0bb7141ecae": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -29017,9 +35498,64 @@
       "url": "https://www.bgca.org/about-us/local-clubs/"
     },
     "c3e83726-0f25-49a8-bfe4-0c1c2f2bad4c": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#MainContent"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -29097,9 +35633,64 @@
       "url": "https://www.slocity.org/government/department-directory/public-works/slo-transit/fare-information"
     },
     "c47f06b2-7459-4088-b81d-f44fb599d293": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -29185,9 +35776,64 @@
       "url": "https://www.assistanceleague.org/san-luis-obispo-county/operation-school-bell/"
     },
     "c5fb706c-0ff2-47e3-96d9-25652d34d6f6": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -29258,58 +35904,61 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".btContentWrap"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31028,9 +37677,64 @@
       "url": "https://channel.recliquecore.com/programs/1269/kid-s-night-out/?locations=140"
     },
     "d21680b9-9122-4ade-b2ad-159f54a2e4a1": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31202,9 +37906,64 @@
       "url": "https://marijuana-anonymous.org/"
     },
     "d3ba620f-d783-4b8b-950f-087564499d21": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#page-6695a0e5d6dcda40f9dc6b1b"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31407,18 +38166,128 @@
       "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council/hsoc-membership"
     },
     "d4b9e658-fa9c-426a-ac54-dd245c7c6671": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=RP-6400"
     },
     "d4c11b6e-e7a9-45bf-a110-411fe313adb7": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".node__content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31513,9 +38382,64 @@
       "url": "https://galacc.org/events/#calendar"
     },
     "d5e498dc-30a1-45cc-be48-627df7075a38": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31596,9 +38520,64 @@
       "url": "https://www.luciamarschools.org/251185_2"
     },
     "d635e0d1-40f3-4090-92d0-e8798950cfe8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#jw-element-555621242"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31679,9 +38658,66 @@
       "url": "https://galacc.org/resources/#support"
     },
     "d67b16bd-b5c6-4bfa-8031-6b03305614fc": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#block-yui_3_17_2_1_1698963308987_1867",
+        "div.row:nth-child(6) > div:nth-child(2)",
+        "div.row:nth-child(9)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -31904,9 +38940,64 @@
       "url": "https://sacramentohomelessunion.org/"
     },
     "d8929415-af2a-4ea4-8d04-c88e58b179e0": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -32318,9 +39409,64 @@
       "url": "https://adulted.luciamarschools.org/citizenship-classes"
     },
     "dbb09583-a273-406a-b3a5-1465bab4a2cf": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -32409,9 +39555,64 @@
       "url": "https://ae.slcusd.org/parent-part/parent-part-clone"
     },
     "dcdacbbf-9189-4edd-9461-477315027302": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -32623,9 +39824,64 @@
       "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division,-draft/what-we-are-doing/projects/welcome-home-village"
     },
     "de06b2e0-345c-4e3b-87e5-758d3c42c34c": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -33517,9 +40773,66 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-3300.9750"
     },
     "e212b62c-a2d1-4139-91da-aded29b277bc": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.fs-5",
+        "div.text-lg-start:nth-child(2)",
+        "div.col-11:nth-child(3)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -33590,9 +40903,64 @@
       "url": "https://slobar.org/Information-and-referral-service/"
     },
     "e2907718-074a-4ec4-954a-4f3c83294300": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -33931,9 +41299,64 @@
       "url": "https://805streetoutreach.org/contact-us"
     },
     "e42dcaf0-16ec-4d1d-88e5-97c2d697106a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#leftContentColumn"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -34329,9 +41752,64 @@
       "url": "https://5chc.org/sites/default/files/2023-04/Cabins%20for%20Change%20FAQ%20v4%20041923_0.pdf"
     },
     "e65473a7-e8d2-44a7-ab85-34b4c6a8165f": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".custom-body-container"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -34410,9 +41888,68 @@
       "url": "https://centralcoasthomehealth.com/index.php/contact-us/"
     },
     "e7980bba-2dff-4e0e-9d4c-bb6d560cac71": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#page-section-680ae3e2c31a755c931303c3",
+        "#yui_3_17_2_1_1769009834191_171",
+        "#block-680a26eaa964d9e3749481ff",
+        ".fe-680af0b36384346a07665fc1",
+        "footer"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -35117,9 +42654,64 @@
       "url": "https://redrover.org/relief/urgent-care-grants/"
     },
     "ec75a346-4369-4e65-8976-61e36aa4c098": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -35876,9 +43468,64 @@
       "url": "https://www.slocounty.ca.gov/departments/health-agency/animal-services"
     },
     "f021c435-4915-45ed-93f3-b4c9ebc83cd3": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#main-content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -35903,9 +43550,64 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=4&search_history_id=262841941&unit_list=0&akaSort=0&query=%20&simple_query=&code=PN&limit=&name="
     },
     "f10f3820-6d71-4b21-b9fc-0fe285c6d358": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#main-content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -36471,9 +44173,64 @@
       "url": "https://www.slolaf.org/programs"
     },
     "f3071a25-0b21-4f29-bd8a-0390de8cf508": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#main-content"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -36565,58 +44322,66 @@
       "browser_steps": [
         {
           "operation": null,
-          "optional_value": null,
-          "selector": null
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         },
         {
-          "operation": null,
-          "optional_value": null,
-          "selector": null
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
         }
       ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.site-header__top-item:nth-child(1)",
+        ".col-lg-5",
+        ".bg__gray-light",
+        "section.bg__white:nth-child(3)",
+        "section.bg__white:nth-child(4)",
+        ".content-buckets"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -37136,9 +44901,64 @@
       "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/quarterly-homelessness-dashboard"
     },
     "f4fb5dc0-ca78-4b5b-97a3-d567d2efe1d9": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -37481,9 +45301,64 @@
       "url": "https://www.cuesta.edu/academics/continuinged/comm-truck-driving/index.html"
     },
     "f71ad54b-cfa7-4151-9a70-5b2a0c447a12": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -37554,9 +45429,64 @@
       "url": "https://www.morrobayca.gov/983/Service-Request"
     },
     "f7d6e5d9-999f-4355-9d7c-7865353b928a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -37779,9 +45709,64 @@
       "url": "https://www.caljobs.ca.gov/vosnet/ContactUs.aspx"
     },
     "f963b250-5277-4491-ae71-fbf946b38cd8": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -37824,15 +45809,122 @@
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-3300.1800"
     },
     "fa0a3843-2e30-409e-80ca-1607fc9436bd": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "div.x-container:nth-child(2)"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/services/runabout-paratransit/faq/"
     },
     "fa103c98-d767-4ec9-a691-a9c4fe2cac9e": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
@@ -38411,9 +46503,64 @@
       "url": "https://cayucoschurch.com/ministries/"
     },
     "fe114cf3-a5eb-40af-9f26-6dd552543f8d": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -38493,18 +46640,128 @@
       "url": "https://www.prcity.com/293/Senior-Services"
     },
     "fe40736c-0c05-4e15-9775-65f63cfa656a": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/schedules-fares/route-27/"
     },
     "fe6f6a94-4916-4017-bad8-e2e479cc12ee": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -38578,6 +46835,70 @@
       "browser_steps": [
         {
           "operation": null,
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        },
+        {
+          "operation": "Choose one",
+          "optional_value": "",
+          "selector": ""
+        }
+      ],
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "include_filters": [
+        "#HomePage"
+      ],
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slomotion.toastmastersclubs.org/"
+    },
+    "ff2a2100-0b21-42ed-9c36-5834c90fdffd": {
+      "browser_steps": [
+        {
+          "operation": null,
           "optional_value": null,
           "selector": null
         },
@@ -38630,24 +46951,73 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
-      "method": "GET",
-      "notification_format": "System default",
-      "processor": "text_json_diff",
-      "url": "https://slomotion.toastmastersclubs.org/"
-    },
-    "ff2a2100-0b21-42ed-9c36-5834c90fdffd": {
-      "filter_text_added": true,
-      "filter_text_removed": true,
-      "filter_text_replaced": true,
+      "ignore_text": [
+        "Services: "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BH-1800"
     },
     "ff372636-29ce-4327-b785-3b8716eadce1": {
+      "browser_steps": [
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        },
+        {
+          "operation": null,
+          "optional_value": null,
+          "selector": null
+        }
+      ],
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".x-main"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",

--- a/monitoring/extract-config.py
+++ b/monitoring/extract-config.py
@@ -10,6 +10,7 @@ import sys
 CONFIG_FIELDS = [
     'url',
     'tag',
+    'tags',
     'title',
     'browser_steps',
     'extract_text',


### PR DESCRIPTION
- Added 'tags' field to CONFIG_FIELDS in extract-config.py so tag assignments are version-controlled going forward
- Removed the resource-guide tag (UUID 82523093-b581-4d00-9d44-4b6c2c58add9) from all 874 monitored URLs since everything monitored is part of the resource-guide project
- Synced config with current runtime state