### PR TITLE
Fix map-data-helper.html tile loading and print its dev URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ Here are some guidelines to help you craft your content for VivaSLO:
    This hyperlink uses HTML rather than markdown.
    VivaSLO converts it into a link that uses the user’s platform-specific mapping application.
    To generate this link, you can use [this tool](./web-app/map-data-helper.html).
+   Don’t just double-click the file or open it with a `file://` URL — the map tiles won’t load, because OpenStreetMap blocks tile requests that have no `Referer` header, and browsers never send one for local files.
+   Instead, from the `web-app` directory run `npm run dev` and open the tool at the printed `http://localhost:...` address.
 1. **Use `*italics*` tather than ALL-CAPS for emphasis.**
 1. **“SLO” is usually an acceptable abbreviation for “the city of San Luis Obispo.”**
    If the context makes it ambiguous whether “SLO” refers to the city or county, you can use “SLO city” or “SLO County.”

--- a/web-app/ARCHITECTURE.md
+++ b/web-app/ARCHITECTURE.md
@@ -35,6 +35,8 @@ web-app/
 ├── package.json            # Dependencies and build scripts
 ├── vite.config.js          # Vite config + PWA manifest
 ├── map-data-helper.html    # Utility for adding map coordinates
+├── vite-plugin-minify-markdown.js       # Strips comments from bundled markdown
+├── vite-plugin-print-map-helper-url.js  # Prints map-data-helper.html URL in dev
 ├── src/
 │   ├── main.js             # App initialization, routing, state
 │   ├── style.css           # All CSS styles
@@ -529,6 +531,30 @@ generates JavaScript data files for map pages
 
 - Automatically runs after `npm run build` (unless using `build:novalidate`)
 - Validates both source `index.html` and built `dist/index.html`
+
+### 14. Map Helper URL Plugin
+
+**Purpose**: Custom Vite plugin that prints the URL of the Map Data Helper
+tool alongside the main site URL when the dev server starts
+
+**File**: `vite-plugin-print-map-helper-url.js`
+
+**How it works**:
+
+1. Wraps `server.printUrls` in `configureServer`, calling the original first
+2. Reads the resolved local URL from `server.resolvedUrls.local[0]` (correct
+   even with a custom `--port` or `--host`)
+3. Logs an additional `➜  Map Tool:` line pointing at
+   `map-data-helper.html`
+
+**Why it's needed**:
+
+- `map-data-helper.html` must be loaded over `http://`, not opened as a
+  `file://` URL — OpenStreetMap's tile server blocks tile requests that
+  have no `Referer` header (browsers never send one for local files), so
+  tiles fail to load if the file is double-clicked
+- Printing the dev-server URL for the tool makes the correct way to open it
+  discoverable without needing to check `CONTRIBUTING.md`
 
 ## Data Flow
 
@@ -1046,10 +1072,22 @@ For questions about this architecture:
 
 ---
 
-*Last updated: 2025-12-11*
-*Document version: 1.3*
+*Last updated: 2026-07-27*
+*Document version: 1.4*
 
 ## Changelog
+
+### Version 1.4 (2026-07-27)
+
+Map Data Helper dev server fix:
+
+- Added `vite-plugin-print-map-helper-url.js` to print `map-data-helper.html`'s
+  URL alongside the main site URL when running `npm run dev`
+- Fixes a silent failure where opening `map-data-helper.html` directly as a
+  `file://` URL caused OpenStreetMap to block tile requests (no `Referer`
+  header sent), leaving the map preview blank
+- Updated `CONTRIBUTING.md` and added an in-page warning to steer contributors
+  toward the dev server URL instead of opening the file directly
 
 ### Version 1.3 (2025-12-11)
 

--- a/web-app/map-data-helper.html
+++ b/web-app/map-data-helper.html
@@ -198,6 +198,13 @@
     <h1>Map Data Helper</h1>
     <p class="subtitle">Generate map data attributes for the Resource Guide</p>
 
+    <div class="info-box" id="file-protocol-warning" style="display: none; margin-bottom: 20px; border-left-color: #dc2626; background: #fef2f2;">
+        <strong>Map tiles won't load from a local file.</strong>
+        You opened this page directly (as a <code>file://</code> URL), so your browser sends no <code>Referer</code> header.
+        OpenStreetMap blocks tile requests with no <code>Referer</code> (see <a href="https://wiki.openstreetmap.org/wiki/Blocked" target="_blank" rel="noopener">their tile usage policy</a>).
+        From the <code>web-app</code> directory, run <code>npm run dev</code> and open this page at the printed <code>http://localhost:...</code> address instead.
+    </div>
+
     <div class="container">
         <div class="panel">
             <h2>📍 Location Information</h2>
@@ -262,6 +269,10 @@
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
+        if (location.protocol === 'file:') {
+            document.getElementById('file-protocol-warning').style.display = 'block';
+        }
+
         // Initialize map
         let map = L.map('map').setView([35.2828, -120.6596], 12);
         let marker = null;

--- a/web-app/vite-plugin-print-map-helper-url.js
+++ b/web-app/vite-plugin-print-map-helper-url.js
@@ -1,0 +1,23 @@
+/**
+ * Vite plugin to print the Map Data Helper tool's URL alongside the
+ * main site URL when the dev server starts.
+ */
+
+export default function printMapHelperUrl() {
+  return {
+    name: 'print-map-helper-url',
+
+    configureServer(server) {
+      const printUrls = server.printUrls;
+      server.printUrls = () => {
+        printUrls();
+
+        const localUrl = server.resolvedUrls?.local?.[0];
+        if (localUrl) {
+          const toolUrl = new URL('map-data-helper.html', localUrl).href;
+          server.config.logger.info(`  ➜  Map Tool: ${toolUrl}`);
+        }
+      };
+    }
+  };
+}

--- a/web-app/vite.config.js
+++ b/web-app/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import minifyMarkdown from './vite-plugin-minify-markdown.js';
+import printMapHelperUrl from './vite-plugin-print-map-helper-url.js';
 
 export default defineConfig({
   base: './',
@@ -33,6 +34,7 @@ export default defineConfig({
   },
   plugins: [
     minifyMarkdown(),
+    printMapHelperUrl(),
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'robots.txt', 'apple-touch-icon.png', 'icon-192-maskable.png', 'icon-512-maskable.png'],


### PR DESCRIPTION
## Summary

- `map-data-helper.html`'s map preview was silently blank because OpenStreetMap now blocks tile requests with no `Referer` header, and browsers never send one for `file://` pages — which is how the tool was linked from `CONTRIBUTING.md` and typically opened.
- Point contributors at the Vite dev server instead: updated `CONTRIBUTING.md`, added an in-page warning that appears if the file is opened via `file://`, and added a small Vite plugin (`vite-plugin-print-map-helper-url.js`) that prints the tool's URL alongside the main site URL when running `npm run dev`.
- Documented the new plugin in `web-app/ARCHITECTURE.md` (section 14, directory tree, changelog v1.4).

## Test plan

- [x] Ran `npm run dev` and confirmed the terminal prints `➜  Map Tool: http://localhost:.../map-data-helper.html` alongside the existing `Local:`/`Network:` lines
- [x] Confirmed `map-data-helper.html` loads correctly via the printed dev-server URL
- [x] Verified the in-page warning banner logic triggers only on `location.protocol === 'file:'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)