### PR TITLE
Add CAPSLO Day Hab Program

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -40,6 +40,7 @@
    - [**Healthcare for the Homeless Program**](#HCHP) happens at 40 Prado
    - [**People’s Kitchen**](#Peoples-Kitchen-SLO) happens at 40 Prado <!-- https://www.slopeopleskitchen.org/serving-info -->
    - [**Recuperative Care Program**](#Recuperative-Care-Program) happens at 40 Prado <!-- Source: https://capslo.org/40-prado/ -->
+   - operates the “[Day Hab Program](https://capslo.org/day-hab/)” (free one-hour classes M–F 2–3pm for people experiencing homelessness; topics include life skills, job readiness, education, health, creative activities, legal support, and community connection) <!-- Source: https://capslo.org/day-hab/ -->
 
 ## 50 Now
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -40,6 +40,7 @@
    - [**Healthcare for the Homeless Program**](#HCHP) tiene lugar en 40 Prado
    - [**People’s Kitchen**](#Peoples-Kitchen-SLO) tiene lugar en 40 Prado <!-- https://www.slopeopleskitchen.org/serving-info -->
    - [**Recuperative Care Program**](#Recuperative-Care-Program) tiene lugar en 40 Prado <!-- Source: https://capslo.org/40-prado/ -->
+   - opera el “[Day Hab Program](https://capslo.org/day-hab/)” (clases gratuitas de una hora, lunes–viernes 2–3pm, para personas en situación de falta de vivienda; los temas incluyen habilidades para la vida, preparación para el empleo, educación, salud, actividades creativas, apoyo legal y conexión comunitaria) <!-- Source: https://capslo.org/day-hab/ -->
 
 ## 50 Now
 

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -3160,6 +3160,12 @@ The site [FlexJobs](https://www.flexjobs.com/) is another way to find remote job
 
 ### <a id="adult-education">Adult Education</a>
 
+[**CAPSLO**](Directory.md#CAPSLO)’s **[Day Habilitation (Day Hab) Program](https://capslo.org/day-hab/)** offers free one-hour classes at the [**40 Prado Homeless Services Center**](Directory.md#40-Prado) for people experiencing homelessness in SLO County.
+Classes are held Monday–Friday at 2pm and cover topics such as life skills, job readiness, education and literacy, health and wellness, creative activities, legal and advocacy support, and community connection.
+People who use 40 Prado’s Access Center day services can join these classes.
+If you are experiencing homelessness in SLO County but do not currently use 40 Prado, you may also be able to attend; call [805-544-4004](tel:+1-805-544-4004) or email [hotline@capslo.org](mailto:hotline@capslo.org) for more information.
+<!-- Source: https://capslo.org/day-hab/ -->
+
 [**Cuesta College**](Directory.md#Cuesta-College)’s [Continuing Education](https://www.cuesta.edu/academics/continuinged/index.html) program is open to the general community (you do not have to be enrolled at Cuesta College).
 Classes themselves are free, but some have additional costs that have to do with supplies, prerequisite documentation and tests, and other things that happen outside the classroom.
 Among their programs are classes to prepare you for a California Commercial Learning Permit so you can become a commercial truck driver. <!-- Source: https://www.cuesta.edu/academics/continuinged/comm-truck-driving/index.html -->

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -3157,6 +3157,12 @@ El sitio [FlexJobs](https://www.flexjobs.com/) es otra forma de encontrar trabaj
 
 ### <a id="adult-education">Educación para Adultos</a>
 
+El **[Programa de Habilitación Diurna (Day Hab)](https://capslo.org/day-hab/)** de [**CAPSLO**](Directory.md#CAPSLO) ofrece clases gratuitas de una hora en el [**40 Prado Homeless Services Center**](Directory.md#40-Prado) para personas en situación de falta de vivienda en el condado de SLO.
+Las clases se ofrecen de lunes a viernes a las 2pm y cubren temas como habilidades para la vida, preparación para el empleo, educación y alfabetización, salud y bienestar, actividades creativas, apoyo legal y de defensa de derechos, y conexión comunitaria.
+Las personas que usan los servicios diurnos del Centro de Acceso de 40 Prado pueden unirse a estas clases.
+Si está en situación de falta de vivienda en el condado de SLO pero no usa actualmente 40 Prado, también puede ser posible asistir; llame al [805-544-4004](tel:+1-805-544-4004) o escriba a [hotline@capslo.org](mailto:hotline@capslo.org) para más información.
+<!-- Source: https://capslo.org/day-hab/ -->
+
 El programa de [Educación Continua](https://www.cuesta.edu/academics/continuinged/index.html) de [**Cuesta College**](Directory.md#Cuesta-College) está abierto a la comunidad general (no tiene que estar matriculado en Cuesta College).
 Las clases en sí son gratuitas, pero algunas tienen costos adicionales relacionados con materiales, documentación y exámenes de requisitos previos, y otras cosas que tienen lugar fuera del aula.
 Entre sus programas hay clases para prepararle para un Permiso de Aprendizaje Comercial de California para que pueda convertirse en conductor de camiones comerciales. <!-- Source: https://www.cuesta.edu/academics/continuinged/comm-truck-driving/index.html -->

--- a/spell-check.cjs
+++ b/spell-check.cjs
@@ -26,7 +26,7 @@ const WHITELIST = new Set([
   'AirTalk', 'enTouch', 'Kanopy', 'Brainfuse', 'ParentConnectionSLO', 'LinkedIn', 'SkillsBuild',
   'HelpNow', 'eLearning', 'EBSCOlearning', 'ProCitizen', 'Zumba', 'flexercise', 'BarreConnect',
   'GriefShare', 'Alateen', 'Narateen', 'Overeaters', 'MaMa', 'Intergroup', 'Brookside',
-  'FindYourAlly', 'craigslist',
+  'FindYourAlly', 'craigslist', 'Habilitation', 'Hab',
 
   // Common abbreviations
   'CalJOBS', 'DMV', 'SSI', 'SSDI', 'SSA', 'TTY', 'TDD', 'CRV', 'RV', 'RVs', 'LGBTQ', 'LGBTQIA',


### PR DESCRIPTION
## Summary

- Adds description of CAPSLO's Day Habilitation (Day Hab) Program to the Adult Education section of the Resource Guide (English and Spanish)
- Notes the program in the 40 Prado Homeless Services Center entry in the Directory (English and Spanish)
- Adds "Habilitation" and "Hab" to the spell-check whitelist

Fixes #323

## Test plan

- [ ] Verify Day Hab entry appears in Adult Education section of Resource Guide
- [ ] Verify Spanish translation is accurate and consistent
- [ ] Verify 40 Prado Directory entry notes the program
- [ ] Confirm spell-check passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)