### PR TITLE
Restore SLO County Small Claims Advisor with updated contact info

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -3407,7 +3407,7 @@ If you see one listed here that is no longer in service, please use the feedback
 
 - **Locations:**
    - Paso Robles: <a href="#" class="map-link" data-lat="35.624257" data-lon="-120.690294" data-zoom="17" data-label="SLO Superior Court">SLO County Superior Court, 901 Park St., Paso Robles</a>
-   - SLO: <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="Small Claims Advisor">SLO County Superior Court, 1050 Monterey St., 3rd Floor, SLO</a>
+   - SLO: <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="Small Claims Advisor">SLO County Superior Court, 1050 Monterey St., Third Floor, SLO</a>
 - **Phone:** [805-548-0678](tel:+1-805-548-0678)
 - **Hours:**
    - Paso Robles: Th 9am–1pm

--- a/Directory.md
+++ b/Directory.md
@@ -3403,14 +3403,19 @@ If you see one listed here that is no longer in service, please use the feedback
   You can also make an appointment to meet with the team by calling [805-540-0057](tel:+1-805-540-0057)
   <!-- L.O.T. Hours & locations verified from a flyer posted at the SLO city library on 22 Nov. 2025 -->
 
-<!-- Small Claims Advisor is closed according to https://www.slocounty.ca.gov/departments/district-attorney/special-prosecutions
 ## <a id="SLO-County-Small-Claims-Advisor">SLO County Small Claims Advisor</a>
 
-- **Location:** <a href="#" class="map-link" data-lat="35.282192" data-lon="-120.660230" data-zoom="17" data-label="SLO County Small Claims Advisor">County Government Center Room 223, SLO</a>
-- **Phone:** [805-781-5856](tel:+1-805-781-5856)
-- **Hours:** M–F 9am–12pm
-- **How to access:** no appointment necessary
--->
+- **Locations:**
+   - Paso Robles: <a href="#" class="map-link" data-lat="35.624257" data-lon="-120.690294" data-zoom="17" data-label="SLO Superior Court">SLO County Superior Court, 901 Park St., Paso Robles</a>
+   - SLO: <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="Small Claims Advisor">SLO County Superior Court, 1050 Monterey St., 3rd Floor, SLO</a>
+- **Phone:** [805-548-0678](tel:+1-805-548-0678)
+- **Hours:**
+   - Paso Robles: Th 9am–1pm
+   - SLO: Tu/We 9am–1pm
+- **Email:** [smallclaims@slolaf.org](mailto:smallclaims@slolaf.org)
+- **How to access:** make an appointment by using of these links:
+   - Paso Robles: [Calendly](https://calendly.com/smallclaims-slolaf/small-claims-paso-robles)
+   - SLO: [Calendly](https://calendly.com/smallclaims-slolaf/30min)
 
 ## <a id="SLO-County-UndocuSupport">SLO County UndocuSupport</a>
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -3424,14 +3424,19 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
   También puede hacer una cita para reunirse con el equipo llamando al [805-540-0057](tel:+1-805-540-0057)
   <!-- L.O.T. Hours & locations verified from a flyer posted at the SLO city library on 22 Nov. 2025 -->
 
-<!-- Small Claims Advisor is closed according to https://www.slocounty.ca.gov/departments/district-attorney/special-prosecutions
 ## <a id="SLO-County-Small-Claims-Advisor">SLO County Small Claims Advisor</a>
 
-- **Ubicación:** <a href="#" class="map-link" data-lat="35.282192" data-lon="-120.660230" data-zoom="17" data-label="SLO County Small Claims Advisor">County Government Center Room 223, SLO</a>
-- **Teléfono:** [805-781-5856](tel:+1-805-781-5856)
-- **Horario:** L–V 9am–12pm
-- **Cómo obtener el servicio:** no es necesaria cita
--->
+- **Ubicaciones:**
+   - Paso Robles: <a href="#" class="map-link" data-lat="35.624257" data-lon="-120.690294" data-zoom="17" data-label="SLO Superior Court">SLO County Superior Court, 901 Park St., Paso Robles</a>
+   - SLO: <a href="#" class="map-link" data-lat="35.282680" data-lon="-120.660770" data-zoom="17" data-label="Small Claims Advisor">SLO County Superior Court, 1050 Monterey St., 3er piso, SLO</a>
+- **Teléfono:** [805-548-0678](tel:+1-805-548-0678)
+- **Horario:**
+   - Paso Robles: J 9am–1pm
+   - SLO: Ma/Mi 9am–1pm
+- **Correo electrónico:** [smallclaims@slolaf.org](mailto:smallclaims@slolaf.org)
+- **Cómo obtener el servicio:** puede hacer una cita usando uno de estos enlaces:
+   - Paso Robles: [Calendly](https://calendly.com/smallclaims-slolaf/small-claims-paso-robles)
+   - SLO: [Calendly](https://calendly.com/smallclaims-slolaf/30min)
 
 ## <a id="SLO-County-YMCA">SLO County YMCA</a>
 

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -2347,7 +2347,7 @@ If you are filing a family law case (for example divorce, child support, child c
 The state of California’s [Small claims in California](https://selfhelp.courts.ca.gov/small-claims-california) web page is also a good introduction to the small claims process.
 
 You can get free information and assistance about small claims matters in SLO County from the [**Small Claims Advisor**](#SLO-County-Small-Claims-Advisor).
-They can help you if you are filing a claim, responding to a claim filed against you, preparing for your appearance in court, or collecting a judgement if your claim succeeds.
+They can help you if you are filing a claim, responding to a claim filed against you, preparing for your appearance in court, or collecting a judgment if your claim succeeds.
 
 The SLO Law Line ([805-548-8884](tel:+1-805-548-8884)) gives free basic legal advice to people who cannot afford an attorney, and can help you find additional legal assistance. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->
 Call to make an appointment for a telephone consultation. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -2330,8 +2330,6 @@ A neutral mediator will be assigned to your case to help you resolve it.
 
 ### <a id="legal-self-help">Legal Self-Help / Law Libraries</a>
 
-<!-- Note: SLO County Small Claims Advisor has been discontinued -->
-
 If you need to research the law, legal precedents, and legal processes, you can visit the [**SLO County Law Library**](Directory.md#SLO-County-Law-Library), a free research library. <!-- Source: https://www.slocll.org/about-us-2/mission/ -->
 The library has thousands of print volumes and also has publicly-accessible computers at which you can access WestLaw, CEB OnLaw, NOLO Guides, Bell’s Compendium, and other electronic legal databases. <!-- Sources: https://www.slocll.org/library-resources/reference-materials/ and https://www.slocll.org/library-resources/amenities/ -->
 It also has tools with which you can create documents that conform to the standards of local courts. <!-- Source: https://www.slocll.org/library-resources/amenities/ -->
@@ -2347,6 +2345,9 @@ If you are filing a family law case (for example divorce, child support, child c
 - the [small claims](https://www.slo.courts.ca.gov/self-help/small-claims) process
 
 The state of California’s [Small claims in California](https://selfhelp.courts.ca.gov/small-claims-california) web page is also a good introduction to the small claims process.
+
+You can get free information and assistance about small claims matters in SLO County from the [**Small Claims Advisor**](#SLO-County-Small-Claims-Advisor).
+They can help you if you are filing a claim, responding to a claim filed against you, preparing for your appearance in court, or collecting a judgement if your claim succeeds.
 
 The SLO Law Line ([805-548-8884](tel:+1-805-548-8884)) gives free basic legal advice to people who cannot afford an attorney, and can help you find additional legal assistance. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->
 Call to make an appointment for a telephone consultation. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -2327,8 +2327,6 @@ Se asignará un mediador neutral a su caso para ayudarlo a resolverlo.
 
 ### <a id="legal-self-help">Autoayuda Legal / Bibliotecas de Derecho</a>
 
-<!-- Note: SLO County Small Claims Advisor has been discontinued -->
-
 Si necesita investigar la ley, precedentes legales y procesos legales, puede visitar la [**SLO County Law Library**](Directory.md#SLO-County-Law-Library), una biblioteca de investigación gratuita. <!-- Source: https://www.slocll.org/about-us-2/mission/ -->
 La biblioteca tiene miles de volúmenes impresos y también tiene computadoras de acceso público en las que puede acceder a WestLaw, CEB OnLaw, Guías NOLO, Compendio de Bell y otras bases de datos legales electrónicas. <!-- Sources: https://www.slocll.org/library-resources/reference-materials/ and https://www.slocll.org/library-resources/amenities/ -->
 También tiene herramientas con las que puede crear documentos que se ajustan a los estándares de las cortes locales. <!-- Source: https://www.slocll.org/library-resources/amenities/ -->
@@ -2344,6 +2342,9 @@ Si está presentando un caso de derecho familiar (por ejemplo divorcio, manutenc
 - el proceso de [reclamos menores](https://www.slo.courts.ca.gov/self-help/small-claims)
 
 La página web [Reclamos menores en California](https://selfhelp.courts.ca.gov/es/reclamos-menores-en-california) del estado de California también es una buena introducción al proceso de reclamos menores.
+
+Puede obtener información y ayuda gratuita sobre asuntos de reclamos menores en el Condado de SLO del [**Small Claims Advisor**](#SLO-County-Small-Claims-Advisor).
+Pueden ayudarle si está presentando un reclamo, respondiendo a un reclamo presentado en su contra, preparándose para su comparecencia en la corte, o cobrando un fallo a su favor.
 
 La Línea de Derecho de SLO ([805-548-8884](tel:+1-805-548-8884)) da consejos legales básicos gratuitos a personas que no pueden pagar un abogado, y puede ayudarle a encontrar asistencia legal adicional. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->
 Llame para hacer una cita para una consulta telefónica. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->


### PR DESCRIPTION
## Summary
- Restores the SLO County Small Claims Advisor entry in Directory.md, which had been commented out as discontinued, with updated locations (SLO and Paso Robles), phone, hours, email, and Calendly booking links
- Adds a paragraph in the Legal Self-Help section of Resource guide.md pointing readers to this resource
- Adds corresponding Spanish translations in Directory_es.md and Resource guide_es.md

Fixes #352

## Test plan
- [ ] Verify Calendly links and phone number for the Small Claims Advisor
- [ ] Confirm hours/locations with SLO Superior Court