### PR TITLE
docs: update SLO YMCA hours to 24 hours

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -3836,6 +3836,12 @@ If you see one listed here that is no longer in service, please use the feedback
 
 > *See [**SLO County UndocuSupport**](#SLO-County-UndocuSupport)*
 
+## <a id="UCC-Pop-Up-Shop">UCC Pop-Up Shop</a>
+
+- **Location:** <a href="#" class="map-link" data-lat="35.260128" data-lon="-120.696026" data-zoom="17" data-label="United Church of Christ">11245 Los Osos Valley Rd., SLO</a>
+- **Hours:** Sa 10am–1pm <!-- Source: coincident with STP showers -->
+- **Services:** Free clothing giveaway
+
 ## <a id="UUSLO">Unitarian Universalists San Luis Obispo</a>
 
 - **Website:** [uuslo.org](https://uuslo.org/)

--- a/Directory.md
+++ b/Directory.md
@@ -3427,7 +3427,7 @@ If you see one listed here that is no longer in service, please use the feedback
 - **Location:** <a href="#" class="map-link" data-lat="35.266421" data-lon="-120.643242" data-zoom="17" data-label="SLO County YMCA">1020 Southwood Dr., SLO</a> <!-- Source: https://www.ciymca.org/locations/san-luis-obispo-county-ymca -->
 - **Phone:** [805-543-8235](tel:+1-805-543-8235) <!-- Source: https://www.ciymca.org/locations/san-luis-obispo-county-ymca -->
 - **Email:** [slo.info@ciymca.org](mailto:slo.info@ciymca.org)
-- **Hours:** M–Th 5:30am–9pm, F 5:30am–7pm, Sa 7am–5pm, Su closed <!-- Source: https://www.ciymca.org/locations/san-luis-obispo-county-ymca -->
+- **Hours:** Open 24 hours <!-- Source: https://www.sanluisobispo.com/news/business/article315970016.html -->
 
 ## <a id="SLO-Court-Self-Help-Services">SLO Court Self-Help Services</a>
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -3438,7 +3438,7 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 - **Ubicación:** <a href="#" class="map-link" data-lat="35.266421" data-lon="-120.643242" data-zoom="17" data-label="SLO County YMCA">1020 Southwood Dr., SLO</a> <!-- Source: https://www.ciymca.org/locations/san-luis-obispo-county-ymca -->
 - **Teléfono:** [805-543-8235](tel:+1-805-543-8235) <!-- Source: https://www.ciymca.org/locations/san-luis-obispo-county-ymca -->
 - **Correo electrónico:** [slo.info@ciymca.org](mailto:slo.info@ciymca.org)
-- **Horario:** L–J 5:30am–9pm, V 5:30am–7pm, S 7am–5pm, D cerrado <!-- Source: https://www.ciymca.org/locations/san-luis-obispo-county-ymca -->
+- **Horario:** Abierto las 24 horas <!-- Source: https://www.sanluisobispo.com/news/business/article315970016.html -->
 
 ## <a id="SLO-Court-Self-Help-Services">SLO Court Self-Help Services</a>
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -3835,6 +3835,12 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 - **Correo electrónico:** [UndocuSupport@cfsloco.org](mailto:UndocuSupport@cfsloco.org)
 - **Horario:** Mi 1–4:15pm
 
+## <a id="UCC-Pop-Up-Shop">UCC Pop-Up Shop</a>
+
+- **Ubicación:** <a href="#" class="map-link" data-lat="35.260128" data-lon="-120.696026" data-zoom="17" data-label="United Church of Christ">11245 Los Osos Valley Rd., SLO</a>
+- **Horario:** S 10am–1pm <!-- Source: coincident with STP showers -->
+- **Servicios:** Ropa gratis
+
 ## <a id="UUSLO">Unitarian Universalists San Luis Obispo</a>
 
 - **Sitio web:** [uuslo.org](https://uuslo.org/)

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -1264,6 +1264,7 @@ Call [**Salvation Army**](Directory.md#Salvation-Army) to find out if you can ge
 --><!-- SOURCE NEEDED (issue #60) -->
 
 [**Shower the People**](Directory.md#Shower-the-People) gives you new socks, underwear, and a t-shirt. <!-- Source: personal experience as volunteer -DG -->
+At its Saturday location in SLO, they are also sometimes joined by the [**UCC Pop-Up Shop**](Directory.md#UCC-Pop-Up-Shop), a free clothing giveaway.
 
 [**SLO Grassroots**](Directory.md#SLO-Grassroots) has clothing to give away, but (as of December 2025) they are still looking for an office to operate from.
 You have to make an appointment with them to view their inventory. <!-- Source: https://slograssroots.org/ -->

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -1261,6 +1261,7 @@ Call [**Salvation Army**](Directory.md#Salvation-Army) to find out if you can ge
 --><!-- SOURCE NEEDED (issue #60) -->
 
 [**Shower the People**](Directory.md#Shower-the-People) le da calcetines, ropa interior y una camiseta nuevos. <!-- Source: personal experience as volunteer -DG -->
+En su ubicación de los sábados en SLO, a veces también se les une el [**UCC Pop-Up Shop**](Directory.md#UCC-Pop-Up-Shop), que regala ropa gratis.
 
 [**SLO Grassroots**](Directory.md#SLO-Grassroots) tiene ropa para regalar, pero (a diciembre de 2025) todavía están buscando una oficina desde donde operar.
 Tiene que hacer una cita con ellos para ver su inventario. <!-- Source: https://slograssroots.org/ -->


### PR DESCRIPTION
Fixes #347. Updated the SLO YMCA operating hours to 24 hours in both the English and Spanish directories based on recent news.