### PR TITLE
Add Woods Humane Society pet loss support group

### DIFF
--- a/Resource guide.md
+++ b/Resource guide.md
@@ -3643,6 +3643,10 @@ It meets every Thursday from 11:30am–1:00pm at Mount Carmel Lutheran Church, <
 
 Several SLO County churches host [GriefShare support groups](https://griefshare.org/) with a Christian focus on grieving.
 
+[**Woods Humane Society**](Directory.md#Woods-Humane-Society) hosts a free, monthly, “Paws to Remember” support group for pet owners who are mourning the loss or imminent loss of a pet. <!-- Source: https://atascaderonews.com/nonprofit/woods-humane-society-hospice-slo-county-launch-monthly-pet-loss-support-group/ -->
+This group meets on the last Thursday of each month from 3–4pm at the Woods Humane Society Community Room. <!-- Source: https://woodshumanesociety.org/resources/pet-loss/ -->
+Contact [rcoleman@woodshumanesociety.org](mailto:rcoleman@woodshumanesociety.org) if you have questions. <!-- Source: https://woodshumanesociety.org/resources/pet-loss/ -->
+
 ### <a id="behavioral-health-peer-support">Behavioral Health</a>
 
 > See [12-Step and Similar Recovery Programs](#twelve-step) in the [Drug Use, Recovery, and Harm Reduction](#drug-use-and-recovery) section above for support groups for people recovering from drug addictions.

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -3641,6 +3641,10 @@ Se reúne todos los jueves de 11:30am a 1:00pm en la Iglesia Luterana Mount Carm
 
 Varias iglesias del Condado de SLO albergan [grupos de apoyo GriefShare](https://griefshare.org/) con un enfoque cristiano en el duelo.
 
+[**Woods Humane Society**](Directory.md#Woods-Humane-Society) organiza un grupo de apoyo gratuito y mensual, “Paws to Remember”, para dueños de mascotas que están de duelo por la pérdida o la pérdida inminente de una mascota. <!-- Source: https://atascaderonews.com/nonprofit/woods-humane-society-hospice-slo-county-launch-monthly-pet-loss-support-group/ -->
+Este grupo se reúne el último jueves de cada mes de 3–4pm en la Sala Comunitaria de Woods Humane Society. <!-- Source: https://woodshumanesociety.org/resources/pet-loss/ -->
+Comuníquese con [rcoleman@woodshumanesociety.org](mailto:rcoleman@woodshumanesociety.org) si tiene preguntas. <!-- Source: https://woodshumanesociety.org/resources/pet-loss/ -->
+
 ### <a id="behavioral-health-peer-support">Salud del Comportamiento</a>
 
 > Vea [Programas de Recuperación de 12 Pasos y Similares](#twelve-step) en la sección [Uso de Drogas, Recuperación y Reducción de Daños](#drug-use-and-recovery) arriba para grupos de apoyo para personas en recuperación de adicciones a las drogas.


### PR DESCRIPTION
Fixes #273

Adds the Woods Humane Society "Paws to Remember" monthly pet loss support group to the peer support section, in both the English and Spanish versions of the Resource Guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)