### PR TITLE
Add broadband internet to California LifeLine Program description

### DIFF
--- a/Resource guide.md
+++ b/Resource guide.md
@@ -3330,7 +3330,7 @@ People in the U.S. military, U.S. military veterans, and their spouses, adult ch
 
 ## <a id="phones">Phones and Phone Service</a>
 
-The [California LifeLine Program](https://www.californialifeline.com/) ([866-272-0357](tel:+1-866-272-0357) or use their [online chat](https://www.californialifeline.com/en/contact)) gives low-income households discounts on home phone or cell phone service.
+The [California LifeLine Program](https://www.californialifeline.com/) ([866-272-0357](tel:+1-866-272-0357) or use their [online chat](https://www.californialifeline.com/en/contact)) gives low-income households discounts on home phone, broadband internet, or cell phone service.
 In many cases the discounts are enough to make the service free. <!-- SOURCE NEEDED -->
 You apply for this program through a commercial phone service provider that supports the program. <!-- Source: https://www.californialifeline.com/en/faq -->
 Some providers also give you a free phone when you register for California LifeLine through their service, for example [AirTalk Wireless](https://airtalkwireless.com/lifeline-application), [enTouch Wireless](https://entouchwireless.com/states/california-lifeline-free-phone-service/), or [Gen Mobile](https://www.genmobile.com/pages/lifeline-program).

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -3328,7 +3328,7 @@ Las personas en el ejército de los Estados Unidos, veteranos militares de los E
 
 ## <a id="phones">Teléfonos y Servicio Telefónico</a>
 
-El [Programa California LifeLine](https://www.californialifeline.com/es) ([866-272-0357](tel:+1-866-272-0357) o use su [chat en línea](https://www.californialifeline.com/es/contact)) da a hogares de bajos ingresos descuentos en servicio de teléfono residencial o celular.
+El [Programa California LifeLine](https://www.californialifeline.com/es) ([866-272-0357](tel:+1-866-272-0357) o use su [chat en línea](https://www.californialifeline.com/es/contact)) da a hogares de bajos ingresos descuentos en servicio de teléfono residencial, internet de banda ancha, o celular.
 En muchos casos los descuentos son suficientes para hacer el servicio gratuito. <!-- SOURCE NEEDED -->
 Solicita este programa a través de un proveedor de servicio telefónico comercial que apoye el programa. <!-- Source: https://www.californialifeline.com/en/faq -->
 Algunos proveedores también le dan un teléfono gratuito cuando se registra para California LifeLine a través de su servicio, por ejemplo [AirTalk Wireless](https://airtalkwireless.com/es/lifeline-application), [enTouch Wireless](https://entouchwireless.com/states/california-lifeline-free-phone-service/) o [Gen Mobile](https://www.genmobile.com/pages/lifeline-program).


### PR DESCRIPTION
## Summary

- Adds broadband internet as a covered service in the California LifeLine Program description
- Updates both English and Spanish versions

## Test plan

- [ ] Verify the LifeLine description reads correctly in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)