### PR TITLE
Update Cuesta College Basic Needs hours/locations, fix Small Claims link

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -1177,13 +1177,17 @@
    - [scchelp@cuesta.edu](mailto:scchelp@cuesta.edu) (South County Campus)
    - [ContinuingEd@cuesta.edu](mailto:ContinuingEd@cuesta.edu) (Continuing Education) <!-- Source: https://www.cuesta.edu/academics/continuinged/Contact-Continuing-Education2.html -->
 - Notes:
-   - Basic Needs Office is in room 5014B of the SLO campus, open M/Th/F 9am–4pm, Tu 9am–6pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
-   - The Paso Robles campus hosts a Cougar Food Pantry for students in room N1005, M–F 9am–5pm; [805-591-4301](tel:+1-805-591-4301) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
-   - The SLO campus hosts a Cougar Food Pantry for students in room 5014A’s cafeteria, M–F 9am–4:30pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+   - Basic Needs Offices:
+      - Arroyo Grande campus: open every other Wednesday, 4pm–8pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+      - Paso Robles campus: NCC Building 1000, room 1005, open every other Wednesday, 11am–8pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+      - SLO campus: room 5014B, open M/Tu/Th 9am–6pm, F 9am–4pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+   - Cougar Food Pantries:
+      - Paso Robles campus: room N1005, open M–F 9am–5pm; [805-591-4301](tel:+1-805-591-4301) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+      - SLO campus: room 5104B, M–F 9am–4:30pm; [805-546-3289](tel:+1-805-546-3289) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
    - [Community Education](https://www.cuesta.edu/community/index.html) programs are open to otherwise unenrolled people
    - [Continuing Education](https://www.cuesta.edu/academics/continuinged/) has vocational / lifetime-learning programs, and ESL
    - Partners with [**Lucia Mar Adult Education**](#Lucia-Mar-Adult-Education) for ESL classes
-   - The SLO & North County campuses are [**SLO Food Bank**](#SLO-Food-Bank) food box distribution sites <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+   - The SLO & Paso Robles campuses are [**SLO Food Bank**](#SLO-Food-Bank) food box distribution sites <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
 
 ## Deaf and Disabled Telecommunication Program (DDTP)
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -1454,13 +1454,17 @@
    - [scchelp@cuesta.edu](mailto:scchelp@cuesta.edu) (Centro South County)
    - [ContinuingEd@cuesta.edu](mailto:ContinuingEd@cuesta.edu) (Programa de Educación Continua) <!-- Source: https://www.cuesta.edu/academics/continuinged/Contact-Continuing-Education2.html -->
 - Notas:
-   - oficina de Necesidades Básicas esta en la sala 5014B del campus SLO, abierto L/Ju/V 9am–4pm, Ma 9am–6pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
-   - el campus de Paso Robles alberga una despensa de alimentos Cougar para estudiantes en la sala N1005, L–V 9am–5pm; [805-591-4301](tel:+1-805-591-4301) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
-   - el campus de SLO campus alberga una despensa de alimentos Cougar para estudiantes en la cafetería de la sala 5014A, L–V 9am–4:30pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+   - Oficinas de Necesidades Básicas:
+      - campus Arroyo Grande: abierto cada dos miércoles, 4pm–8pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+      - campus Paso Robles: NCC Building 1000, sala 1005, abierto cada dos miércoles, 11am–8pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+      - campus SLO: sala 5014B, abierto L/Ma/Ju 9am–6pm, V 9am–4pm <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+   - Despensas de alimentos Cougar:
+      - campus Paso Robles: sala N1005, abierto L–V 9am–5pm; [805-591-4301](tel:+1-805-591-4301) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+      - campus SLO: sala 5104B, L–V 9am–4:30pm; [805-546-3289](tel:+1-805-546-3289) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
    - [Community Education](https://www.cuesta.edu/community/index.html) programas están abiertos a personas que de otro modo no estarían inscritas
    - [Continuing Education](https://www.cuesta.edu/academics/continuinged/) tiene programas vocacionales/de aprendizaje permanente y ESL
    - se asocia con [**Lucia Mar Adult Education**](#Lucia-Mar-Adult-Education) for ESL classes
-   - los campus de SLO y North County son sitios de distribución de cajas de alimentos de [**SLO Food Bank**](#SLO-Food-Bank) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
+   - los campus de SLO y Paso Robles son sitios de distribución de cajas de alimentos de [**SLO Food Bank**](#SLO-Food-Bank) <!-- Source: https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html -->
 
 ## Deaf and Disabled Telecommunication Program (DDTP)
 

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -1269,7 +1269,7 @@ At its Saturday location in SLO, they are also sometimes joined by the [**UCC Po
 [**SLO Grassroots**](Directory.md#SLO-Grassroots) has clothing to give away, but (as of December 2025) they are still looking for an office to operate from.
 You have to make an appointment with them to view their inventory. <!-- Source: https://slograssroots.org/ -->
 
-[The Basic Needs Center](https://www.cuesta.edu/student-support/basic-needs-center/food-resources/index.html) at [**Cuesta College**](Directory.md#Cuesta-College) has free, gently-used clothing for currently-enrolled Cuesta College students.
+[The Basic Needs Office](https://www.cuesta.edu/student-support/basic-needs-center/food-resources/index.html) at [**Cuesta College**](Directory.md#Cuesta-College) has free, gently-used clothing for currently-enrolled Cuesta College students.
 
 #### <a id="free-clothes-for-kids">Free Clothes for Kids</a>
 
@@ -2342,7 +2342,7 @@ If you are filing a family law case (for example divorce, child support, child c
 
 The state of California’s [Small claims in California](https://selfhelp.courts.ca.gov/small-claims-california) web page is also a good introduction to the small claims process.
 
-You can get free information and assistance about small claims matters in SLO County from the [**Small Claims Advisor**](#SLO-County-Small-Claims-Advisor).
+You can get free information and assistance about small claims matters in SLO County from the [**Small Claims Advisor**](Directory.md#SLO-County-Small-Claims-Advisor).
 They can help you if you are filing a claim, responding to a claim filed against you, preparing for your appearance in court, or collecting a judgment if your claim succeeds.
 
 The SLO Law Line ([805-548-8884](tel:+1-805-548-8884)) gives free basic legal advice to people who cannot afford an attorney, and can help you find additional legal assistance. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -1269,7 +1269,7 @@ En su ubicación de los sábados en SLO, a veces también se les une el [**UCC P
 [**SLO Grassroots**](Directory.md#SLO-Grassroots) tiene ropa para regalar, pero (a diciembre de 2025) todavía están buscando una oficina desde donde operar.
 Tiene que hacer una cita con ellos para ver su inventario. <!-- Source: https://slograssroots.org/ -->
 
-El [Basic Needs Center](https://www.cuesta.edu/student-support/basic-needs-center/food-resources/index.html) de [**Cuesta College**](Directory.md#Cuesta-College) tiene ropa gratis, usada y en buen estado, para estudiantes actualmente inscritos en Cuesta College.
+La [Oficina de Necesidades Básicas](https://www.cuesta.edu/student-support/basic-needs-center/food-resources/index.html) de [**Cuesta College**](Directory.md#Cuesta-College) tiene ropa gratis, usada y en buen estado, para estudiantes actualmente inscritos en Cuesta College.
 
 #### <a id="free-clothes-for-kids">Ropa Gratis para Niños</a>
 
@@ -2342,7 +2342,7 @@ Si está presentando un caso de derecho familiar (por ejemplo divorcio, manutenc
 
 La página web [Reclamos menores en California](https://selfhelp.courts.ca.gov/es/reclamos-menores-en-california) del estado de California también es una buena introducción al proceso de reclamos menores.
 
-Puede obtener información y ayuda gratuita sobre asuntos de reclamos menores en el Condado de SLO del [**Small Claims Advisor**](#SLO-County-Small-Claims-Advisor).
+Puede obtener información y ayuda gratuita sobre asuntos de reclamos menores en el Condado de SLO del [**Small Claims Advisor**](Directory.md#SLO-County-Small-Claims-Advisor).
 Pueden ayudarle si está presentando un reclamo, respondiendo a un reclamo presentado en su contra, preparándose para su comparecencia en la corte, o cobrando un fallo a su favor.
 
 La Línea de Derecho de SLO ([805-548-8884](tel:+1-805-548-8884)) da consejos legales básicos gratuitos a personas que no pueden pagar un abogado, y puede ayudarle a encontrar asistencia legal adicional. <!-- Source: https://montereylaw.edu/clinics/sloclclinics.html -->


### PR DESCRIPTION
## Summary
- Split Basic Needs Office and Cougar Food Pantry hours/locations by campus (Arroyo Grande, Paso Robles, SLO); corrected the SLO Food Bank distribution site note from North County to Paso Robles
- Renamed "Basic Needs Center" to "Basic Needs Office" in the clothing section, matching Cuesta's current terminology
- Fixed a broken link fragment for the Small Claims Advisor entry (now points to `Directory.md#...`)
- Applied corresponding updates to the Spanish translations (`Directory_es.md`, `Resource guide_es.md`)

## Test plan
- [x] `markdownlint` run on all four changed files (pre-existing unrelated lint warnings confirmed via `git stash` comparison)
- [x] Pre-commit hooks (translation sync, markdown lint, spell check) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)