### PR TITLE
Add Family Resource Centers content and fix stale contact info (#152)

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -1913,14 +1913,14 @@
 - **Website:** [linkslo.org](https://linkslo.org/)
 - **Locations:**
    - Atascadero: <a href="#" class="map-link" data-lat="35.513562" data-lon="-120.686928" data-zoom="17" data-label="The Link Family Resource Center (Atascadero)">4507 Del Rio Ave Bldg. #1, Atascadero</a> <!-- Source: https://linkslo.org/ -->
-   - Paso Robles: <a href="#" class="map-link" data-lat="35.628326" data-lon="-120.691147" data-zoom="17" data-label="The Link Family Resource Center (Paso Robles)">1802 Chestnut St., Paso Robles</a>
+   - Paso Robles: <a href="#" class="map-link" data-lat="35.641077" data-lon="-120.693910" data-zoom="17" data-label="The Link Family Resource Center (Paso Robles)">665 26th St., Paso Robles</a> <!-- Source: https://linkslo.org/ (moved from the former 1802 Chestnut St. address; verified 1 Aug. 2026) -->
 - **Phone:** [805-466-5404](tel:+1-805-466-5404) <!-- Source: https://linkslo.org/ -->
    - Family Advocate Services: [805-794-0217](tel:+1-805-794-0217) <!-- Source: https://linkslo.org/ -->
 - **Hours:** M–F 9am–5pm <!-- Source: https://linkslo.org/ -->
 - **How to access:** accepts self-referrals, school referrals, and community agency referrals
 - Notes:
    - Operated by [**Center for Family Strengthening (CFS)**](#CFS)
-   - See also [**North County Family Resource Center**](#North-County-Family-Resource-Center)
+   - See also [**Paso Robles Family Resource Center**](#North-County-Family-Resource-Center) (a separate program, also run in Paso Robles, this one operated by CAPSLO)
    - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers)
 
 ## <a id="Literacy-Connection">The Literacy Connection</a>
@@ -2237,7 +2237,8 @@ If you see one listed here that is no longer in service, please use the feedback
    - Community Dinners: Wednesdays 5–6pm <!-- Source: https://www.losososcares.com/programs -->
 - Notes:
    - Hosts Community Dinner at [**South Bay Community Center**](#South-Bay-Community-Center)
-   - Hosts “Coastal Family Resource Center”
+   - The county has listed this site as a “Coastal Family Resource Center” meeting point for its SAFE System of Care, but the contact info listed there differs from this Directory entry, and it does not appear as such on Los Osos Cares’ own current website <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (checked against https://www.losososcares.com/, 1 Aug. 2026); SOURCE NEEDED to confirm current status -- call to verify -->
+   - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) and [**Link Family Resource Center**](#Link-Family-Resource-Center) for the SAFE program offices with regular public hours
 
 ## <a id="Lucia-Mar-Adult-Education">Lucia Mar Adult Education</a>
 
@@ -2516,15 +2517,6 @@ If you see one listed here that is no longer in service, please use the feedback
 - **Hours:** M–F 10am–5pm <!-- Source: https://www.urgentcare.com/practice/U4378-north-county-care-minor-services-paso-robles-ca-93446 -->
 <!-- Cash-only; does not accept insurance (source: phone call 12-May-2026) -->
 
-## <a id="North-County-Family-Resource-Center">North County Family Resource Center</a>
-
-- **Website:** [capslo.org/north-county-family-resource-center](https://capslo.org/north-county-family-resource-center/)
-- **Location:** <a href="#" class="map-link" data-lat="35.621655" data-lon="-120.690685" data-zoom="17" data-label="Family Resource Center">704 Spring St., Paso Robles</a> <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
-- **Phone:** [805-440-1878](tel:+1-805-440-1878) <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
-- Notes:
-   - See also [**Link Family Resource Center**](#Link-Family-Resource-Center)
-   - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers)
-
 ## <a id="North-County-NeighborAid">North County NeighborAid</a>
 
 - **Website:** [cfsslo.org/north-county-neighboraid](https://cfsslo.org/north-county-neighboraid/)
@@ -2593,6 +2585,11 @@ If you see one listed here that is no longer in service, please use the feedback
 
 - **Phone:** [805-543-3277](tel:+1-805-543-3277) <!-- Source: https://www.phpslo.org/ -->
 - **Email:** [php@ucp-slo.org](mailto:php@ucp-slo.org) <!-- Source: https://www.phpslo.org/ -->
+- **How to access:** Call or email to ask about services. <!-- Source: https://www.phpslo.org/en/referral/ -->
+- Notes:
+   - Designated a Family Resource Center (FRC) and Family Empowerment Center (FEC); a member of the statewide [Family Resource Centers Network of California](https://frcnca.org/) <!-- Source: https://phpslo.org/en/about/ -->
+   - Serves families of children with disabilities or special needs, from birth to adulthood <!-- Source: https://phpslo.org/en/about/ -->
+   - A program of UCP of San Luis Obispo County (UCP+) <!-- Source: https://phpslo.org/en/about/ and email address domain ucp-slo.org -->
 
 ## <a id="Paso-Cares">Paso Cares</a>
 
@@ -2606,6 +2603,18 @@ If you see one listed here that is no longer in service, please use the feedback
 
 - **Phone:** [805-591-0078](tel:+1-805-591-0078) <!-- Source: https://www.pasocares.org/ and other pages on that site -->
 - **Email:** [pasocares@gmail.com](mailto:pasocares@gmail.com) <!-- Source: https://www.pasocares.org/ -->
+
+## <a id="North-County-Family-Resource-Center">Paso Robles Family Resource Center</a>
+
+<!-- This program was formerly called "North County Family Resource Center"; CAPSLO's own website now titles it "Paso Robles Family Resource Center" (verified 1 Aug. 2026). Anchor id kept as North-County-Family-Resource-Center so existing links do not break. Hours and email not found on capslo.org as of 1 Aug. 2026 -- call 805-440-1878 to confirm. -->
+- **Website:** [capslo.org/north-county-family-resource-center](https://capslo.org/north-county-family-resource-center/)
+- **Location:** <a href="#" class="map-link" data-lat="35.621655" data-lon="-120.690685" data-zoom="17" data-label="Paso Robles Family Resource Center">704 Spring St., Paso Robles</a> <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+- **Phone:** [805-440-1878](tel:+1-805-440-1878) <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+- Notes:
+   - Operated by [**Community Action Partnership San Luis Obispo (CAPSLO)**](#CAPSLO)
+   - Services include free developmental screening for children aged 0–5 (Help Me Grow), help applying for Head Start/Early Head Start, and child care payment assistance and navigation <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+   - Not to be confused with [**The Link Family Resource Center**](#Link-Family-Resource-Center)’s separate Paso Robles office
+   - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers)
 
 ## <a id="Paso-Robles-Housing-Authority">Paso Robles Housing Authority</a>
 
@@ -2916,16 +2925,18 @@ If you see one listed here that is no longer in service, please use the feedback
 <!-- Source (location/phone): https://capslo.org/s-a-f-e-family-resource-centers/ -->
 | Location | Phone |
 | -------- | ----- |
-| <a href="#" class="map-link" data-lat="35.102919" data-lon="-120.610154" data-zoom="17" data-label="SAFE Family Resource Center">1511 19th St., Oceano</a> | [805-474-3690](tel:+1-805-474-3690) |
+| <a href="#" class="map-link" data-lat="35.103757" data-lon="-120.610374" data-zoom="17" data-label="SAFE Family Resource Center">1425 19th St., Oceano</a> | [805-474-3690](tel:+1-805-474-3690) |
 | <a href="#" class="map-link" data-lat="35.119759" data-lon="-120.595638" data-zoom="17" data-label="SAFE Family Resource Center">1086 Grand Ave., Arroyo Grande</a> | [805-474-2105](tel:+1-805-474-2105) |
 | <a href="#" class="map-link" data-lat="35.027607" data-lon="-120.497553" data-zoom="16" data-label="SAFE Family Resource Center">920 W. Tefft St., Nipomo</a> | [805-474-3000&#xA0;x5147](tel:+1-805-474-3000;ext=5147) |
 
+<!-- Oceano address updated 1 Aug. 2026 from 1511 19th St. (Oceano Library building) to 1425 19th St. (Oceano Community Center building) per current capslo.org text; a human should confirm by phone, since this changed from the prior sourced value. -->
 - **Email:** [southcountysafe@capslo.org](mailto:southcountysafe@capslo.org) <!-- Source: https://capslo.org/s-a-f-e-family-resource-centers/ -->
-- **How to access:** Walk-ins OK; appointments preferred.
+- **How to access:** Walk-ins OK; appointments preferred. <!-- Source: https://capslo.org/s-a-f-e-family-resource-centers/ -->
+<!-- Hours not found on capslo.org or other reputable sources as of 1 Aug. 2026 -- call to confirm -->
 - Note:
    - Operated by [**Community Action Partnership San Luis Obispo (CAPSLO)**](#CAPSLO)
    - See also [**Link Family Resource Center**](#Link-Family-Resource-Center)
-   - See also [**North County Family Resource Center**](#North-County-Family-Resource-Center)
+   - See also [**Paso Robles Family Resource Center**](#North-County-Family-Resource-Center)
 
 ## <a id="St-Barnabas-Thrift-Shop">St. Barnabas Thrift Shop</a>
 
@@ -2988,7 +2999,8 @@ If you see one listed here that is no longer in service, please use the feedback
    - Or, come to the office during business hours
    - Or, call during business hours
 - Note:
-   - Hosts “San Luis Obispo Family Resource Center”
+   - The county has listed this site as a “San Luis Obispo Family Resource Center” meeting point for its SAFE System of Care, but the contact info listed there differs from this Directory entry, and it does not appear as such on San Luis Coastal Adult School’s own current website <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (checked against https://ae.slcusd.org/, 1 Aug. 2026); SOURCE NEEDED to confirm current status -- call to verify -->
+   - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) and [**Link Family Resource Center**](#Link-Family-Resource-Center) for the SAFE program offices with regular public hours
 
 ## <a id="SLO-College-of-Law-Legal-Clinic">San Luis Obispo College of Law Legal Clinic</a>
 

--- a/Directory.md
+++ b/Directory.md
@@ -2996,9 +2996,6 @@ If you see one listed here that is no longer in service, please use the feedback
    - Register for classes online at [slcusd.asapconnected.com](https://slcusd.asapconnected.com/)
    - Or, come to the office during business hours
    - Or, call during business hours
-- Note:
-   - The county has listed this site as a “San Luis Obispo Family Resource Center” meeting point for its SAFE System of Care, but the contact info listed there differs from this Directory entry, and it does not appear as such on San Luis Coastal Adult School’s own current website <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (checked against https://ae.slcusd.org/, 1 Aug. 2026); SOURCE NEEDED to confirm current status -- call to verify -->
-   - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) and [**Link Family Resource Center**](#Link-Family-Resource-Center) for the SAFE program offices with regular public hours
 
 ## <a id="SLO-College-of-Law-Legal-Clinic">San Luis Obispo College of Law Legal Clinic</a>
 

--- a/Directory.md
+++ b/Directory.md
@@ -2237,8 +2237,6 @@ If you see one listed here that is no longer in service, please use the feedback
    - Community Dinners: Wednesdays 5–6pm <!-- Source: https://www.losososcares.com/programs -->
 - Notes:
    - Hosts Community Dinner at [**South Bay Community Center**](#South-Bay-Community-Center)
-   - The county has listed this site as a “Coastal Family Resource Center” meeting point for its SAFE System of Care, but the contact info listed there differs from this Directory entry, and it does not appear as such on Los Osos Cares’ own current website <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (checked against https://www.losososcares.com/, 1 Aug. 2026); SOURCE NEEDED to confirm current status -- call to verify -->
-   - See also [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) and [**Link Family Resource Center**](#Link-Family-Resource-Center) for the SAFE program offices with regular public hours
 
 ## <a id="Lucia-Mar-Adult-Education">Lucia Mar Adult Education</a>
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -3077,9 +3077,6 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
    - Regístrese para clases en línea en [slcusd.asapconnected.com](https://slcusd.asapconnected.com/)
    - O, venga a la oficina durante el horario de oficina
    - O, llame durante el horario de oficina
-- Nota:
-   - El condado ha listado este sitio como un punto de encuentro “San Luis Obispo Family Resource Center” de su Sistema de Cuidado SAFE, pero la información de contacto que aparece allí es distinta a la de esta entrada, y no aparece como tal en el sitio web actual de San Luis Coastal Adult School <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (verificado contra https://ae.slcusd.org/, 1 ago. 2026); SOURCE NEEDED para confirmar el estado actual -- llame para verificar -->
-   - Vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) y [**Link Family Resource Center**](#Link-Family-Resource-Center) para las oficinas del programa SAFE con horario público regular
 
 ## <a id="SLO-College-of-Law-Legal-Clinic">San Luis Obispo College of Law Legal Clinic</a>
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -2193,14 +2193,14 @@
 - **Sitio web:** [linkslo.org](https://linkslo.org/)
 - **Ubicaciones:**
    - Atascadero: <a href="#" class="map-link" data-lat="35.513562" data-lon="-120.686928" data-zoom="17" data-label="The Link Family Resource Center (Atascadero)">4507 Del Rio Ave Bldg. #1, Atascadero</a> <!-- Source: https://linkslo.org/ -->
-   - Paso Robles: <a href="#" class="map-link" data-lat="35.628326" data-lon="-120.691147" data-zoom="17" data-label="The Link Family Resource Center (Paso Robles)">1802 Chestnut St., Paso Robles</a>
+   - Paso Robles: <a href="#" class="map-link" data-lat="35.641077" data-lon="-120.693910" data-zoom="17" data-label="The Link Family Resource Center (Paso Robles)">665 26th St., Paso Robles</a> <!-- Source: https://linkslo.org/ (se mudó de la antigua dirección 1802 Chestnut St.; verificado 1 ago. 2026) -->
 - **Teléfono:** [805-466-5404](tel:+1-805-466-5404) <!-- Source: https://linkslo.org/ -->
    - Family Advocate Services: [805-794-0217](tel:+1-805-794-0217) <!-- Source: https://linkslo.org/ -->
 - **Horario:** L–V 9am–5pm <!-- Source: https://linkslo.org/ -->
 - **Cómo obtener el servicio:** acepta auto-referencias, referencias escolares y referencias de agencias comunitarias
 - Notas:
    - operado por [**Centro para el Fortalecimiento Familiar (CFS)**](#CFS)
-   - vea también [**North County Family Resource Center**](#North-County-Family-Resource-Center)
+   - vea también [**Paso Robles Family Resource Center**](#North-County-Family-Resource-Center) (un programa distinto, también en Paso Robles, operado por CAPSLO)
    - vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers)
 
 ## <a id="Literacy-Connection">The Literacy Connection</a>
@@ -2267,7 +2267,8 @@
    - cenas comunitarias: los miércoles 5–6pm <!-- Source: https://www.losososcares.com/programs -->
 - Notas:
    - alberga cenas comunitarias en [**South Bay Community Center**](#South-Bay-Community-Center)
-   - alberga “Coastal Family Resource Center”
+   - El condado ha listado este sitio como un punto de encuentro “Coastal Family Resource Center” de su Sistema de Cuidado SAFE, pero la información de contacto que aparece allí es distinta a la de esta entrada, y no aparece como tal en el sitio web actual de Los Osos Cares <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (verificado contra https://www.losososcares.com/, 1 ago. 2026); SOURCE NEEDED para confirmar el estado actual -- llame para verificar -->
+   - Vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) y [**Link Family Resource Center**](#Link-Family-Resource-Center) para las oficinas del programa SAFE con horario público regular
 
 ## <a id="Lucia-Mar-Adult-Education">Lucia Mar Adult Education</a>
 
@@ -2527,15 +2528,6 @@
 - **Horario:** L–V 10am–5pm <!-- Source: https://www.urgentcare.com/practice/U4378-north-county-care-minor-services-paso-robles-ca-93446 -->
 <!-- Cash-only; does not accept insurance (source: phone call 12-May-2026) -->
 
-## <a id="North-County-Family-Resource-Center">North County Family Resource Center</a>
-
-- **Sitio web:** [capslo.org/north-county-family-resource-center](https://capslo.org/north-county-family-resource-center/)
-- **Ubicación:** <a href="#" class="map-link" data-lat="35.621655" data-lon="-120.690685" data-zoom="17" data-label="Family Resource Center">704 Spring St., Paso Robles</a> <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
-- **Teléfono:** [805-440-1878](tel:+1-805-440-1878) <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
-- Notas:
-   - vea también [**Link Family Resource Center**](#Link-Family-Resource-Center)
-   - vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers)
-
 ## <a id="North-County-NeighborAid">North County NeighborAid</a>
 
 - **Sitio web:** [cfsslo.org/north-county-neighboraid](https://cfsslo.org/north-county-neighboraid/)
@@ -2594,7 +2586,7 @@
 
 ## <a id="Parents-Helping-Parents">Parents Helping Parents of SLO County</a>
 
-- **Sitio web:** [phpslo.org](https://www.phpslo.org/)
+- **Sitio web:** [phpslo.org](https://www.phpslo.org/es/)
 
 <!-- Source (locations): https://www.phpslo.org/ -->
 | Ubicación | Horario |
@@ -2604,6 +2596,11 @@
 
 - **Teléfono:** [805-543-3277](tel:+1-805-543-3277) <!-- Source: https://www.phpslo.org/ -->
 - **Correo electrónico:** [php@ucp-slo.org](mailto:php@ucp-slo.org) <!-- Source: https://www.phpslo.org/ -->
+- **Cómo obtener el servicio:** Llame o envíe un correo electrónico para preguntar sobre los servicios. <!-- Source: https://www.phpslo.org/en/referral/ -->
+- Notas:
+   - Designado como Centro de Recursos Familiares (FRC, por sus siglas en inglés) y Centro de Empoderamiento Familiar (FEC); miembro de la red estatal [Family Resource Centers Network of California](https://frcnca.org/) <!-- Source: https://phpslo.org/en/about/ -->
+   - Atiende a familias con niños con discapacidades o necesidades especiales, desde el nacimiento hasta la edad adulta <!-- Source: https://phpslo.org/en/about/ -->
+   - Un programa de UCP of San Luis Obispo County (UCP+) <!-- Source: https://phpslo.org/en/about/ y el dominio de correo ucp-slo.org -->
 
 ## <a id="Paso-Cares">Paso Cares</a>
 
@@ -2617,6 +2614,18 @@
 
 - **Teléfono:** [805-591-0078](tel:+1-805-591-0078) <!-- Source: https://www.pasocares.org/ and other pages on that site --> <!-- [805-571-0078](tel:+1-805-571-0078) Source: https://www.pasocares.org/contact only (typo?) -->
 - **Correo electrónico:** [pasocares@gmail.com](mailto:pasocares@gmail.com) <!-- Source: https://www.pasocares.org/ -->
+
+## <a id="North-County-Family-Resource-Center">Paso Robles Family Resource Center</a>
+
+<!-- Este programa se llamaba antes "North County Family Resource Center"; el sitio web de CAPSLO ahora lo titula "Paso Robles Family Resource Center" (verificado 1 ago. 2026). Se mantiene el id de anclaje como North-County-Family-Resource-Center para no romper enlaces existentes. No se encontró horario ni correo electrónico en capslo.org al 1 ago. 2026 -- llame al 805-440-1878 para confirmar. -->
+- **Sitio web:** [capslo.org/north-county-family-resource-center](https://capslo.org/es/north-county-family-resource-center/)
+- **Ubicación:** <a href="#" class="map-link" data-lat="35.621655" data-lon="-120.690685" data-zoom="17" data-label="Paso Robles Family Resource Center">704 Spring St., Paso Robles</a> <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+- **Teléfono:** [805-440-1878](tel:+1-805-440-1878) <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+- Notas:
+   - Operado por [**Community Action Partnership San Luis Obispo (CAPSLO)**](#CAPSLO)
+   - Los servicios incluyen evaluación gratuita del desarrollo para niños de 0 a 5 años (Help Me Grow), ayuda para inscribirse en Head Start/Early Head Start, y ayuda con el pago del cuidado infantil <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+   - No confundir con la oficina separada de [**The Link Family Resource Center**](#Link-Family-Resource-Center) en Paso Robles
+   - vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers)
 
 ## <a id="Paso-Robles-Housing-Authority">Paso Robles Housing Authority</a>
 
@@ -2984,21 +2993,23 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 
 ## <a id="SAFE-Family-Resource-Centers">SAFE Family Resource Centers</a>
 
-- **Sitio web:** [capslo.org/s-a-f-e-family-resource-centers](https://capslo.org/s-a-f-e-family-resource-centers/)
+- **Sitio web:** [capslo.org/s-a-f-e-family-resource-centers](https://capslo.org/es/s-a-f-e-family-resource-centers/)
 
 <!-- Source (location/phone): https://capslo.org/s-a-f-e-family-resource-centers/ -->
 | Ubicación | Teléfono |
 | --------- | -------- |
-| <a href="#" class="map-link" data-lat="35.102919" data-lon="-120.610154" data-zoom="17" data-label="SAFE Family Resource Center">1511 19th St., Oceano</a> | [805-474-3690](tel:+1-805-474-3690) |
+| <a href="#" class="map-link" data-lat="35.103757" data-lon="-120.610374" data-zoom="17" data-label="SAFE Family Resource Center">1425 19th St., Oceano</a> | [805-474-3690](tel:+1-805-474-3690) |
 | <a href="#" class="map-link" data-lat="35.119759" data-lon="-120.595638" data-zoom="17" data-label="SAFE Family Resource Center">1086 Grand Ave., Arroyo Grande</a> | [805-474-2105](tel:+1-805-474-2105) |
 | <a href="#" class="map-link" data-lat="35.027607" data-lon="-120.497553" data-zoom="16" data-label="SAFE Family Resource Center">920 W. Tefft St., Nipomo</a> | [805-474-3000&#xA0;x5147](tel:+1-805-474-3000;ext=5147) |
 
+<!-- Dirección de Oceano actualizada el 1 ago. 2026: de 1511 19th St. (edificio de la biblioteca de Oceano) a 1425 19th St. (edificio del centro comunitario de Oceano), según el texto actual de capslo.org; se recomienda confirmar por teléfono, ya que este valor cambió del anterior. -->
 - **Correo electrónico:** [southcountysafe@capslo.org](mailto:southcountysafe@capslo.org) <!-- Source: https://capslo.org/s-a-f-e-family-resource-centers/ -->
-- **Cómo obtener el servicio:** Se aceptan visitas sin cita; se prefieren citas.
+- **Cómo obtener el servicio:** Se aceptan visitas sin cita; se prefieren citas. <!-- Source: https://capslo.org/s-a-f-e-family-resource-centers/ -->
+<!-- No se encontró el horario en capslo.org ni en otras fuentes confiables al 1 ago. 2026 -- llame para confirmar -->
 - Nota:
    - operado por [**Community Action Partnership San Luis Obispo (CAPSLO)**](#CAPSLO)
    - Vea también [**Link Family Resource Center**](#Link-Family-Resource-Center)
-   - Vea también [**North County Family Resource Center**](#North-County-Family-Resource-Center)
+   - Vea también [**Paso Robles Family Resource Center**](#North-County-Family-Resource-Center)
 
 ## <a id="St-Barnabas-Thrift-Shop">St. Barnabas Thrift Shop</a>
 
@@ -3068,7 +3079,9 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
    - Regístrese para clases en línea en [slcusd.asapconnected.com](https://slcusd.asapconnected.com/)
    - O, venga a la oficina durante el horario de oficina
    - O, llame durante el horario de oficina
-- Nota: alberga “San Luis Obispo Family Resource Center”
+- Nota:
+   - El condado ha listado este sitio como un punto de encuentro “San Luis Obispo Family Resource Center” de su Sistema de Cuidado SAFE, pero la información de contacto que aparece allí es distinta a la de esta entrada, y no aparece como tal en el sitio web actual de San Luis Coastal Adult School <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (verificado contra https://ae.slcusd.org/, 1 ago. 2026); SOURCE NEEDED para confirmar el estado actual -- llame para verificar -->
+   - Vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) y [**Link Family Resource Center**](#Link-Family-Resource-Center) para las oficinas del programa SAFE con horario público regular
 
 ## <a id="SLO-College-of-Law-Legal-Clinic">San Luis Obispo College of Law Legal Clinic</a>
 

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -2267,8 +2267,6 @@
    - cenas comunitarias: los miércoles 5–6pm <!-- Source: https://www.losososcares.com/programs -->
 - Notas:
    - alberga cenas comunitarias en [**South Bay Community Center**](#South-Bay-Community-Center)
-   - El condado ha listado este sitio como un punto de encuentro “Coastal Family Resource Center” de su Sistema de Cuidado SAFE, pero la información de contacto que aparece allí es distinta a la de esta entrada, y no aparece como tal en el sitio web actual de Los Osos Cares <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) (verificado contra https://www.losososcares.com/, 1 ago. 2026); SOURCE NEEDED para confirmar el estado actual -- llame para verificar -->
-   - Vea también [**SAFE Family Resource Centers**](#SAFE-Family-Resource-Centers) y [**Link Family Resource Center**](#Link-Family-Resource-Center) para las oficinas del programa SAFE con horario público regular
 
 ## <a id="Lucia-Mar-Adult-Education">Lucia Mar Adult Education</a>
 

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -295,6 +295,8 @@ Contact service providers directly to verify their most current information befo
 - [For U.S. Military Veterans](#housing-veterans)
 - [Sober Living Homes and Residential Treatment Options](#sober-living-homes)
 
+> If you have children, see the [Family Resource Centers](#family-resource-centers) section, in [Children, Youth, and People with Children](#children-youth-parents), for agencies that can connect you to housing help and other support.
+
 ### <a id="eviction-protection">Eviction Prevention</a>
 
 If you are homeless or are threatened with eviction with a “pay rent or quit” notice, or if you have had to move your family into a hotel, you can get immediate help from the [**CalWORKs Homeless Assistance Program**](Directory.md#CalWORKs). <!-- Source: https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance -->
@@ -613,8 +615,13 @@ It is designed specifically for people reentering society from incarceration.
 As of December 2025 the project is still looking for a suitable location (and has been for over a decade); they are not admitting residents.
 - Source: https://hopesvillageofslo.com/helping
 
-The [Balay Ko Family Resource Center](https://www.echoshelter.org/buildinghopeandhome) in Atascadero hopes to add 30 shelter beds for families to what is currently offered by [**El Camino Homeless Organization (ECHO)**](Directory.md#ECHO).
+The [Balay Ko Family Resource Center](https://www.echoshelter.org/buildinghopeandhome) in Atascadero will add 30 shelter beds for families to what is currently offered by [**El Camino Homeless Organization (ECHO)**](Directory.md#ECHO).
+As of 1 August 2026 it is still under construction and is not yet open; do not uncomment/add this until confirmed open and taking families.
+ECHO broke ground in October 2025 and, as of March 2026, expected the building to be complete around October 2026 (about a year after groundbreaking); no firm opening date has been published.
+Do not confuse this with [**Balay Ko on Barka**](Directory.md#Balay-Ko-on-Barka) in Grover Beach (a different, already-open program run by 5Cities Homeless Coalition, mentioned above), or with an unrelated "Balay Ko" senior housing development reported in SLO city.
 - Source: https://www.echoshelter.org/buildinghopeandhome
+- Source: https://www.ksby.com/san-luis-obispo/atascadero-homeless-organization-celebrates-new-construction-project-for-families (Oct. 6, 2025 groundbreaking article)
+- Source: https://atascaderonews.com/news/first-modular-units-arrive-for-balay-ko-family-resource-center/ (March 23, 2026: modular units arriving, still under construction, no opening date given)
 -->
 
 ### <a id="housing-veterans">For U.S. Military Veterans</a>
@@ -2836,6 +2843,8 @@ Many do not give you money directly, but help you purchase goods or pay bills.
 
 > See the [Banking and money management](#financial-literacy) section of this guide for financial literacy and credit counseling resources that can help you reduce your debt or save money for when you need it.
 
+> If you have children, see the [Family Resource Centers](#family-resource-centers) section, in [Children, Youth, and People with Children](#children-youth-parents); staff there can also help connect you to financial help.
+
 ### <a id="financial-aid-apply-yourself">You Can Apply Yourself</a>
 
 [**5Cities Homeless Coalition**](Directory.md#5CHC) has an [Immediate Needs](https://5chc.org/programs/immediate-needs) program that helps low-income families and individuals in need in the Five Cities area.
@@ -3401,6 +3410,7 @@ The free [**Front Porch**](Directory.md#Front-Porch) cafe on the Cal Poly campus
 
 **In this section:**
 
+1. [Family Resource Centers](#family-resource-centers)
 1. [Help with Parenting](#parenting)
 1. [Daycare, Preschool, and After-School Programs](#daycare)
 1. [Holiday Gifts for Children](#holiday-gifts-for-children)
@@ -3434,6 +3444,36 @@ These services are free to people with Medi-Cal/CenCal coverage, and available o
 > See [Family Law / Child Support](#family-law) in the [Legal Help & Crime Victim Protection](#legal-help) section of this guide for information about enforcing child support orders and other family law issues.
 
 > See the [Medical Resources for Specific Populations: Children](#medical-resources-specific-populations) in the [Health & Medical Care](#health-medical-care) section of this guide for pediatric and other child-oriented medical services.
+
+### <a id="family-resource-centers">Family Resource Centers</a>
+
+A “Family Resource Center” is a place that helps families with children.
+Staff can connect you to food, housing help, health care, school support, and parenting classes.
+They can also refer you to other agencies for more help.
+
+Different agencies in SLO County use the name “Family Resource Center” for different programs.
+Each program has its own services and its own rules.
+
+Most Family Resource Centers in SLO County are part of the county’s “SAFE System of Care.” <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) -->
+“SAFE” is short for “Services Affirming Family Empowerment.”
+SLO County created SAFE; it is a local program, not a state or national one. <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) -->
+Schools, SLO County Behavioral Health, CAPSLO, and other agencies work together in SAFE to help children stay safe, healthy, and in school. <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) -->
+
+You do not need a school or social worker to refer you.
+You can call or visit a SAFE Family Resource Center yourself and ask for help. <!-- Source: https://capslo.org/s-a-f-e-family-resource-centers/ -->
+A school, doctor, or social worker can also refer you.
+
+The two SAFE Family Resource Centers you can visit are:
+
+- [**The Link Family Resource Center**](Directory.md#Link-Family-Resource-Center), with offices in Atascadero and Paso Robles, serving families throughout northern SLO County.
+- [**SAFE Family Resource Centers**](Directory.md#SAFE-Family-Resource-Centers), run by CAPSLO, with offices in Oceano, Arroyo Grande, and Nipomo.
+
+CAPSLO also runs a different program with a similar name, the [**Paso Robles Family Resource Center**](Directory.md#North-County-Family-Resource-Center), at its own separate office.
+It focuses on young children: free developmental screening, help applying for Head Start, and help paying for child care. <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+
+[**Parents Helping Parents of SLO County**](Directory.md#Parents-Helping-Parents) is a different kind of Family Resource Center.
+It is only for families who have a child with a disability or special needs. <!-- Source: https://www.phpslo.org/ -->
+It is part of a statewide network, the Family Resource Centers Network of California. <!-- Source: https://phpslo.org/en/about/ -->
 
 ### <a id="parenting">Help with Parenting</a>
 

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -295,6 +295,8 @@ Comuníquese directamente con los proveedores de servicios para verificar su inf
 - [Para Veteranos Militares de EE.UU.](#housing-veterans)
 - [Viviendas de Vida Sobria y Opciones de Tratamiento Residencial](#sober-living-homes)
 
+> Si tiene hijos, vea la sección [Centros de Recursos Familiares](#family-resource-centers), en [Niños, Jóvenes y Personas con Hijos](#children-youth-parents), para conocer agencias que pueden ayudarlo con vivienda y otro tipo de apoyo.
+
 ### <a id="eviction-protection">Prevención de Desalojos</a>
 
 Si está sin hogar o está amenazado con desalojo mediante un aviso para pagar la renta o desocupar, o si ha tenido que mudar a su familia a un hotel, puede obtener ayuda inmediata del [**CalWORKs Homeless Assistance Program**](Directory.md#CalWORKs). <!-- Source: https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/homeless-assistance -->
@@ -614,8 +616,13 @@ It is designed specifically for people reentering society from incarceration.
 As of December 2025 the project is still looking for a suitable location (and has been for over a decade); they are not admitting residents.
 - Source: https://hopesvillageofslo.com/helping
 
-The [Balay Ko Family Resource Center](https://www.echoshelter.org/buildinghopeandhome) in Atascadero hopes to add 30 shelter beds for families to what is currently offered by [**El Camino Homeless Organization (ECHO)**](Directory.md#ECHO).
+The [Balay Ko Family Resource Center](https://www.echoshelter.org/buildinghopeandhome) in Atascadero will add 30 shelter beds for families to what is currently offered by [**El Camino Homeless Organization (ECHO)**](Directory.md#ECHO).
+As of 1 August 2026 it is still under construction and is not yet open; do not uncomment/add this until confirmed open and taking families.
+ECHO broke ground in October 2025 and, as of March 2026, expected the building to be complete around October 2026 (about a year after groundbreaking); no firm opening date has been published.
+Do not confuse this with [**Balay Ko on Barka**](Directory.md#Balay-Ko-on-Barka) in Grover Beach (a different, already-open program run by 5Cities Homeless Coalition, mentioned above), or with an unrelated "Balay Ko" senior housing development reported in SLO city.
 - Source: https://www.echoshelter.org/buildinghopeandhome
+- Source: https://www.ksby.com/san-luis-obispo/atascadero-homeless-organization-celebrates-new-construction-project-for-families (Oct. 6, 2025 groundbreaking article)
+- Source: https://atascaderonews.com/news/first-modular-units-arrive-for-balay-ko-family-resource-center/ (March 23, 2026: modular units arriving, still under construction, no opening date given)
 -->
 
 ### <a id="housing-veterans">Para Veteranos Militares de los Estados Unidos</a>
@@ -2836,6 +2843,8 @@ Muchos no le dan dinero directamente, sino que le ayudan a comprar bienes o paga
 
 > Vea la sección de [Banca y manejo de dinero](#financial-literacy) de esta guía para recursos de educación financiera y asesoramiento de crédito que pueden ayudarle a reducir su deuda o ahorrar dinero para cuando lo necesite.
 
+> Si tiene hijos, vea la sección [Centros de Recursos Familiares](#family-resource-centers), en [Niños, Jóvenes y Personas con Hijos](#children-youth-parents); el personal de allí también puede ayudarlo a conectarse con ayuda financiera.
+
 ### <a id="financial-aid-apply-yourself">Puede Solicitar Usted Mismo</a>
 
 [**5Cities Homeless Coalition**](Directory.md#5CHC) tiene un programa de [Necesidades Inmediatas](https://5chc.org/programs/immediate-needs) que ayuda a familias e individuos de bajos ingresos en necesidad en el área de Five Cities.
@@ -3402,6 +3411,7 @@ El [**40 Prado Homeless Services Center**](Directory.md#40-Prado) tiene enchufes
 
 **En esta sección:**
 
+1. [Centros de Recursos Familiares](#family-resource-centers)
 1. [Ayuda con la Crianza](#parenting)
 1. [Guardería, Preescolar y Programas Después de la Escuela](#daycare)
 1. [Regalos de Temporada para Niños](#holiday-gifts-for-children)
@@ -3435,6 +3445,36 @@ Estos servicios son gratuitos para personas con cobertura de Medi-Cal/CenCal, y 
 > Vea [Derecho Familiar / Manutención Infantil](#family-law) en la sección [Ayuda Legal y Protección a Víctimas de Crímenes](#legal-help) de esta guía para información sobre hacer cumplir órdenes de manutención infantil y otros asuntos de derecho familiar.
 
 > Vea los [Recursos Médicos para Poblaciones Específicas: Niños](#medical-resources-specific-populations) en la sección [Salud y Atención Médica](#health-medical-care) de esta guía para servicios médicos pediátricos y otros orientados a niños.
+
+### <a id="family-resource-centers">Centros de Recursos Familiares</a>
+
+Un “Centro de Recursos Familiares” (Family Resource Center) es un lugar que ayuda a familias con niños.
+El personal puede conectarlo con comida, ayuda con la vivienda, atención médica, apoyo escolar y clases para padres.
+También pueden referirlo a otras agencias para más ayuda.
+
+Distintas agencias del condado de SLO usan el nombre “Family Resource Center” para programas diferentes.
+Cada programa tiene sus propios servicios y sus propias reglas.
+
+La mayoría de los Centros de Recursos Familiares del condado de SLO forman parte del “Sistema de Cuidado SAFE” del condado. <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) -->
+SAFE significa “Services Affirming Family Empowerment” (Servicios que Afirman el Empoderamiento Familiar).
+El condado de SLO creó SAFE; es un programa local, no un programa estatal ni nacional. <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) -->
+Las escuelas, SLO County Behavioral Health, CAPSLO y otras agencias trabajan juntas en SAFE para ayudar a que los niños estén seguros, saludables y sigan en la escuela. <!-- Source: https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe) -->
+
+No necesita que una escuela o un trabajador social lo refiera.
+Puede llamar o visitar usted mismo un SAFE Family Resource Center y pedir ayuda. <!-- Source: https://capslo.org/s-a-f-e-family-resource-centers/ -->
+Una escuela, un médico o un trabajador social también pueden referirlo.
+
+Los dos SAFE Family Resource Centers que puede visitar son:
+
+- [**The Link Family Resource Center**](Directory.md#Link-Family-Resource-Center), con oficinas en Atascadero y Paso Robles, que atiende a familias en todo el norte del condado de SLO.
+- [**SAFE Family Resource Centers**](Directory.md#SAFE-Family-Resource-Centers), operado por CAPSLO, con oficinas en Oceano, Arroyo Grande y Nipomo.
+
+CAPSLO también opera un programa distinto con un nombre parecido, el [**Paso Robles Family Resource Center**](Directory.md#North-County-Family-Resource-Center), en su propia oficina separada.
+Se enfoca en niños pequeños: evaluación gratuita del desarrollo, ayuda para inscribirse en Head Start y ayuda para pagar el cuidado infantil. <!-- Source: https://capslo.org/north-county-family-resource-center/ -->
+
+[**Parents Helping Parents of SLO County**](Directory.md#Parents-Helping-Parents) es un tipo diferente de Family Resource Center.
+Es solo para familias que tienen un hijo o hija con una discapacidad o necesidades especiales. <!-- Source: https://www.phpslo.org/ -->
+Forma parte de una red estatal, la Family Resource Centers Network of California. <!-- Source: https://phpslo.org/en/about/ -->
 
 ### <a id="parenting">Ayuda con la Crianza</a>
 


### PR DESCRIPTION
Closes/addresses #152.

## Summary

- Adds a new **Family Resource Centers** subsection to `Resource guide.md` (and `Resource guide_es.md`) explaining what a "Family Resource Center" is in SLO County, why the name covers several unrelated programs, and how to self-refer — with cross-references from **Shelter & Housing** and **Emergency Financial Help**.
- Fills known gaps and corrects stale facts in `Directory.md` / `Directory_es.md`, all re-verified against each agency's *current* website (the January 2026 AI research in the issue thread was treated as unverified leads only — see the issue comment for where it turned out to be wrong).
- Updates the commented-out Balay Ko Family Resource Center (ECHO, Atascadero) note with current construction status and sources. It is **not yet open**, so it stays commented out.

My detailed answers to the four questions in the issue, the full list of changes, and — most importantly — the list of facts I could **not** verify (with what a human should call/visit to confirm), are posted as a comment on #152.

## Key Directory corrections

- The Link's Paso Robles office moved to **665 26th St.** (was 1802 Chestnut St., per linkslo.org's own current site).
- CAPSLO's "North County Family Resource Center" is now branded **"Paso Robles Family Resource Center"** on capslo.org; renamed the Directory entry (kept the old anchor id so existing links don't break) and added its services.
- CAPSLO's SAFE Family Resource Center in Oceano is now listed at **1425 19th St.** (was 1511 19th St.), per capslo.org — flagged for a human to phone-confirm since it's a nontrivial address change.
- Resolved the conflicting-phone-number question: `805-474-2105` (Arroyo Grande SAFE FRC) is correct per capslo.org; `805-474-2025` is a **fax** number for SAFE Team referrals, not a center's phone. The Link's two published numbers (`805-466-5404` main, `805-794-0217` Family Advocate Services) are both confirmed current on linkslo.org — no change needed there.
- Added a "How to access" line and a note about Parents Helping Parents' FRC/FEC statewide network membership.
- The "Coastal Family Resource Center" (hosted by Los Osos Cares) and "San Luis Obispo Family Resource Center" (hosted by San Luis Coastal Adult School) mentions are flagged as unconfirmed — the county's SAFE page lists them, but neither host organization's own current website mentions them, and the county page had other addresses that were independently confirmed stale. Did **not** create separate Directory entries for these per the agency-vs-program guidance.

## Testing

- `npm run lint:remark` — clean on all four touched files (5 remaining warnings in `Resource guide_es.md` and 4 `markdownlint` MD007 errors in `Directory.md` are pre-existing on `main`, confirmed unrelated to this change).
- `npx markdownlint-cli` on all four files — clean.
- Verified every new/changed internal anchor (`#family-resource-centers`, `#North-County-Family-Resource-Center`, etc.) resolves.
- Pre-commit hooks (translation sync, markdown lint, spell check) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)