### PR TITLE
Add missing source URLs to Changedetection.io watchlist, de-duplicate, and re-export

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -3188,8 +3188,8 @@ If you see one listed here that is no longer in service, please use the feedback
 
 - **Website:** [slocog.org](https://www.slocog.org/)
 - **Location:** <a href="#" class="map-link" data-lat="35.281490" data-lon="-120.658717" data-zoom="17" data-label="SLO Council of Governments">1114 Marsh Street, SLO</a> { Source: https://www.slocog.org/ }
-- **Phone:** [805-781-4219](tel:+1-805-781-4219) { Source: https://www.slocog.org/contact-page }
-- **Email:** [slocog@slocog.org](mailto:slocog@slocog.org) { Source: https://www.slocog.org/contact-page }
+- **Phone:** [805-781-4219](tel:+1-805-781-4219) { Source: https://slocog.org/contact/ }
+- **Email:** [slocog@slocog.org](mailto:slocog@slocog.org) { Source: https://slocog.org/contact/ }
 -->
 
 ## SLO Counseling Service

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -3290,8 +3290,8 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 
 - **Sitio web:** [slocog.org](https://www.slocog.org/)
 - **Ubicación:** <a href="#" class="map-link" data-lat="35.281490" data-lon="-120.658717" data-zoom="17" data-label="SLO Council of Governments">1114 Marsh Street, SLO</a> { Source: https://www.slocog.org/ }
-- **Teléfono:** [805-781-4219](tel:+1-805-781-4219) { Source: https://www.slocog.org/contact-page }
-- **Correo electrónico:** [slocog@slocog.org](mailto:slocog@slocog.org) { Source: https://www.slocog.org/contact-page }
+- **Teléfono:** [805-781-4219](tel:+1-805-781-4219) { Source: https://slocog.org/contact/ }
+- **Correo electrónico:** [slocog@slocog.org](mailto:slocog@slocog.org) { Source: https://slocog.org/contact/ }
 -->
 
 ## SLO Counseling Service

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -3515,11 +3515,11 @@ There is also a “Migrant and Seasonal Head Start” program designed specifica
 You can apply for that program by completing [the form on this page](https://www.childplus.net/apply/en-us/4C3A30704DEAD016C09968C44ACD9A8B/CE180CB5372A691D8A0368833B588572).
 For more information, contact [mshschildcare@capslo.org](mailto:mshschildcare@capslo.org) or [888-633-6747](tel:+1-888-633-6747). <!-- Source: https://capslo.org/migrant-and-seasonal-head-start/ -->
 
-[Bright Futures](http://luciamarschools.org/251185_2) is a program for students who are registered in the Lucia Mar Unified School District. <!-- Source: https://www.luciamarschools.org/251185_2 -->
+[Bright Futures](https://www.luciamarschools.org/251185_2) is a program for students who are registered in the Lucia Mar Unified School District. <!-- Source: https://www.luciamarschools.org/251185_2 -->
 It gives K-8 students a safe before- and after-school environment including academic support and enrichment classes, as well as a free supper. <!-- Source: https://www.luciamarschools.org/251185_2 -->
 There are limited spaces available, and sometimes there is a waiting list. <!-- SOURCE NEEDED -->
 Priority is given to foster youth, students experiencing homelessness, English language learners, and students qualifying for free/reduced price lunch services. <!-- SOURCE NEEDED -->
-You can apply to enroll your child in this program at the [Bright Futures](http://luciamarschools.org/251185_2) website.
+You can apply to enroll your child in this program at the [Bright Futures](https://www.luciamarschools.org/251185_2) website.
 
 The [**Child Development Resource Center**](Directory.md#Child-Development-Resource-Center) operates several programs including childcare for children aged 2–5 that includes early-childhood education, therapy and rehabilitation for children who need it, meals (breakfast, lunch, and an afternoon snack), and family events. <!-- Source: https://www.childrensresource.org/curriculum and https://www.childrensresource.org/therapy and https://www.childrensresource.org/classrooms and https://www.childrensresource.org/food-program and https://www.childrensresource.org/other -->
 They specialize in working with children who come from circumstances that included poverty, homelessness, foster care, domestic violence, or child abuse. <!-- Source: https://members.slochamber.org/directory/Details/child-development-resource-center-of-the-central-coast-2095758 -->

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -3516,11 +3516,11 @@ También hay un programa “Migrant and Seasonal Head Start” (Head Start para 
 Puede solicitar ese programa completando [el formulario en esta página](https://www.childplus.net/apply/es/4C3A30704DEAD016C09968C44ACD9A8B/CE180CB5372A691D8A0368833B588572).
 Para más información, contacte a [mshschildcare@capslo.org](mailto:mshschildcare@capslo.org) o [888-633-6747](tel:+1-888-633-6747). <!-- Source: https://capslo.org/migrant-and-seasonal-head-start/ -->
 
-[Futuros Brillantes](http://luciamarschools.org/251185_2) es un programa para estudiantes inscritos en el Distrito Escolar Unificado de Lucia Mar. <!-- Source: https://www.luciamarschools.org/251185_2 -->
+[Futuros Brillantes](https://www.luciamarschools.org/251185_2) es un programa para estudiantes inscritos en el Distrito Escolar Unificado de Lucia Mar. <!-- Source: https://www.luciamarschools.org/251185_2 -->
 Da a estudiantes de K-8 un ambiente seguro antes y después de la escuela incluyendo apoyo académico y clases de enriquecimiento, así como una cena gratuita. <!-- Source: https://www.luciamarschools.org/251185_2 -->
 Hay espacios limitados disponibles, y a veces hay una lista de espera. <!-- SOURCE NEEDED -->
 Se da prioridad a jóvenes en hogares de crianza, estudiantes que experimentan falta de hogar, estudiantes de inglés como segundo idioma y estudiantes que califican para servicios de almuerzo gratuito/a precio reducido. <!-- SOURCE NEEDED -->
-Puede solicitar inscribir a su hijo en este programa en el sitio web de [Futuros Brillantes](http://luciamarschools.org/251185_2).
+Puede solicitar inscribir a su hijo en este programa en el sitio web de [Futuros Brillantes](https://www.luciamarschools.org/251185_2).
 
 El [**Child Development Resource Center**](Directory.md#Child-Development-Resource-Center) opera varios programas incluyendo cuidado infantil para niños de 2–5 años que incluye educación de la primera infancia, terapia y rehabilitación para niños que la necesitan, comidas (desayuno, almuerzo y merienda) y eventos familiares. <!-- Source: https://www.childrensresource.org/curriculum and https://www.childrensresource.org/therapy and https://www.childrensresource.org/classrooms and https://www.childrensresource.org/food-program and https://www.childrensresource.org/other -->
 Se especializan en trabajar con niños que vienen de circunstancias que incluyen pobreza, falta de hogar, hogares de crianza, violencia doméstica o abuso infantil. <!-- Source: https://members.slochamber.org/directory/Details/child-development-resource-center-of-the-central-coast-2095758 -->

--- a/monitoring/changedetection-config.json
+++ b/monitoring/changedetection-config.json
@@ -64,6 +64,15 @@
       "processor": "text_json_diff",
       "url": "https://5chc.org/sites/default/files/2024-02/New%20Warming%20Center%20Talking%20Points.pdf"
     },
+    "015c6b76-cd8a-45a8-af7c-2a4fb1d5d602": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://immigranthopeag.org/contact-us/"
+    },
     "01604da8-029a-4805-91a3-689914fa347e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -96,6 +105,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://capslo.org/child-care-resource-connection/"
+    },
+    "01dffa8d-6d63-4b0d-b150-8525b9c12905": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://victims.ca.gov/"
+    },
+    "02185469-949f-49e3-9207-fcec2ecf8922": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.childrensresource.org/other"
     },
     "029451f1-1fa1-4987-b4e3-1be7335a96ab": {
       "filter_text_added": true,
@@ -147,6 +174,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=FT-3200"
+    },
+    "03499c32-3db6-4da2-99c5-92176e481714": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ccatc.org/"
+    },
+    "03726893-861d-4139-ac97-7e7b732685fa": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://refugechurch.info/connect/open-arms-ministry"
     },
     "03787874-03d2-4f15-a899-e614a683d120": {
       "filter_text_added": true,
@@ -243,6 +288,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=DD-1500.4280"
     },
+    "04b3cd20-b162-42f5-a9ec-ecffaffb1426": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://saintbarnabas-ag.org/get-involved/thrift-shop/"
+    },
     "04b6cd15-b9b5-42b7-8bd6-3b19796e82d2": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -263,6 +317,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-6500"
+    },
+    "053f2e73-04a0-44b3-9071-1ced83a71b20": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.salvationarmyusa.org/location-finder/?services=7-c0a3f2d8bf-lz3kps"
     },
     "0549ad40-e7ed-417f-a4ac-34691af180c5": {
       "filter_text_added": true,
@@ -366,6 +429,33 @@
       "processor": "text_json_diff",
       "url": "https://www.freecycle.org/town/SanLuisObispoCA"
     },
+    "06dffdad-d9b1-477a-b818-b9fc2905992e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.vftafoundation.org/helping_friends"
+    },
+    "06e48f52-9c5b-4bfe-ab03-f1f1c770ee14": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://postpartum.net/en-espanol/encuentros-de-apoyo-virtuales/"
+    },
+    "06fca9bf-7d41-459c-8654-d211e229d83a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.flexjobs.com/"
+    },
     "0758e792-79a3-44d2-9c77-53c9616b2c7d": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -391,6 +481,15 @@
       ],
       "url": "https://centerforautism.com/locations/san-luis-obispo-california/"
     },
+    "07be72ba-3da8-4a44-9623-cbc05e586126": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://equipperscc.com/"
+    },
     "07e2b547-aa96-4d96-85e2-212daecf6ae8": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -409,12 +508,160 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "BESbswy",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -422,9 +669,19 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/templeton-las-tablas/"
+    },
+    "0823bcdb-c33a-468e-88a1-cb2cabb025b7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://crla.org/articles/san-luis-obispo-county-residents-clear-criminal-records-help-echo-peoples-justice-project"
     },
     "086de21a-ea7c-4904-8c55-2c67f9c04561": {
       "filter_text_added": true,
@@ -526,6 +783,15 @@
       "processor": "text_json_diff",
       "url": "https://selfhelp.courts.ca.gov/immigration"
     },
+    "0a0bdcda-50dc-4ca6-b155-5fcfb3e770bf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://tenantstogether.org/"
+    },
     "0a15cef8-e773-4c4f-938e-f2b50c1377d8": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -564,6 +830,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PD"
+    },
+    "0a5c6289-a833-4c56-9ec2-8b57b45b1819": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://connect.crisistextline.org/chat"
     },
     "0a7cb531-d3b1-4545-8d68-bc30f0d13d8f": {
       "filter_text_added": true,
@@ -667,6 +942,15 @@
       "processor": "text_json_diff",
       "url": "https://crla.org/about-crla"
     },
+    "0b56843f-ebc5-4045-8edc-5464b27cec80": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://library.calpoly.edu/"
+    },
     "0b82d332-3efd-453e-ab07-7cec624649f6": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -690,6 +974,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.t-mha.org/housing.php"
+    },
+    "0c65b773-353b-48d3-b4f8-44539804fc47": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.modestneeds.org/mn/about-us"
     },
     "0cd0577a-5a06-4b46-93e4-40d534307497": {
       "filter_text_added": true,
@@ -734,6 +1027,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/about-rta/contact/"
     },
+    "0d5f283e-e525-4c62-891b-ca2d4aeb74de": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/financial-assistance"
+    },
     "0d96ff4d-3dc4-43b1-85e2-5dbfdb15ef2c": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -770,6 +1072,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BH-3800"
     },
+    "0e174f25-db8e-4e7e-afb6-975372594a5f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdss.ca.gov/Portals/9/CalWORKS/CalWORKs-WtW-Participant-Handbook%20-%20Spanish.pdf"
+    },
     "0e1e2561-5e9e-441c-bb05-5b5cc73f18bb": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -790,6 +1101,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://rv.elks322.org/contact-us/"
+    },
+    "0f0cfd30-1727-43ff-a06e-b8ba51608ae1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://accesssupportnetwork.org/programs/hiv/"
     },
     "0f0fcb01-5e78-486f-a5de-9d78b1d8f56a": {
       "filter_text_added": true,
@@ -856,6 +1176,33 @@
       "processor": "text_json_diff",
       "url": "https://www.loveisrespect.org/"
     },
+    "0fac53b0-bbde-4970-99ff-aad31e8e5de3": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.crla.org/"
+    },
+    "0fd199fb-8c73-4eb5-bd41-29ef14d178c5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cayucoschurch.org/"
+    },
+    "106f9141-c1ab-44df-8f89-5a895b207571": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ca-arroyogrande.civicplus.com/464/Citizen-Complaint"
+    },
     "109f0676-be1e-45f1-b784-4146277e7218": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -921,6 +1268,33 @@
       "processor": "text_json_diff",
       "url": "https://slopartners.org/"
     },
+    "11172fbe-3961-4d7f-b5e8-0a6ec7b9e584": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cityfarmslo.org/"
+    },
+    "112f997c-cd48-44dd-a95d-2df9c5bf9786": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/clerk-recorder"
+    },
+    "11523002-81dd-4580-abcb-54a84ea06849": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sloaa.org/meetings/?type=espanol"
+    },
     "116b8288-acff-4016-b625-fa7a41ab5b09": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -947,6 +1321,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://988lifeline.org/"
+    },
+    "11bba705-dc12-4a7f-a6d7-56bcccecac37": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slolibrary.org/"
     },
     "11c50945-40b6-4e08-9703-72c2d3919962": {
       "filter_text_added": true,
@@ -1020,6 +1403,15 @@
       "processor": "text_json_diff",
       "url": "https://www.caljobs.ca.gov/vosnet/LoginIntro2.aspx"
     },
+    "13451643-2bbe-4c7d-8b28-78eb11e29d19": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://galacc.org/"
+    },
     "137087a9-2ee3-48b9-9106-221f2726c097": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1090,6 +1482,15 @@
       "processor": "text_json_diff",
       "url": "https://joinbankon.org/about/"
     },
+    "145b412a-cdba-4e5e-b46b-ce3cd67a0d3d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.chp.ca.gov/notify-chp/commend-or-complain/"
+    },
     "147e0f46-6823-45bd-ab69-92d581d33930": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1152,6 +1553,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.pshhc.org/rental-faq/#1603302191846-0d88dd41-feca"
+    },
+    "15d8c73a-8fb3-4ea6-b2cc-a376cab0866f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.instructables.com/Basic-Street-Safety-for-Women/"
     },
     "166358f3-3246-4c5d-83f4-e238ede64f5f": {
       "filter_text_added": true,
@@ -1230,6 +1640,24 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=ND"
     },
+    "178f8866-0155-428c-adac-b39e7b999424": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://debtorsanonymous.org/en-espanol/#title-8"
+    },
+    "17b6da26-c766-4934-9ff9-6a542cfdeb78": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pge.com/es/account/billing-and-assistance/financial-assistance/family-electric-rate-assistance-program-fera.html"
+    },
     "17cb121a-0885-448b-a659-c1c34ee4a8c7": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1270,6 +1698,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://uuslo.org/Immigration-Legal-Services"
+    },
+    "189f3bf0-76c6-47b8-ac1b-98fdc80af57d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cuesta.edu/academics/continuinged/"
     },
     "18d0b1f8-51f1-4a85-bb91-1f96e17226e7": {
       "filter_text_added": true,
@@ -1319,6 +1756,15 @@
       "processor": "text_json_diff",
       "url": "https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/replace-your-driver-license-or-identification-dl-id-card/"
     },
+    "193146f4-c21d-4d59-9511-3deb3f968c7a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccvhv.org/"
+    },
     "195a6181-98dc-4e22-a36c-06ebe1a314ac": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1361,6 +1807,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/clerk-recorder/forms-documents/fees/fee-schedule-effective-1-1-2024"
     },
+    "19b7f227-f94c-4ef1-8459-1b61398944bd": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://airtalkwireless.com/es/lifeline-application"
+    },
     "19e9463d-fdaf-48f5-802f-697e5b8a1cd5": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1398,6 +1853,15 @@
       "processor": "text_json_diff",
       "url": "https://library.municode.com/ca/san_luis_obispo_county/codes/county_code?nodeId=TIT11PARE_CH11.04ALCOPAFAEXNALA_11.04.090CA"
     },
+    "1a38d1e1-30f2-46a2-896e-6a26d0c15f86": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.bikelink.org/"
+    },
     "1a758668-31b6-4e43-9727-fcba07926ca1": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1418,6 +1882,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.disabilityrightsca.org/what-we-do/programs"
+    },
+    "1adc0ddc-1260-4a2f-82c1-2294d5a8b360": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://va.gov/health-care/about-va-health-benefits/"
     },
     "1ae9473f-c195-41b2-9ceb-c26cbc7c2291": {
       "filter_text_added": true,
@@ -1451,6 +1924,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.casasolanainc.org/contact"
+    },
+    "1b2a9068-81ec-473b-81f9-96eda6ba5c86": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sesloc.org/es/why-sesloc/financial-education/greenpath-financial-counseling/"
+    },
+    "1b5fa661-faeb-4565-aa59-bdd94c7bd383": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.mybenefitscalwin.org/"
+    },
+    "1c098f95-3716-4471-b03d-2889e21de6e5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://care4paws.org/clinics"
+    },
+    "1ca7e169-8dbb-41b2-a84a-1e4b1b120dbf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://seeclickfix.com/web_portal/mWPmZTZqbheqdCAtKircrZNq/issues/map"
     },
     "1cbb43e9-4bef-426a-80e3-71345bea8f9b": {
       "filter_text_added": true,
@@ -1521,6 +2030,15 @@
       "processor": "text_json_diff",
       "url": "https://www.fs.usda.gov/database/feis/plants/vine/toxdiv/all.html"
     },
+    "1da2aeca-f57f-451c-b3e1-2c1ae15dd763": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://prepareforyourcare.org/"
+    },
     "1e06d739-3460-4fbe-aad5-6a817ce66f7e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1532,6 +2050,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://petsofthehomeless.org/get-help/find-locations/#latitude=35.2899811&longitude=-120.6534214&zoom=10&types%255B%255D=food-supplies&types%255B%255D=shelters&types%255B%255D=resources&types%255B%255D=donation-sites"
+    },
+    "1ed8d2ca-1b21-44f2-8a2e-07d43c413463": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://findyourally.com/"
     },
     "1edd1783-de96-4493-bbd4-f3c17c3dc038": {
       "filter_text_added": true,
@@ -1547,6 +2074,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://slocasa.org/contact-casa/"
+    },
+    "1f05a759-66ec-4664-bc2b-b267d88d4040": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://benefits.calitp.org/"
     },
     "1f0a1fdd-0597-458a-880e-c69fcbfc3dab": {
       "filter_text_added": true,
@@ -1570,6 +2106,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://catalog.slolibrary.org/passport-services"
+    },
+    "1f4fcebe-1ee8-4bca-ad13-fc1a1d746e9a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slobarlris.org/"
     },
     "1f6a5649-99ed-4650-ab2b-dc2a83a0fdec": {
       "filter_text_added": true,
@@ -1609,6 +2154,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/schedules-fares/route-28/"
+    },
+    "1f984d27-c8fa-4f99-bd2e-49f90ede06aa": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://debtorsanonymous.org/meeting-search-virtual/?tz=PT"
+    },
+    "1fa37fac-1a35-41ef-ba9d-3b65f328bcfc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://dovecreekchurch.org/"
     },
     "1fce93ec-abe3-4050-8d1f-64ca4da16900": {
       "filter_text_added": true,
@@ -1677,6 +2240,15 @@
       "processor": "text_json_diff",
       "url": "https://www.buckinghampm.com/homes/california-manor"
     },
+    "20bdebe1-8a40-43b7-82c4-b45555a5adcf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://al-anon.org/al-anon-meetings/"
+    },
     "20ce1a2c-6dfa-4e5b-bcc4-1a82fa2de421": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1685,6 +2257,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://pacificmidwiferycare.com/"
+    },
+    "20e7714c-573a-494f-843a-a24e78d6d421": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.samhsa.gov/communities/homelessness-programs-resources/grants/soar"
+    },
+    "210ac792-2219-4416-a6ea-9f5b982ef77c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://cesanluisobispo.ucanr.edu/"
     },
     "21173c9e-2e3c-4141-8bb4-7051b0152c52": {
       "filter_text_added": true,
@@ -1700,6 +2290,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-adult-services/homeless-outreach-full-service-partnership"
     },
+    "212e1f04-6e1b-486b-b44a-24a49aece858": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.portsanluis.com/"
+    },
     "2168ef59-c6a4-449f-9aba-a4777aa03518": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1708,6 +2307,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/center/learningexpresslibrary/recursos-para-hispanohablantes/home/mejore-sus-habilidades-escritas-orales-y-gramaticales"
+    },
+    "2184ab9f-b0b3-4c9a-8e1a-2a345343b3df": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dhcs.ca.gov/services/ccs/Pages/ProgramOverview.aspx"
     },
     "21befa35-ae86-4336-a573-798a23545fd5": {
       "filter_text_added": true,
@@ -1729,12 +2337,148 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Powered by",
+        "Please accept cookies to access this content",
+        "BESbswy",
+        "BESbswy"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -1742,7 +2486,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/slo-prado/"
     },
@@ -1770,6 +2515,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://mixteco.org/indigenous-interpreter-services/"
+    },
+    "226a07a4-0c4b-41aa-998d-4377705c40f7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://woodshumanesociety.org/adoptions/surrender-a-pet/"
     },
     "22882992-56bf-4c4f-b54d-a7d12b17d17a": {
       "filter_text_added": true,
@@ -1820,6 +2574,15 @@
       ],
       "url": "https://www.pathpoint.org/locations/san-luis-obispo/"
     },
+    "22e37fb4-92a9-4df8-8c69-e10c7f9513af": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://woodshumanesociety.org/resources/pet-loss/"
+    },
     "2304c27a-aa87-4164-b640-85f3a094f3be": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1848,6 +2611,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/social-services/adult-services/services/adult-protective-services-program-%28aps%29"
     },
+    "237b41c0-fe71-4291-b8ac-802c3741c7e6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.hpcn.org/"
+    },
     "2386efdf-a44f-4885-82b1-514032dac5e3": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -1860,14 +2632,14 @@
       "processor": "text_json_diff",
       "url": "https://www.renovateslo.com/"
     },
-    "239c5622-c2ca-4840-878b-c7b32ccdb335": {
+    "238db1de-a2e9-4be1-909d-7092127c74c4": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://pasoroblesha.org/community-services/youth-works/"
+      "url": "https://humantraffickinghotline.org/es"
     },
     "23a5c880-8f12-40e8-a5b7-ad4317be45be": {
       "filter_text_added": true,
@@ -1908,6 +2680,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://adulted.luciamarschools.org/info-registration"
+    },
+    "249c347c-710d-4177-b6fa-a4c240218ac8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/en/passports/have-passport/lost-stolen.html"
     },
     "24c14f2a-fdac-4773-8c59-ab2d94749013": {
       "filter_text_added": true,
@@ -1967,6 +2748,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=DD-1800"
     },
+    "2584d838-3af6-4fc3-b88a-a35583cf1b37": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocity.org/government/department-directory/police-department/citizen-complaints-commendations"
+    },
     "25a7ad52-494b-43f8-a3d4-8f4399d68db0": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2005,6 +2795,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262842460&unit_list=0&akaSort=0&query=%20&simple_query=&code=TD&limit=&name="
     },
+    "26825b19-96a7-4208-b7b3-87692b176055": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.stpatsag.org/ministries/service-ministries"
+    },
     "26b4807c-3cad-42a9-8698-7c777aabfe09": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2023,6 +2822,15 @@
       "processor": "text_json_diff",
       "url": "https://www.morrobayca.gov/679/Tennis-Opportunities"
     },
+    "26f59237-3bde-42fb-a3fa-2c3ad52defe5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://montereylaw.edu/_resources/images/SLOCL%20Clinics%20-%20Spanish.pdf"
+    },
     "2723c64e-3a23-46fd-aceb-0cd17c550327": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2031,6 +2839,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/veterans-services/forms-documents/pamphlets/ssvf-pamplet"
+    },
+    "272449e3-2a2b-475e-8113-9de0817e0e15": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://apameds.org/for-clients/"
     },
     "276669fd-e657-487a-81dd-4c688a473313": {
       "filter_text_added": true,
@@ -2141,12 +2958,153 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "BESbswy",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -2154,9 +3112,19 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/atascadero/"
+    },
+    "28a396da-93a4-4512-89a3-214114d42740": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "http://www.scyouthcoalition.org/clases-en-espantildeol.html"
     },
     "28c53f1b-3e0a-406e-a275-6bbaaca8b4a8": {
       "filter_text_added": true,
@@ -2185,6 +3153,15 @@
       "processor": "text_json_diff",
       "url": "https://www.pasocares.org/contact"
     },
+    "2935f98a-c2a7-4ea5-961c-ad91807c5609": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://assets.glasscow.tech/pasohouse/wp-content/uploads/2020/09/Tenant-Selection-Plan-for-OP1.pdf"
+    },
     "2939d93b-19d5-4b9d-aa5a-ed8d93c27192": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2193,6 +3170,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cityfarmslo.org/farmstand"
+    },
+    "29f71b92-e9cb-4362-a63b-3d7a319aa106": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/central-coast/locations/arroyo-grande"
     },
     "2a72005a-2e8d-415c-ad76-e28c3bd15377": {
       "filter_text_added": true,
@@ -2205,6 +3191,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-3300.6500"
+    },
+    "2a8564d1-9ecd-4aa3-85b5-cd3be6936c6b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://luminaalliance.org/accompaniment"
+    },
+    "2a87e037-5b92-40e7-ae23-f3aeff6684dc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://laundrylove.org/"
     },
     "2abab1a1-67e5-45e5-983f-cb9024f09a48": {
       "filter_text_added": true,
@@ -2236,6 +3240,15 @@
       "processor": "text_json_diff",
       "url": "https://www.communityhealthcenters.org/patient-resources/payment-options-test/"
     },
+    "2b09deda-dbda-4a9d-aa46-9d9d185b03c2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://dollarfor.org/"
+    },
     "2b212880-8d25-49d4-9e19-8a86c73fe7ce": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2257,6 +3270,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=LV"
     },
+    "2b2fc286-be53-48e2-8bfd-17577d18d79c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.newtimesslo.com/news/slos-sunny-acres-could-become-a-health-campus-by-restorative-partners-and-homekey-funds-16578959"
+    },
     "2b3f63f3-b1ee-4ffc-9912-fc5511ed9b6a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2274,6 +3296,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slohealthaccess.org/prenatal-and-postpartum-care.html"
+    },
+    "2bb82127-aa62-4587-9004-a59266baa4d6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dca.ca.gov/"
+    },
+    "2bdb1253-6dc2-41a5-8836-28f09ba2fdce": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://littlefreelibrary.org/"
     },
     "2c122a5d-ae74-4bb4-95e0-918fef45d4c0": {
       "filter_text_added": true,
@@ -2295,6 +3335,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.t-mha.org/program-details.php?id=20"
+    },
+    "2c15a2d5-7706-4cc3-8c9d-699ec70ad874": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slobangers.com/"
     },
     "2c762d80-ed9a-45fa-8287-024483028af6": {
       "filter_text_added": true,
@@ -2320,6 +3369,15 @@
       "processor": "text_json_diff",
       "url": "https://edd.ca.gov/en/jobs_and_training/Job_Seeker_Information/"
     },
+    "2d19b0d8-2b46-48c6-80d4-a6f6a7a8faaf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slodefend.com/"
+    },
     "2d38043b-5249-4c01-9f09-fde5b837e061": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2337,6 +3395,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://sloparents.org/"
+    },
+    "2d9790f1-57ff-4d15-a3bf-017c62085067": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.vetride.va.gov/"
+    },
+    "2dcab954-fcfe-4906-9ff6-8d88a8e88784": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://crestonchurch.com/"
     },
     "2de10715-1c0f-41b8-bee6-ff2f9781a82a": {
       "filter_text_added": true,
@@ -2367,6 +3443,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/drug-alcohol-services-residential-programs"
     },
+    "2e3efe98-5a88-48e5-b7fd-80b6c3e48360": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://play.google.com/store/apps/details?id=edu.calpoly.android.SloBusMapper&hl=en"
+    },
     "2e4e56d5-5942-4141-8bef-202d58466867": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2384,12 +3469,18 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "/html/body/div[2]/div[1]/div/div/div/section[4]/div/div/div/div/div/div[1]",
-        "/html/body/div[2]/div[1]/div/div/div/section[4]/div/div/div/div/div/div[2]/div/div[1]/div/div"
+        ".bt_bb_wrapper"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".wpsl-search",
+        "#wpsl-gmap",
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge"
+      ],
       "url": "https://www.communityhealthcenters.org/locations/"
     },
     "2e72183b-d53f-46b4-947f-12199b559aa0": {
@@ -2436,6 +3527,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/district-attorney/adult-prosecutions/veterans-treatment-court"
     },
+    "2f5f6d1a-5657-487a-8061-68ca1f83641b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ssa.gov/prepare/check-eligibility-for-benefits"
+    },
     "2fdd3986-cedb-4c19-b054-13ee814db0bb": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2460,6 +3560,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.centralcoastdentalsociety.org/"
+    },
+    "305dbf86-adba-4522-bf8f-48fa9bd2242e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocity.org/government/department-directory/parks-and-recreation/slo-swim-center/swim-classes-events"
+    },
+    "30b11265-6808-4cfc-a07a-b31cf3283df5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ciymca.org/childcare-sites"
+    },
+    "30b5776d-e816-4d32-ad30-253e8794087d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://5chc.org/community-services"
+    },
+    "30bca1a6-313e-4812-be03-f1b180d8bad1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://edd.ca.gov/es/unemployment/ui_online/"
     },
     "30c701b0-0711-443c-ad97-ed5ab37dc589": {
       "filter_text_added": true,
@@ -2548,6 +3684,24 @@
       "processor": "text_json_diff",
       "url": "https://www.slocm.org/visit"
     },
+    "3175d8e2-fa39-4655-b28c-9d4125734d95": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://plantingseedsblog.cdfa.ca.gov/wordpress/?p=28082"
+    },
+    "31a6c076-b779-4b7c-98f1-2d840f1e5459": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/medication-assisted-treatment"
+    },
     "31bc7448-96bd-4c77-bf7e-da3fe379bfb2": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2580,12 +3734,24 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "ignore_text": [
-        "Screenshot"
+        "Screenshot",
+        "**********************************************************************************",
+        "************************************************************************************************",
+        "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://nipomoseniorcenter.org/"
+    },
+    "3290522e-0e31-4932-b242-d1c1ccd11925": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.readyslo.org/prepare/"
     },
     "3315db20-a232-4002-9fa4-83695c47e23d": {
       "filter_text_added": true,
@@ -2595,6 +3761,33 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.goodsamaritanshelter.org/who-we-are-1"
+    },
+    "333e2ded-91ca-4817-8bcf-1fdbdbfd8f7b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://tools.usps.com/zip-code-lookup.htm"
+    },
+    "33696973-ec06-4238-a7e4-cada70643590": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.flyingflagsavilabeach.com"
+    },
+    "337a7d50-6fc3-4f0c-ba3d-3d99b41ec5fe": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://calendly.com/csulegalservices/ild"
     },
     "3398b95c-f84a-438f-aecf-c4b7fd3d575d": {
       "filter_text_added": true,
@@ -2682,7 +3875,8 @@
         "nav",
         ".experiencefragment",
         ".csh-aem-maincontent",
-        ".jump-nav"
+        ".jump-nav",
+        ".csh-aem-card-dropdown__toggle-button"
       ],
       "url": "https://www.commonspirit.org/find-a-location/oncology-hematology-mission-hope-santa-maria-1914"
     },
@@ -2780,6 +3974,15 @@
       "processor": "text_json_diff",
       "url": "https://choosework.ssa.gov/about/how-it-works"
     },
+    "361b17eb-8cbd-419c-bbb3-e923dbe5e201": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.identitytheft.gov/"
+    },
     "3622c4c6-0d3c-45cd-8828-0c739e456c68": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2826,6 +4029,15 @@
       "processor": "text_json_diff",
       "url": "https://www.plannedparenthood.org/health-center/california/san-luis-obispo/93401/san-luis-obispo-health-center-2252-90170"
     },
+    "36dc3411-0fc5-4eca-af83-6c58fb00f4d7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cancer.org/cancer/risk-prevention/sun-and-uv/uv-radiation.html"
+    },
     "3727f960-4a66-4e9c-ba69-74454f83f78b": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -2835,19 +4047,59 @@
       "processor": "text_json_diff",
       "url": "https://www.slohelpmegrow.org/services"
     },
+    "37337743-c0f2-4c5f-8b6b-a599e9b19990": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sloundocusupport.org/es"
+    },
+    "3749bde2-6242-4a57-b4d5-94582eb287c7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/en/passports/how-apply/photos.html"
+    },
     "375fc722-d722-4cb0-a260-98814a17cf09": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "/html/body/div[2]/div[1]/div/div/div/section[3]/div/div/div/div/div/div[1]/div/div[1]/p/span",
-        "/html/body/div[2]/div[1]/div/div/div/section[3]/div/div/div/div/div/div[1]/div/div[3]/div[2]",
-        "/html/body/div[2]/div[1]/div/div/div/section[3]/div/div/div/div/div/div[1]/div/div[4]/p[3]/span"
+        ".bt_bb_wrapper"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".bt_bb_hidden_xs",
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge"
+      ],
       "url": "https://www.communityhealthcenters.org/health-services/dental/"
+    },
+    "379e651f-5199-4087-9743-b8534fd5d0ba": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.thebautistaprojectinc.org/post/personal-security-homeless-shelter"
+    },
+    "37e9c7db-2b49-4645-b528-8d0d555e4948": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cde.ca.gov/ds/sh/sn/summersites.asp"
     },
     "3880b7b2-b367-4371-b596-e8eb26a867d1": {
       "filter_text_added": true,
@@ -2860,6 +4112,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://eckerd.org/jobs-training/"
+    },
+    "38b1eec0-2416-4906-8341-dea3d7cff6f8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.literacyforlifeslo.org/"
     },
     "38ce16eb-6734-4752-ae09-260b16c40eac": {
       "filter_text_added": true,
@@ -2875,12 +4136,21 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "div.MuiContainer-root:nth-child(2)"
+        "div.MuiContainer-maxWidthLg"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://needymeds.org/helpline"
+    },
+    "39fc7cfc-1d87-4136-a82d-fdceadd24640": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slo.craigslist.org/search/zip"
     },
     "3a37cc10-4654-4ab3-afb4-fdec6d6df18e": {
       "filter_text_added": true,
@@ -2945,14 +4215,23 @@
       "processor": "text_json_diff",
       "url": "https://loavesandfishespaso.org/contact/"
     },
-    "3ae3bb18-62aa-4c73-b92d-6d70805262fa": {
+    "3ab3dca5-85c8-4f7a-9a86-244d11c2cb80": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://sloalanoclub.org"
+      "url": "https://www.cuesta.edu/student-support/student-health-services/"
+    },
+    "3abed8ff-d23d-4496-a85f-a3afbfd77ac4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ipm.ucanr.edu/PMG/WEEDS/pacific_poisonoak.html"
     },
     "3af927e2-039c-4e16-8a06-894a20e905d3": {
       "filter_text_added": true,
@@ -2987,6 +4266,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PB"
     },
+    "3b3a2788-d668-48bf-aecf-6b6137fe37ce": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services"
+    },
     "3bc758af-4d03-4498-b75b-9942443ca12d": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3008,6 +4296,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://beachareastorage.com/location-grover-beach/"
+    },
+    "3c96dda0-e4ea-4e17-b710-dfae6e21c0a6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.phpslo.org/es/"
     },
     "3cb4006c-cd0c-41a2-9823-d5e3d27411c5": {
       "filter_text_added": true,
@@ -3035,6 +4332,24 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/animal-services/contact-us"
     },
+    "3cdd5304-95d1-4c0d-aacd-04c3f3d76a40": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/welcomehomevillage.aspx"
+    },
+    "3d4a6ca5-ad08-440b-9eba-39d5ddd15bbf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.haslo.org/"
+    },
     "3d5f1652-372c-4904-beba-66d2c14b1728": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3053,6 +4368,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.findhelp.org/paso-cares%2D%2Dpaso-robles-ca%2D%2Dfeeding-the-homeless/5153804446597120"
+    },
+    "3d71288f-880a-4a34-ab32-108c8e554880": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://pmc.ncbi.nlm.nih.gov/articles/PMC2776751/"
     },
     "3dde73ca-be4c-4c81-9485-66f5add7c8d3": {
       "filter_text_added": true,
@@ -3110,6 +4434,24 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/public-health/clinic-locations"
     },
+    "3e83e5a1-6a30-48d0-b71c-00688ca89875": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.immigrantdefenseproject.org/"
+    },
+    "3eb75486-c631-4555-949c-f732024e0ad5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://selfhelp.courts.ca.gov/es/reclamos-menores-en-california"
+    },
     "3f38594c-6edf-40db-8374-d1238857c818": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3119,17 +4461,14 @@
       "processor": "text_json_diff",
       "url": "https://fpcslo.org/"
     },
-    "3f4db263-226f-4f0f-aa87-f2ad1be60160": {
+    "3f4a9098-57f5-49a0-9d8a-890d0fe6739a": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
-      "include_filters": [
-        "#item1433254"
-      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "http://luciamarschools.org/251185_2"
+      "url": "https://californiafarmworkers.org/what-we-do/"
     },
     "3f4ddbd8-474f-4370-aa11-baaed4a7b956": {
       "filter_text_added": true,
@@ -3151,6 +4490,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.va.gov/careers-employment/vocational-rehabilitation/eligibility/"
+    },
+    "4006b671-5f5d-4e9c-af3a-86cfc9dc8497": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://docs.google.com/document/d/1iVGbPgBH0IzZWpfp2gkt-2gmF3_Q0zK0HPNgsZgM2TE/mobilebasic"
     },
     "40187dcb-fe16-45e1-a207-65de745dfffa": {
       "filter_text_added": true,
@@ -3234,6 +4582,15 @@
       "processor": "text_json_diff",
       "url": "https://aevumhospice.com/"
     },
+    "415aed77-32b1-4ec7-8249-c66803573f51": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.va.gov/homeless/ssvf/ssvf-overview/"
+    },
     "41d4d06e-4fda-40f2-8f14-54241698f359": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3249,12 +4606,146 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Satellite",
+        "Map",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Powered by",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -3262,7 +4753,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/arroyo-grande-walk-in/"
     },
@@ -3401,6 +4893,24 @@
       "processor": "text_json_diff",
       "url": "https://www.5citiesmow.com/services.html"
     },
+    "43bcef53-e2c3-4fa3-84ff-6bc741b79cc1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/en/passports/how-apply/identification.html"
+    },
+    "43bee43f-8d3b-4a01-8109-5d5c4c616189": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.literacyforlifeslo.org/learning-centers.php"
+    },
     "43f54e0b-f03b-4c7f-9f96-e06353796d3d": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3418,6 +4928,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cencalhealth.org/health-plans/careconnect/how-to-apply/"
+    },
+    "44b8f61f-279e-4393-934f-e5d99ffb222d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://accesscentralcoast.org/about-us/contact-information.php"
     },
     "44de6fbd-caa3-411b-b943-09a0869214a0": {
       "filter_text_added": true,
@@ -3445,6 +4964,15 @@
         "header"
       ],
       "url": "https://centerforautism.com/services/parent-resources/insurance-accepted/"
+    },
+    "45cbb855-9638-4d7f-9a3e-cafc804999c8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.noozhawk.com/a-t-still-university-to-move-central-coast-campus-from-santa-maria/"
     },
     "45ff07bd-2db5-430d-be62-1a78407a9996": {
       "filter_text_added": true,
@@ -3475,6 +5003,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slo.courts.ca.gov/self-help/family-law/divorce"
+    },
+    "463c6769-c7ef-448c-bf43-0d78d96c1f8a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/es/s-a-f-e-family-resource-centers/"
     },
     "4651bff6-73a5-4cb3-a077-65dff0df2830": {
       "filter_text_added": true,
@@ -3560,6 +5097,24 @@
       "processor": "text_json_diff",
       "url": "https://fcni.org/what-we-do/"
     },
+    "471081d6-ae95-489b-b130-f27209d1a7d5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ssa.gov/"
+    },
+    "47236999-f8e0-4c7d-b2ed-876a1233a974": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.first5slo.org/what-we-do.php"
+    },
     "4743495b-cfe6-4a2f-9b22-267354f60319": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3641,6 +5196,24 @@
       "processor": "text_json_diff",
       "url": "https://5chc.org/community-services/mental-health,-drug-and-alcohol"
     },
+    "483b1ae6-292c-4033-9d0c-fff584528068": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ssa.gov/es/apply"
+    },
+    "4840725b-0c57-4aa5-ad05-58172ae4c7ae": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.modestneeds.org/mn/for-applicants"
+    },
     "48abe1a1-0206-4259-a37f-ce27c453b49d": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3695,6 +5268,15 @@
       "processor": "text_json_diff",
       "url": "https://www.ssa.gov/number-card/replace-card/get-started/apply-online"
     },
+    "499c1f99-72ad-47af-a629-7bde79ac590b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://southbayseniorspeoplehelpingpeople.com/"
+    },
     "49a49f2c-b35a-4eb9-bb8b-d8fad7369c9b": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3716,6 +5298,15 @@
       "processor": "text_json_diff",
       "url": "https://post66slo.org/"
     },
+    "49ef074b-693e-4810-a141-e6ade10e1a8a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/en/passports/have-passport/renew-online.html"
+    },
     "4a0698db-73b4-4e10-9fc6-d35265683375": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3730,6 +5321,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://mealsthatconnect.org/en/"
+    },
+    "4a0fe95f-dacd-4831-8353-cdc1a0192bed": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.nipomopresbyterian.org/calendar"
     },
     "4a909e0b-d174-419d-a53c-9197a67a2166": {
       "filter_text_added": true,
@@ -3746,6 +5346,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://caconnect.org/service/"
+    },
+    "4aa5ef47-dc5e-4a07-8474-524700217c25": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.veteranscrisisline.net/es/"
     },
     "4afa2ae3-9a70-4eae-bb98-eb792ef283a2": {
       "filter_text_added": true,
@@ -3781,6 +5390,15 @@
       "processor": "text_json_diff",
       "url": "https://www.infantsee.org/about-us"
     },
+    "4b4ccc96-6d04-4a35-9cfc-4932359eb766": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/en/passports/have-passport/renew.html"
+    },
     "4b8a80c6-57b3-470e-96dd-16ed0f6f597a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3799,6 +5417,15 @@
       "processor": "text_json_diff",
       "url": "https://catalog.slolibrary.org/tlc"
     },
+    "4b953050-1770-4e5c-b558-b77929f484fa": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.computerswithcauses.org/application/"
+    },
     "4c018a90-1d49-434c-8c58-da4c9b010773": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3813,6 +5440,24 @@
       "processor": "text_json_diff",
       "url": "https://unitedwayslo.org/"
     },
+    "4c1ce555-e41e-4bfd-aa55-74ff55308a68": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.childrensresource.org/therapy"
+    },
+    "4c3627f4-142e-47f0-9baa-5924357f7174": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://stjosephcayucos.org/"
+    },
     "4c65f85e-6574-4d36-bab6-59c2379ce36a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3821,6 +5466,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://hopesvillageofslo.com/programs"
+    },
+    "4cbe0a82-f963-4e73-a4e5-0c4ef6242010": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://coasthills.coop/resources/about/locations"
     },
     "4cfd1fc5-1641-426b-975b-e13c8b09d969": {
       "filter_text_added": true,
@@ -3844,14 +5498,23 @@
       "processor": "text_json_diff",
       "url": "https://catalog.slolibrary.org/Record/143205?searchId=16314408&recordIndex=1&page=1&referred=resultIndex"
     },
-    "4d74c6a8-0891-4552-beba-0f5642fa3366": {
+    "4d3a5ef4-365d-41d6-8a4c-174417557f71": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://www.kickitca.org/"
+      "url": "https://calendly.com/self-help-center/"
+    },
+    "4d6a74ba-0c0f-45ab-b30e-e357bdda0d89": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.bar.ca.gov/cap"
     },
     "4d87cdc2-9256-405b-888e-dc2f1b8fda2f": {
       "filter_text_added": true,
@@ -3872,12 +5535,153 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "BESbswy",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -3885,9 +5689,19 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/san-miguel/"
+    },
+    "4dcb88f3-1589-407d-89b9-63acc97de903": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.commonspirit.org/services-specialties/urgent-care"
     },
     "4e06e94c-95c5-4f5f-8617-357825594538": {
       "filter_text_added": true,
@@ -3912,6 +5726,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.sesloc.org/why-sesloc/financial-education/greenpath-financial-counseling/"
+    },
+    "4e657b81-05c4-40f5-8054-5f7ae3e151a8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cottagehealth.org/urgent-care/"
+    },
+    "4e9979d8-7b3f-4bb0-a503-9bb9e593bd66": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.hpcn.org/mssp"
     },
     "4e9fa301-69a7-4cbf-91f8-62436f97733a": {
       "filter_text_added": true,
@@ -3943,6 +5775,15 @@
       "processor": "text_json_diff",
       "url": "https://5chc.org/community-services/transportation"
     },
+    "4f82657a-5989-4575-bc1d-f974249dae60": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://moovitapp.com/index/en/public_transit-San_Luis_Obispo_CA-4003"
+    },
     "4f872828-06e7-421f-9193-16cff7b8e504": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -3954,6 +5795,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.uhccf.org/"
+    },
+    "4f8ab893-0a92-4c63-ae1f-b3706a2e88a4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/minor-home-repair/"
     },
     "4fa42342-cb80-4044-9556-dd24d4488b2a": {
       "filter_text_added": true,
@@ -4010,6 +5860,15 @@
       "processor": "text_json_diff",
       "url": "https://lp.constantcontactpages.com/sl/Jg4jVHc/warmingcenter"
     },
+    "505aec1c-2ad0-434a-9545-94804c453dc1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services/forms-documents/department-wide-forms/informational-documents/slo-county-resources-and-information-(5-1-2024)"
+    },
     "505fa7d6-c431-4437-822d-7017542ee77a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4028,6 +5887,15 @@
         "form"
       ],
       "url": "https://mealsthatconnect.org/en/how-meals-work/"
+    },
+    "507f47e7-2fce-4f04-a387-9314b39a5f56": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.caljobs.ca.gov/"
     },
     "50815880-e806-44db-87e0-5f074d257efe": {
       "filter_text_added": true,
@@ -4110,6 +5978,15 @@
       "processor": "text_json_diff",
       "url": "https://www.aclusocal.org/en/seeking-legal-help-aclu"
     },
+    "51860c15-1727-4466-9531-2bd6b8da98d1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pshhc.org/rental-properties/"
+    },
     "51ebbf58-d1b3-4fd9-9c94-899a906f05a7": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4121,6 +5998,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://capslo.org/head-start-and-early-head-start/"
+    },
+    "521d934a-6a42-4efb-80f0-3165dec230b8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccpnhpn.com/becoming-a-member/"
+    },
+    "524ee5ec-51e0-4fea-a69f-dfbb697564dc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://cscslo.org/spanish-programs/"
     },
     "526bf02f-f50e-4822-a4d2-01a865af1133": {
       "filter_text_added": true,
@@ -4204,6 +6099,15 @@
       "processor": "text_json_diff",
       "url": "https://www.losososcares.com/programs#comp-kadleziz"
     },
+    "5383ad58-7be1-48e7-972f-9ca71f19a866": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://alsnetwork.org/event/san-luis-obispo-connect-support-chat-2025-12-13/"
+    },
     "53a33f3f-1d04-4a35-961e-4bcecd82bf91": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4212,6 +6116,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262842000&unit_list=0&akaSort=0&query=%20&simple_query=&code=RX&limit=&name="
+    },
+    "53ac2b2f-af56-4468-9f2c-c89b5a8c2d40": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sesloc.org/es/why-sesloc/financial-education/seminars-and-webinars/"
     },
     "53be69cb-0a0d-4e83-bb41-1e73766cccb8": {
       "filter_text_added": true,
@@ -4313,6 +6226,15 @@
       "processor": "text_json_diff",
       "url": "https://morrobayseniors.org/resources/"
     },
+    "54a94480-359f-449f-aa93-ee9f6c24ad80": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdph.ca.gov/Programs/CFH/DWICSN/Pages/WICFoods.aspx"
+    },
     "54a9d825-aee2-4f9a-9c51-5b49bb89ad53": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4347,6 +6269,15 @@
         "#gt-wrapper-72906128"
       ],
       "url": "https://fcni.org/how-we-help/ensuring-stability/"
+    },
+    "5514d2df-2a30-4806-b4b7-59bf004af214": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://darebee.com/workouts/"
     },
     "5529e9e0-9c44-4d20-822b-a44aff1a6fd6": {
       "filter_text_added": true,
@@ -4396,6 +6327,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.yelp.com/biz/north-county-care-minor-emergency-services-paso-robles"
+    },
+    "55cc7c67-80fa-400c-920d-28cd8343195a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/"
+    },
+    "55f8b920-49f1-42cb-bd98-5498190bd81e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://smwisdomcenter.org/"
     },
     "56016309-49fe-4093-8810-17b8664df8bc": {
       "filter_text_added": true,
@@ -4457,6 +6406,15 @@
       "processor": "text_json_diff",
       "url": "https://ilshealth.com/calaim-resources/"
     },
+    "5640605a-fa67-440f-a9cd-ee3107407613": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.vetride.va.gov/app/contact-us"
+    },
     "565319b8-94a0-4d28-8876-6d889b90e341": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4489,6 +6447,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.org/senior-independent-housing-options/"
+    },
+    "571d3c33-a307-4ee9-84d9-55a93af4707e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dor.ca.gov/"
     },
     "575b3408-fd54-4467-be91-d6b6a0e0d813": {
       "filter_text_added": true,
@@ -4545,6 +6512,15 @@
       "processor": "text_json_diff",
       "url": "https://petsofthehomeless.org/get-help/how-we-help/"
     },
+    "587fc788-8d36-4c01-9bb5-c2d36d1459c1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.communityhealthcenters.org/patient-resources/payment/"
+    },
     "58ee0f61-5005-4ede-8e84-3585911daca6": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4593,6 +6569,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.newlifepismo.com/pantry/"
+    },
+    "5999d8b3-0758-49df-960a-2c8ac3fd9088": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.disabilityrightsca.org/es/get-help"
     },
     "5a25fb93-3ea4-4481-b61b-5ebde87fac09": {
       "filter_text_added": true,
@@ -4671,6 +6656,33 @@
       "processor": "text_json_diff",
       "url": "https://www.californialifeline.com/en/contact"
     },
+    "5b2ad46a-a171-42b1-9c18-00228efa1d4c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.va.gov/homeless/nationalcallcenter.asp"
+    },
+    "5b37d8c3-ac85-4ced-93d5-471928a29f70": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ilshealth.com/"
+    },
+    "5b3ffc63-a416-4f0f-bfdb-10a4f9b7bbb3": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.reddit.com/r/beermoney/"
+    },
     "5b438f2d-7a3a-4882-a978-2e74bc798447": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4723,6 +6735,15 @@
       "processor": "text_json_diff",
       "url": "https://restorativepartners.org/contact/"
     },
+    "5bccbcb4-e4d7-4b2c-81a5-359d16eb8133": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cencalhealth.org/es/members/transportation/"
+    },
     "5c6292e7-5609-4f41-9769-325685cc16a3": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4755,6 +6776,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://learning.pronunciator.com/getstarted-procitizen-ES.php?library_id=18096"
+    },
+    "5dc2800d-5136-4df6-8294-a63396612451": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slofoodbank.org/wp-content/uploads/2026/05/ENG_June26_Distribution-ResourceList.pdf"
+    },
+    "5de61e7c-a67b-40d2-bec4-1fc653528da0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pge.com/es/account/billing-and-assistance/financial-assistance/relief-for-energy-assistance-through-community-help.html"
     },
     "5e0179c4-7468-46bd-83bf-1328fb727663": {
       "filter_text_added": true,
@@ -4841,6 +6880,24 @@
       "processor": "text_json_diff",
       "url": "https://www.t-mha.org/wellness-calendars.php"
     },
+    "5fbe1926-86b7-4553-9e69-0e7e231d6140": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://habitatslo.org/homeownership/"
+    },
+    "6004750c-e203-47d2-88d2-77f94b7af9d2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.centralcoastseniors.org/"
+    },
     "6053b1f4-6b39-4c0a-a3b3-846075ca6e55": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -4875,12 +6932,93 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "This page can't load Google Maps correctly.",
+        "Do you own this website?  OK",
+        "BESbswy",
+        "BESbswy",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "wpEmojiSettingsSupports",
+        "session",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "cookieyes-*",
+        "1 year",
+        "CookieYes sets this cookie for consent solution management.",
+        "ts",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "ts_c",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "rc::a",
+        "Never Expires",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "rc::c",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "YSC",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "_ga_*",
+        "1 year 1 month 4 days",
+        "Google Analytics sets this cookie to store and count page views.",
+        "_ga",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "VISITOR_INFO1_LIVE",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "__Secure-YENID",
+        "1 year 1 month",
+        "Description is currently not available.",
+        "__Secure-YNID",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "__Secure-ROLLOUT_TOKEN",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "__Secure-YEC",
+        "past",
+        "NID",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "iutk",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Powered by",
+        "BESbswy",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -4888,9 +7026,19 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/arroyo-grande-station-way/"
+    },
+    "60b9ffad-f424-4697-bdd3-47683456efa7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slohelpmegrow.org/"
     },
     "60fce347-0c72-42fe-98f7-a845a97a9a9b": {
       "filter_text_added": true,
@@ -4952,6 +7100,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slo.courts.ca.gov/self-help/gender-change"
+    },
+    "6166c8cf-4dac-475f-a751-57bfdd21bb43": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccgoodwill.org/locations/grover-beach-goodwill-thrift-store/"
+    },
+    "617153c5-3a9c-4c76-a82c-b8a19fb59418": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.reddit.com/r/beermoney/comments/ab0dyv/most_common_beer_money_sites_do_not_create/"
     },
     "61adb461-48da-4adf-b130-594fe6d18ac5": {
       "filter_text_added": true,
@@ -5018,6 +7184,24 @@
       "processor": "text_json_diff",
       "url": "https://removery.com/tattoo-removal/aftercare/"
     },
+    "6232d7f5-ea26-4163-9eb9-4623305e3015": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dmv.ca.gov/"
+    },
+    "626782dc-155b-42f6-b028-fadef268b1b0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slolaf.org/foreclosureprevention"
+    },
     "62b260f9-c97c-4b97-9232-4c977f38ae28": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5051,6 +7235,15 @@
       "processor": "text_json_diff",
       "url": "https://www.nipomopresbyterian.org/join-us"
     },
+    "62dc3157-5887-409a-aa43-b2aa1c7b7ca0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://habitatslo.org/homepreservation/"
+    },
     "62e53fc0-c232-46e4-9e2f-edbff3c6d7d0": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5066,6 +7259,15 @@
         "footer"
       ],
       "url": "https://www.thetrevorproject.org/get-help/"
+    },
+    "62fa15eb-4f9e-454e-82ec-ea5ffbe9fef6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://catholiccharitiesdom.org/"
     },
     "637cfe1c-668f-4ebe-b72d-ea0a4b815bf5": {
       "filter_text_added": true,
@@ -5125,6 +7327,24 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=DM"
     },
+    "64688a13-a33a-4d77-927e-17c6f2e6c10e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.consumerfinance.gov/complaint/"
+    },
+    "647fe3c3-ebbe-4a09-bcb4-ed1d3dbd88b2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://24petconnect.com/SLOCStray"
+    },
     "6494336c-0f2a-4d22-a6dd-d3f91859b1cd": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5166,6 +7386,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://slobarlris.org/contact/"
+    },
+    "65085a63-a81e-4097-be06-e02d83d89254": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://5chc.org/"
+    },
+    "653c27ae-c151-4946-969a-1bfb9509eda3": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cuesta.edu/student-support/eops/care.html"
+    },
+    "6559d736-8c34-4e1a-acf2-975ce44af5f4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ssa.gov/apply"
+    },
+    "65702512-6c83-4692-8edc-450362400d35": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.amtrak.com/"
     },
     "6572336a-e2d4-4faa-a54d-cd7e4944505e": {
       "filter_text_added": true,
@@ -5215,6 +7471,15 @@
       "processor": "text_json_diff",
       "url": "https://coasthills.coop/"
     },
+    "65f0925e-bf50-48ba-b72d-4bc66af33039": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://oceanoelks2504.org/"
+    },
     "66023f8e-8768-43c2-85f4-b2d53630bf00": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5223,6 +7488,33 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262841467&unit_list=0&akaSort=0&query=%20&simple_query=&code=LH-2700&limit=&name="
+    },
+    "6602e21d-aa65-40b6-ba32-dedd49f4272c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/access-and-crisis-services/mobile-crisis-team-%28mct%29"
+    },
+    "660a4916-1d08-495d-b2c5-033d990c3053": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://tenantpowertoolkit.org/"
+    },
+    "6648b181-4927-4e19-a077-3d3a158b8009": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.samhsa.gov/"
     },
     "66862e2c-d91a-4e79-927f-2929fd511345": {
       "filter_text_added": true,
@@ -5236,6 +7528,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://gracecentralcoast.org/gods-storehouse-care"
+    },
+    "66bdebe0-ad23-4979-a9a7-00632a9f8acc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cottagehealth.org/urgent-care/appointments/san-luis-obispo-marigold-center/"
     },
     "6720043f-a9a1-4bb5-bcee-2c5474c50647": {
       "filter_text_added": true,
@@ -5295,6 +7596,24 @@
       "processor": "text_json_diff",
       "url": "https://arisevineyard.com/"
     },
+    "681b0a20-1b89-45f1-8b5a-f460df9d4c60": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.childplus.net/apply/es/4C3A30704DEAD016C09968C44ACD9A8B/CE180CB5372A691D8A0368833B588572"
+    },
+    "6822e360-0203-4e30-afd6-2d0a8a339f13": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.calflora.org/entry/observ.html#srch=t&taxon=Toxicodendron+diversilobum&lpcli=t&cch=t&inat=r&chk=t&cc=SLO"
+    },
     "68479b14-f568-4aec-a359-5e75a2953fd4": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5303,6 +7622,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=3&search_history_id=262841941&unit_list=0&akaSort=0&query=%20&simple_query=&code=PN&limit=&name="
+    },
+    "69524843-dbc1-464d-8b30-46787f8c8e9a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cuesta.edu/student-support/basic-needs-center/homeless-food-resources.html"
     },
     "69b46c50-e74c-4438-87e4-278882f3eb40": {
       "filter_text_added": true,
@@ -5341,6 +7669,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slo.courts.ca.gov/general-information/location-contact-info"
     },
+    "6a131102-601b-4f45-aace-f7c01b8f57c8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.californialifeline.com/"
+    },
     "6a459818-45dd-4f7b-b79e-a0c9273cf16c": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5359,12 +7696,146 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Powered by",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -5372,7 +7843,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/arroyo-grande-fair-oaks/"
     },
@@ -5400,6 +7872,15 @@
       "processor": "text_json_diff",
       "url": "https://www.auntieisabellfoundation.org/grant"
     },
+    "6a97352c-b456-4a22-b2fe-4b30e7dd8444": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://sloautism.org/"
+    },
     "6ac46c71-e660-4606-b69e-e4e5ce011d03": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5408,6 +7889,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262841087&unit_list=0&akaSort=0&query=%20&simple_query=&code=DD-1500.4150&limit=&name="
+    },
+    "6af78bcd-2666-4eef-9a96-de81447a04bf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.prcity.com/RequestTracker.aspx"
     },
     "6b2d85fc-1b3f-4ee3-a6e9-363e27e2d79e": {
       "filter_text_added": true,
@@ -5479,6 +7969,15 @@
       "processor": "text_json_diff",
       "url": "https://admissions.centerforautism.com/"
     },
+    "6c0d86f3-137b-40f6-8fd8-322ee4b2cc14": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.commonspirit.org/services-specialties/home-based-care"
+    },
     "6c604047-92fb-4650-a066-4c477025cc2c": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5503,6 +8002,15 @@
       "processor": "text_json_diff",
       "url": "https://www.stroke.org/en/stroke-groups/hope-for-stroke"
     },
+    "6cd08f4c-b7b1-4a8c-9b99-5e29cf7b7067": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://805streetoutreach.org/"
+    },
     "6d114c94-2398-4f5e-b0ba-d686ebf72cb4": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5516,6 +8024,15 @@
       "processor": "text_json_diff",
       "url": "https://restorativepartners.org/about/"
     },
+    "6d40b0aa-3e08-499e-8a41-4f4be86ea6d7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://adulted.luciamarschools.org/learning-center-directions"
+    },
     "6d5e48a7-0904-4d15-9b11-dcf8ff67d38e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5527,6 +8044,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-3300.3000"
+    },
+    "6d64e212-c157-433b-9901-aeb7fdd5989d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.nar-anon.org/find-a-narateen-meeting"
+    },
+    "6d69277b-e807-430f-8730-e60fc963f925": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/central-coast/locations/frenchhospital"
+    },
+    "6d81698e-fc9f-4a7f-b6e7-4aad6d28d79a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://eforms.com/power-of-attorney/ca/california-advanced-health-care-directive/"
+    },
+    "6da1079f-be44-4109-889a-f2249ed5d836": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/public-health"
     },
     "6dc16ccc-a405-48bd-a084-1a2d3ca85160": {
       "filter_text_added": true,
@@ -5599,6 +8152,15 @@
       "processor": "text_json_diff",
       "url": "https://slocounselingservice.calpoly.edu/faq"
     },
+    "6e74750e-e278-487e-b5d2-b11092c5936e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://pasoroblespress.com/news/nonprofit/operation-school-bell/"
+    },
     "6ea8040c-f88b-4a1d-9772-da0edde684b9": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5631,6 +8193,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://slocounselingservice.calpoly.edu/about"
+    },
+    "6ed06d84-ca89-414d-bf23-c42889f4e7df": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://myatprogram.org/"
+    },
+    "6ee9b954-8317-4571-8c1e-c253dbef0917": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.humangood.org/judson-terrace-lodge"
     },
     "6eef2c07-2070-4611-945d-c4037f4be18c": {
       "filter_text_added": true,
@@ -5683,6 +8263,24 @@
       "processor": "text_json_diff",
       "url": "https://ae.slcusd.org/hsd-esl/english-as-a-second-language"
     },
+    "6f809eae-db12-4553-9232-45145e06a29b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sloaa.org/meetings/"
+    },
+    "6f946f9c-3d95-47ea-a8cb-65cd10a5fd17": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.womenadeslo.org/"
+    },
     "6fc2ff73-4642-4222-8224-25a87524fce7": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5691,6 +8289,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://tinyurl.com/CCCUSS-Apply"
+    },
+    "6fe0464b-ceeb-4618-89cc-a3a74845e367": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://provdir.cencalhealth.org/"
     },
     "6fe6b119-78be-4398-a35d-7cc88d33c69c": {
       "filter_text_added": true,
@@ -5753,6 +8360,15 @@
       "processor": "text_json_diff",
       "url": "https://www.pge.com/en/account/billing-and-assistance/financial-assistance/relief-for-energy-assistance-through-community-help.html"
     },
+    "70649eef-3222-4572-a9d6-312530214a00": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://1af473-cd.myshopify.com/pages/tcc-transmasc-support-group"
+    },
     "70e9a453-da75-44a0-a936-01b493ee1162": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5774,6 +8390,33 @@
       "processor": "text_json_diff",
       "url": "https://www.cdfa.ca.gov/SeniorFarmersMrktNutritionPrgm/"
     },
+    "71438a44-f089-425e-828d-99cacf7f71a8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://calendly.com/smallclaims-slolaf/small-claims-paso-robles"
+    },
+    "71471e12-549b-48b6-958d-d84709dbf750": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/recovery-support-services"
+    },
+    "7177b696-6f56-4f9c-809f-895f668ee588": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.saangeltree.org/"
+    },
     "71c46ee1-9d3c-49f7-b981-6b909396dcb1": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5787,6 +8430,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/medically-indigent-services-program-(misp)"
+    },
+    "71e4b300-c988-4c40-a8cc-2fcab149e0e1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cancer.org/support-programs-and-services/patient-lodging.html"
     },
     "71f38a90-98b4-4ed6-bc01-58709f8f9a2b": {
       "filter_text_added": true,
@@ -5809,6 +8461,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://sloiwma.recyclist.co/guide/beverage-containers/"
+    },
+    "72303a41-c964-45dd-8b58-1b732913995f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "http://www.scyouthcoalition.org/contact.html"
     },
     "72644427-4ba7-40f0-a64f-055cb5aeb00f": {
       "filter_text_added": true,
@@ -5861,6 +8522,15 @@
       "processor": "text_json_diff",
       "url": "https://www.dignityhealth.org/central-coast/services/home-health-hospice-and-infusion-services"
     },
+    "73622716-3322-4c80-a0fb-c44efe503ea2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/es/north-county-family-resource-center/"
+    },
     "73753a78-242c-496d-8110-10c430e9a4db": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5896,6 +8566,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.t-mha.org/workshop-details.php?id=80"
+    },
+    "73b56121-8960-4c91-8ce3-49ec9fff3b9a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://habitatslo.org/restores/"
     },
     "73b8b7c8-a3bb-447c-be5f-609a8dd541da": {
       "filter_text_added": true,
@@ -5944,6 +8623,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=5&search_history_id=262841941&unit_list=0&akaSort=0&query=%20&simple_query=&code=PN&limit=&name="
     },
+    "74946a01-79b4-4cbe-9810-8e5dae73ed9f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://static1.squarespace.com/static/59681974579fb3a01279b99b/t/691783a98308c513367e2078/1763148713791/MHRG+-+MASTER+UPDATE+-+11-15-25.pdf"
+    },
     "756abbb8-2327-4f88-b8f6-8e073cc4c2aa": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -5986,6 +8674,24 @@
         ".wpgmza-radius-container"
       ],
       "url": "https://jailstojobs.org/resources/tattoo-removal-programs/"
+    },
+    "75c60057-89af-4b8a-8874-9a9837b2f39e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.golden1.com"
+    },
+    "75f5dc94-277d-48b1-a536-df7ea51fcabb": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocll.org/"
     },
     "75f64251-3bcf-41c2-a15c-048574547414": {
       "filter_text_added": true,
@@ -6058,6 +8764,33 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://capslo.org/rcp/"
+    },
+    "76819f69-b3f7-42b8-98f5-25d900f66a85": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://localwiki.org/slo/Sharing_SLO"
+    },
+    "76d3d89a-6eef-4f86-bb3b-f4ed4348d4fd": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://atascaderonews.com/nonprofit/woods-humane-society-hospice-slo-county-launch-monthly-pet-loss-support-group/"
+    },
+    "76e7e0f3-00ce-4e58-ab17-d2665f5f9651": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://al-anon.org/es/recien-llegados/rincon-para-adolescentes-alateen/"
     },
     "775e79c6-ddb5-4788-a4c5-a88e24a64800": {
       "filter_text_added": true,
@@ -6153,6 +8886,15 @@
       "processor": "text_json_diff",
       "url": "https://www.cuesta.edu/academics/continuinged/index.html"
     },
+    "77f4c507-4ceb-4061-9641-74a68c1dd74d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://status.ciymca.org/"
+    },
     "77f9dd45-e152-4d0f-8984-922534936a86": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6190,6 +8932,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center"
     },
+    "78115ed8-ec63-4095-9860-2bb8d698a538": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cuesta.edu/community/index.html"
+    },
     "7843ccde-4d06-4ad2-b22c-48ab611ca568": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6224,6 +8975,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://travel.state.gov/en/passports/apply/adults.html"
+    },
+    "7898959b-ff49-4fd7-8a60-0a777a54904b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slopeopleskitchen.org/"
     },
     "78acc259-2aa3-41b5-9820-2696a2e678cb": {
       "filter_text_added": true,
@@ -6296,6 +9056,33 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=NT"
     },
+    "7966a710-de10-4fc4-9265-11c6cb2c6fc2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cuesta.edu/student-support/eops/"
+    },
+    "7969d244-5c18-4d6d-8d02-c86ab59c5e5d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://embassy.goabroad.com/"
+    },
+    "79745e20-db78-4246-b683-e58f420bf314": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://gracecentralcoast.org/"
+    },
     "79944609-db0f-4d2b-bb54-1b373ba3a473": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6309,6 +9096,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/drug-alcohol-services-walk-in-clinics"
+    },
+    "79b1c56c-5c63-4865-9704-1c0e68752113": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-promotion/tobacco-control-program"
     },
     "7a366633-0752-4a3b-be58-c0b0add3d2fc": {
       "filter_text_added": true,
@@ -6330,6 +9126,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://travel.state.gov/en/passports/renew-replace/mail.html"
+    },
+    "7a7a730a-e8a0-4692-b329-51af0378586c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ciymca.org/childwatch-schedule#/results?locations=932&start_date=2025-12-10&page=1&sort=start_datetime:asc"
+    },
+    "7a8a3bc4-6890-49fc-ac7f-945f966bc8f7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slofoodbank.org/es/localizador-de-comida/"
     },
     "7a976ca9-8f05-458b-82bf-71e0f1ab812f": {
       "filter_text_added": true,
@@ -6460,6 +9274,24 @@
       "processor": "text_json_diff",
       "url": "https://www.assistanceleague.org/san-luis-obispo-county/wp-content/uploads/sites/102/2024/02/ACE-FULL-ANNOUNCEMENT-v2.pdf"
     },
+    "7bddac0d-b68e-4e00-9f41-4f4b2cd6cbed": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://crla.org/es"
+    },
+    "7bfdf41b-49e5-4afc-ae52-ef593661d1a7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://selfhelp.courts.ca.gov/small-claims-california"
+    },
     "7c1b1dbf-4454-44b0-9078-7920117330a9": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6483,6 +9315,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.pge.com/en/account/billing-and-assistance/financial-assistance/california-alternate-rates-for-energy-program.html"
+    },
+    "7c5b47d7-b0cd-4f90-b558-dd2fbe225744": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.californialifeline.com/es/contact"
     },
     "7c6aff6b-bfd8-40c8-9268-6a5bd364ec0a": {
       "filter_text_added": true,
@@ -6525,6 +9366,15 @@
       "processor": "text_json_diff",
       "url": "https://adulted.luciamarschools.org/diploma"
     },
+    "7c93c3fb-c432-4889-bb9e-81ff7de8dd3a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://secure.ssa.gov/ICON/ic001.action"
+    },
     "7d1292e6-be6e-4451-bad0-78ada820d9e1": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6545,6 +9395,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262840599&unit_list=0&akaSort=0&query=%20&simple_query=&code=BD-5000.1500&limit=&name="
+    },
+    "7d7a21fc-b398-49bc-852c-2fda2ab0b05d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://medi-calrx.dhcs.ca.gov/"
     },
     "7dcfee49-45a1-4af8-9a07-6075e37288ac": {
       "filter_text_added": true,
@@ -6573,6 +9432,15 @@
       "processor": "text_json_diff",
       "url": "https://sites.vivery.org/kings-cupboard-at-el-morro-church-pantry/los-osos-ca/2156"
     },
+    "7df1f309-91d0-4cdd-8051-b2971315e837": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ae.slcusd.org/adult-education"
+    },
     "7df28e36-bda9-41ae-829b-be87d598ee32": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6584,6 +9452,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://basicneeds.calpoly.edu/foodpantry"
+    },
+    "7dfc28e7-1ad5-4853-9027-4192a9f58a90": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.littlefreepantry.org/"
+    },
+    "7e144bf0-e778-4ac5-a03b-2337030d292b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slofoodbank.org/wp-content/uploads/2025/11/ENG_December_DistributionResourceList.pdf"
     },
     "7e171396-ba56-49a3-b859-933702586f0d": {
       "filter_text_added": true,
@@ -6609,12 +9495,153 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "BESbswy",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -6622,7 +9649,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/slo-casa/"
     },
@@ -6637,6 +9665,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/schedules-fares/avila-trolley/"
+    },
+    "7f247c54-5138-40f4-8487-e7e0593ebddf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://SLOCalCareers.org"
     },
     "7f616e4d-22ba-4771-9963-c436bee908b1": {
       "filter_text_added": true,
@@ -6725,6 +9762,33 @@
       "processor": "text_json_diff",
       "url": "https://www.templetonusd.org/schools/tae/tas"
     },
+    "81011e7f-5360-400f-9a2e-3cfd96880b3d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.racemattersslo.org/raiseup-slo"
+    },
+    "81011e84-1d10-4e0b-b01f-13c15d70b56c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://fimcslo.com/faq/"
+    },
+    "810d1c18-df12-461b-9358-a4f789c2898f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/central-coast/locations/arroyo-grande/patients-and-visitors/for-patients/billing-information/financial-assistance"
+    },
     "8119c9d4-9a8a-41ca-9ae9-ce210f69d351": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6766,6 +9830,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=3&search_history_id=262840967&unit_list=0&akaSort=0&query=%20&simple_query=&code=BT&limit=&name="
+    },
+    "819b6a14-9f1a-4551-b317-00622d62dd78": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council/hsoc-membership/forms-documents/2024/hsoc-membership-application-form"
     },
     "81bc145c-0f2f-4300-a5dc-a1f022221fa4": {
       "filter_text_added": true,
@@ -6814,6 +9887,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.plannedparenthood.org/get-care/our-services"
+    },
+    "8280377a-d270-4996-98a4-282ec8ff047c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://centralcoasthomehealth.com/"
     },
     "82ac34dc-9b87-428c-9834-8bc3e9c82cf9": {
       "filter_text_added": true,
@@ -6883,6 +9965,24 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=5&search_history_id=262842494&unit_list=0&akaSort=0&query=%20&simple_query=&code=TJ-3000&limit=&name="
     },
+    "8423f08b-1bd1-46e2-8d6e-7ad3542449ff": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ssa.gov/myaccount"
+    },
+    "844d64a5-2188-4abc-9b54-904cdf29890a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.golden1.com/atm-branch-finder"
+    },
     "84a9258a-ab45-44bb-a528-264e26f48daa": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6909,6 +10009,15 @@
       ],
       "url": "https://www.yelp.com/biz/california-cool-thrift-store-grover-beach#location-and-hours"
     },
+    "84c0aef3-91b6-4237-956d-59a65b3da0cd": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://blog.ssa.gov/social-security-to-fully-transition-to-electronic-payments/"
+    },
     "84f1aaa9-bb61-4d55-b127-f136ed93f36c": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6917,6 +10026,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/public-health/all-public-health-services/health-care-access/oral-health/medi-cal-dental-providers-in-san-luis-obispo-count"
+    },
+    "8502f422-cb15-4cfd-a5e4-a595999ffc25": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.osi.ca.gov/eWIC.html"
     },
     "8503c6e4-4f97-4584-ba1b-89549b757764": {
       "filter_text_added": true,
@@ -6933,6 +10051,51 @@
       "processor": "text_json_diff",
       "url": "https://www.pshhc.org/"
     },
+    "852adee8-c3bc-4a84-948f-74c2c071e2d8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://luminaalliance.org/advocacy-legal-services"
+    },
+    "8532fcb5-276b-4c7a-81bf-5d50a697ded9": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://itunes.apple.com/us/app/slo-transit/id458554556?mt=8"
+    },
+    "86284fc3-0f20-4386-a988-8511c0611666": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://centralcoastseniors.org/wp-content/uploads/CC-SRG-2023.pdf"
+    },
+    "8628dcfd-0b1e-48e9-b0ea-103bd3b08bb6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://captivehearts.org/"
+    },
+    "86319759-aadc-4d76-a055-f064e67ee805": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://joinbankon.org/accounts/"
+    },
     "86655b8a-b845-4530-a145-3c9c68f25900": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -6945,6 +10108,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://joniandfriends.org/support/christian-fund-for-the-disabled/"
+    },
+    "8679a0f5-3f53-4db5-b98c-2c42f8b0b7a2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://griefshare.org/"
     },
     "8692eebd-ea5a-409f-840a-3fbda61180c1": {
       "filter_text_added": true,
@@ -7110,6 +10282,33 @@
       "processor": "text_json_diff",
       "url": "https://www.assistanceleague.org/san-luis-obispo-county/thrift-shop/"
     },
+    "8937c956-4c36-4a26-991c-a0d8c685c337": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.californialifeline.com/es"
+    },
+    "893a81f5-e9f5-49e5-9c17-d9c39d46cab5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://phpslo.org/en/about/"
+    },
+    "89525d85-8932-4a10-b643-52de22d74715": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://smokefree.gov/"
+    },
     "8999eea3-9c4a-4463-b5bc-09235f08c93e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7140,6 +10339,15 @@
       "processor": "text_json_diff",
       "url": "https://www.portsanluis.com/2163/RV-Camping"
     },
+    "8a16b25c-3772-4d6d-a8f1-d6c101d0a509": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.womenadeslo.org/contact"
+    },
     "8a1f8472-181e-4745-a48a-e3c4988f62cc": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7160,6 +10368,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cuesta.edu/academics/continuinged/Contact-Continuing-Education2.html"
+    },
+    "8a370f74-c9bd-40d6-aafc-4505b5f4c3c9": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdc.gov/niosh/docs/2010-118/default.html"
     },
     "8a5a1670-fed3-4d0d-9a4a-0083841d5e0e": {
       "filter_text_added": true,
@@ -7191,6 +10408,15 @@
       "processor": "text_json_diff",
       "url": "https://www.805undocufund.org/programs#anchors-lt8rv4na"
     },
+    "8adba084-ce1d-407b-88a0-ee48899dc77f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/veterans-services/veterans-services-food-pantry"
+    },
     "8b01f701-beed-41c8-8975-da4a7bcd57e9": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7213,15 +10439,6 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.coatsforkidsslocounty.org/"
-    },
-    "8b7f60e2-c9ba-4cc9-ae0b-1ed5e01ca953": {
-      "filter_text_added": true,
-      "filter_text_removed": true,
-      "filter_text_replaced": true,
-      "method": "GET",
-      "notification_format": "System default",
-      "processor": "text_json_diff",
-      "url": "https://www.thebridgecafe.org/"
     },
     "8b828b18-ddd7-4615-8119-cb098e6f7b15": {
       "filter_text_added": true,
@@ -7292,6 +10509,24 @@
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/fares/discounts/"
     },
+    "8c132825-e9ee-4aa8-9ede-a40d92628959": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://healthconsumer.org/es"
+    },
+    "8c149a92-e8c5-46a8-80ad-728e8d567854": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slofoodbank.org/"
+    },
     "8c1f04ee-1a30-4ede-982a-7dce1255d570": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7300,6 +10535,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://cfsslo.org/#mfh"
+    },
+    "8c9e958e-9244-4d84-841b-e08f8fb5f153": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://vituitycares.org/"
     },
     "8cc42efc-d249-4bdc-99e0-bc09b15fde16": {
       "filter_text_added": true,
@@ -7321,6 +10565,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/community-services/social-services"
+    },
+    "8cf9fe19-f63b-47cf-a3ba-5cef15fe4e49": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www2.calrecycle.ca.gov/BevContainer/InStoreRedemption"
     },
     "8d4f01e8-7680-441b-b3d4-1edb6b0cdc82": {
       "filter_text_added": true,
@@ -7394,6 +10647,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.toastmasters.org/Find-a-Club/28676059-cal-poly-toastmasters"
+    },
+    "8dfbe6a8-0375-4cce-92d9-13329a75f0df": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.healthline.com/health/outdoor-health/poison-oak-pictures-remedies"
     },
     "8e614113-8888-4526-9871-172919059d9d": {
       "filter_text_added": true,
@@ -7492,6 +10754,15 @@
       "processor": "text_json_diff",
       "url": "https://dovecreekchurch.org/who-we-are/find-us"
     },
+    "8fef04eb-d7c0-4ecd-ba98-3cd067a6e72e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccgoodwill.org/locations/goodwill-san-luis-obispo-higuera/"
+    },
     "900804a7-08e0-44d1-9ba3-e964393d592d": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7513,6 +10784,42 @@
       "processor": "text_json_diff",
       "url": "https://morrobayseniors.org/about/"
     },
+    "90582ac8-25be-4a65-9b1c-00938486a5ba": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://dental.dhcs.ca.gov/"
+    },
+    "907d0ab4-3ffc-4200-ac60-fe82858f8331": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ciymca.org/open-doors-scholarship-application"
+    },
+    "90919073-e72c-4d08-84d2-22dc902de14a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slcusd.asapconnected.com/"
+    },
+    "90b03d5d-4b5c-477a-9500-d4bcb7b516cf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://medi-calrx.dhcs.ca.gov/home/find-a-pharmacy"
+    },
     "90b9db16-3775-46e2-b983-a0b2fa360a77": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7524,6 +10831,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.grover.org/652/Report-an-Issue"
+    },
+    "9154f730-5943-4eba-a990-bccf652a8ab2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slorta.org/fares/contactless/"
     },
     "91634458-787c-4050-b5ce-46c40387e4fc": {
       "filter_text_added": true,
@@ -7553,6 +10869,42 @@
       "processor": "text_json_diff",
       "url": "https://linkslo.org/"
     },
+    "91870cf5-fed9-4768-90bc-1e9ed89ded3b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://995hope.org/"
+    },
+    "919324ed-0e16-49d9-808e-cd49bbbd6519": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ada.gov/file-a-complaint/"
+    },
+    "91d30f4e-65c5-4090-9c82-9a8cf27dde00": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sloundocusupport.org/"
+    },
+    "91f5eda9-fdcf-4f0f-a38d-f397417bc6e4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://edd.ca.gov/Unemployment/UI_Online.htm"
+    },
     "920a010a-5276-4114-90af-31efb0ff9886": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7564,6 +10916,33 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=2&search_history_id=262841941&unit_list=0&akaSort=0&query=%20&simple_query=&code=PN&limit=&name="
+    },
+    "921499c3-cacd-434e-9cf7-6ee2ecdfb4c6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://espanol.loveisrespect.org/"
+    },
+    "9226a6c2-1835-45f1-be88-9e63f2b26b3f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://mixteco.org/"
+    },
+    "92b06a40-90f4-45ec-9644-a3937490ce32": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://pub-slocity.escribemeetings.com/filestream.ashx?DocumentId=24170"
     },
     "92b444d6-e0ee-4147-9c1c-2692940cb75e": {
       "filter_text_added": true,
@@ -7648,6 +11027,24 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/administrative-office/services/citizen-complaint-investigations"
     },
+    "9310642f-23e8-4a36-9baf-7faa2d08797f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.moneymanagement.org/"
+    },
+    "9314e03a-364f-4d57-aa7d-5b32b2b6ff69": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cencalhealth.org/es/members/provider-directory-for-members/"
+    },
     "937d1da7-06d7-4b4d-a2af-4746791b7fac": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7697,6 +11094,24 @@
       "processor": "text_json_diff",
       "url": "https://www.cuesta.edu/academics/continuinged/adultsdisabilities/index.html"
     },
+    "93eb7c0f-dfa2-4a2f-8de3-f897444ea8fc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.haslo.org/contact"
+    },
+    "94681088-df82-4767-826d-9bd344a76a52": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.adventisthealth.org/about-us/community-benefit/"
+    },
     "947f18ab-4efa-42c5-b78d-456d486139ad": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7708,6 +11123,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.communitylegalsocal.org/contact-us/"
+    },
+    "948b7683-52d2-419a-93cf-2b729799e308": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://accesssupportnetwork.org/programs/hep-c/"
+    },
+    "94a86bc5-e945-4083-b471-f653f9c5477a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.greyhound.com/"
+    },
+    "94c0e158-c241-4a61-bdee-c4043565201a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://nationalunionofthehomeless.org/"
+    },
+    "94cdb496-6f9e-4dcc-a8b4-de2605dd5b52": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://centralcoastseniors.org/senior-connection/resources/publications/"
     },
     "94d41843-d9e6-4939-bb66-6f0a01f1dd15": {
       "filter_text_added": true,
@@ -7742,6 +11193,24 @@
       "processor": "text_json_diff",
       "url": "https://vituitycares.org/contact-us/"
     },
+    "95fbf202-b6dd-4a6e-a016-e8511688d4ec": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://tenantpowertoolkit.org/es/"
+    },
+    "9641b318-c1f2-4ae7-915d-507f3f750b60": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slo.courts.ca.gov/"
+    },
     "964d44cf-bac8-416e-8139-7262e4fafc30": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7773,6 +11242,15 @@
       "processor": "text_json_diff",
       "url": "https://www.va.gov/health-care/health-needs-conditions/substance-use-problems/"
     },
+    "96bd10e0-f826-449d-aade-6987e18946fb": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pshhc.org/build-your-own-home/"
+    },
     "9717deb1-a522-4776-bc70-8dc55761e82a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7784,6 +11262,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/programs/warming-center"
+    },
+    "971deed1-7df0-4c37-87d1-5e066429bc32": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/40pradodonations/"
     },
     "97206300-1d1c-45af-aadb-9993b7fbbb45": {
       "filter_text_added": true,
@@ -7797,6 +11284,15 @@
       "processor": "text_json_diff",
       "url": "https://petsofthehomeless.org/emergency-veterinary-care/"
     },
+    "9743012b-8b5a-4555-b82a-afdc65e4eab0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://al-anon.org/es/reuniones-de-al-anon/"
+    },
     "97b5a205-3741-4035-aa66-9e810af81898": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7806,6 +11302,24 @@
       "processor": "text_json_diff",
       "url": "https://fpcslo.org/greenpastures"
     },
+    "97f4e075-52f0-47bc-a456-1190069aa620": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.mylowcostauto.com/spanish"
+    },
+    "97fc7302-3773-4748-ad83-f27bd089479f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capolst.org/"
+    },
     "9830c61d-d09e-4b3a-9f02-9dc46d40463b": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7814,6 +11328,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://rideshare.org/program/bike-month/"
+    },
+    "984812ed-6327-467f-88af-46df15a3c337": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocvsc.org/"
+    },
+    "98993b60-8d16-4518-b274-99fd1b38f21c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.communityhealthcenters.org/"
+    },
+    "98d226a5-07a2-4453-8be0-092d09753ae1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.humangood.org/judson-terrace-homes"
+    },
+    "9904b14d-dad8-4dbf-815d-3ff1b239d1d4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://selfhelp.courts.ca.gov/es/inmigracion"
     },
     "99801ba8-0c81-4b0f-bd3b-684aaf15452d": {
       "filter_text_added": true,
@@ -7888,15 +11438,17 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "/html/body/div[2]/div[1]/div/div/div/section[2]/div/div/div/div/div/div[1]/div/div[1]/p[1]/span[1]",
-        "/html/body/div[2]/div[1]/div/div/div/section[2]/div/div/div/div/div/div[1]/div/div[1]/p[2]/span",
-        "/html/body/div[2]/div[1]/div/div/div/section[2]/div/div/div/div/div/div[1]/div/div[1]/p[3]/span",
-        "/html/body/div[2]/div[1]/div/div/div/section[2]/div/div/div/div/div/div[1]/div/div[1]/p[4]/span",
-        "/html/body/div[2]/div[1]/div/div/div/section[2]/div/div/div/div/div/div[1]/div/div[1]"
+        ".bt_bb_wrapper"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".bt_bb_hidden_xs",
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge"
+      ],
       "url": "https://www.communityhealthcenters.org/patient-resources/"
     },
     "99e9f688-d29d-487b-abba-0469e4460007": {
@@ -7923,6 +11475,15 @@
       "processor": "text_json_diff",
       "url": "https://5chc.org/programs/housing-assistance"
     },
+    "9a7f8911-ff35-4d65-9e52-453c469156c1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "http://www.scyouthcoalition.org/classes--events.html"
+    },
     "9a860be3-7f93-45a1-bf2b-37f363a22899": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7931,6 +11492,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.northcounty-pawscause.org/"
+    },
+    "9aa89970-eda0-40b9-aa2e-cb3f6dc337a4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ksby.com/morro-bay/805-street-outreach-expands-services-to-include-free-laundry"
     },
     "9b4a2c00-ae81-41e2-8d61-8e58e90e1470": {
       "filter_text_added": true,
@@ -7971,6 +11541,15 @@
       "processor": "text_json_diff",
       "url": "https://www.dioceseofmonterey.org/parishfinder"
     },
+    "9b88c6d5-821b-4da3-9b89-6f50bf5ff5da": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://debtorsanonymous.org/"
+    },
     "9ba0727e-4fc7-4d9f-958d-b85182aa7a26": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -7993,6 +11572,15 @@
       "processor": "text_json_diff",
       "url": "https://calcivilrights.ca.gov/"
     },
+    "9c0a543c-b05f-4722-82d5-6fed90c4091d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sslocw.org/"
+    },
     "9c3d2fd2-ae20-4928-8fe2-d24bb540f808": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8001,6 +11589,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slohealthaccess.org/covered-ca.html"
+    },
+    "9c4177f0-942f-4792-a9b4-3428ce9c95b1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cencalhealth.org/wp-content/uploads/2025/01/Feb2025_SLO_PrintDirectory_tagged.pdf"
     },
     "9ccdeef8-2f42-472d-92d8-0eb9e8be916d": {
       "filter_text_added": true,
@@ -8032,6 +11629,24 @@
       "processor": "text_json_diff",
       "url": "https://www.cpuc.ca.gov/consumer-support/financial-assistance-savings-and-discounts/ddtp"
     },
+    "9d2f0efe-a07b-49b7-98db-8331d7a67381": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.coveredca.com/"
+    },
+    "9d362ea0-f844-4534-ab0e-3467169a923e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://thediscipleshiphome.com/"
+    },
     "9d3a6e97-9534-45b9-901f-f6f54b7d0887": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8052,6 +11667,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.dhcs.ca.gov/services/ccs/Pages/benefits.aspx"
+    },
+    "9d560a69-4a4a-4145-a4be-842e8b7f017a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://tokentransit.com/riders/download"
     },
     "9d7b4a5d-3112-4ea4-bb76-4ebd85305cb2": {
       "filter_text_added": true,
@@ -8114,6 +11738,15 @@
       "processor": "text_json_diff",
       "url": "https://unitedwayslo.org/prescription-drug-discount-cards/"
     },
+    "9e3b9d16-9221-49cf-9b02-0fd4061d1303": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccgoodwill.org/locations/san-luis-obispo-industrial-way-goodwill-thrift-store/"
+    },
     "9e9a391c-32ba-436b-adf0-f37861d9eabf": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8138,6 +11771,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.sesloc.org/"
+    },
+    "9ec0b9c4-3658-4268-8d7a-3858bddc81d7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cityofsantamaria.org/home/showpublisheddocument/32758/639033871854700000"
     },
     "9ed77935-9cc9-4d46-8f5d-3f497064da5c": {
       "filter_text_added": true,
@@ -8168,6 +11810,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/public-health/contact-us"
+    },
+    "9f18577b-bfa8-4201-8f7d-b69d2152aec6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://bar.ca.gov/"
     },
     "9f4eecbd-09ca-4d5a-9ef5-f2bea1167189": {
       "filter_text_added": true,
@@ -8259,6 +11910,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/programs/immediate-needs"
+    },
+    "a09544bf-e3cb-41ba-aa91-faa2904e690e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council/full-hsoc/meetings/2025/11-19-2025-full-hsoc-meeting"
+    },
+    "a0bfc8ab-91f8-4ee4-abfb-8fe7999d20ff": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://centerforautism.com/contact/"
     },
     "a0d7ab91-79f7-4a13-a6f1-6f877ff95494": {
       "filter_text_added": true,
@@ -8368,6 +12037,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/contact-us"
     },
+    "a30f14ad-8e63-4a38-ab6d-47568096f14f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.aclusocal.org/es/know-your-rights/"
+    },
     "a30f32d4-7822-4f29-b8b8-a42f35b618c3": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8380,6 +12058,15 @@
       "processor": "text_json_diff",
       "url": "https://morrobayseniors.org/help/"
     },
+    "a347bacf-6efc-4be4-9122-ea959a7b9cdd": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://arroyogrande.salvationarmy.org/"
+    },
     "a357f7ec-e3af-4f6d-ba8f-2d372f9d5e5a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8388,6 +12075,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/learningexpresslibrary/libraryhome"
+    },
+    "a365881c-b80e-4d8b-8948-cd31b7c53315": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.lifestepsfoundation.org/"
+    },
+    "a3847d7e-8ff4-4093-a763-dc9b7df83c29": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://sanluisobispocountyveteransservices.as.me/schedule/970de54e"
     },
     "a38b326d-2018-43a6-81e4-eb14fb2c06f9": {
       "filter_text_added": true,
@@ -8460,6 +12165,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BH-8500"
     },
+    "a405c29f-ffef-4eba-9628-e8a1d7062f80": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.redcross.org/local/california/central-california.html"
+    },
     "a42eae5b-1e2c-4b0c-a4b5-f9d1745bae19": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8499,6 +12213,15 @@
       "processor": "text_json_diff",
       "url": "https://sanluisobispo.salvationarmy.org/"
     },
+    "a51c56a1-6dd4-45e3-b13e-aa88c72efc8d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.newtimesslo.com/capslo-to-take-over-operation-of-paso-robles-senior-center/"
+    },
     "a529b03d-b5af-4e16-aa0e-21f23ecc06e8": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8525,6 +12248,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://montereylaw.edu/clinics/indexslocl.html"
+    },
+    "a611f4a4-fbb3-4668-a108-9b6fd35037ff": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://atascaderonews.com/news/first-modular-units-arrive-for-balay-ko-family-resource-center/"
+    },
+    "a62676b3-fcb9-40e8-a503-bc7548e2dee5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www4.courts.ca.gov/documents/California-Tenants-Guide-Spanish.pdf"
     },
     "a632b9b9-8277-4f17-a865-f1248b301839": {
       "filter_text_added": true,
@@ -8574,6 +12315,9 @@
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".support-group-next-date"
+      ],
       "url": "https://hospiceslo.org/support-groups"
     },
     "a72dfe47-fc4b-4dc9-9eb3-8684de033d8b": {
@@ -8584,6 +12328,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slohealthaccess.org/basic-needs.html"
+    },
+    "a72eb6f6-f7ae-48fb-a386-1d023cddf49d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sloundocusupport.org/es/immigrantservicesguide"
     },
     "a76153ff-11c7-448b-84bf-18865b1eb4f4": {
       "filter_text_added": true,
@@ -8613,6 +12366,15 @@
         "h4.wp-block-heading"
       ],
       "url": "https://atascadero-ca.toysfortots.org/local-coordinator-sites/lco-sites/local-toy-request-single-form.aspx"
+    },
+    "a7945d5a-302d-4469-81cb-1a3ee9ed54c1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.atascadero.org/sites/default/files/2024-01/Scholarship_App_Spanish_23-24.pdf"
     },
     "a79ad668-7434-4855-9333-8369dc073cee": {
       "filter_text_added": true,
@@ -8644,12 +12406,30 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        ".content"
+        ".entry-content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://www.slocog.org/contact-page"
+      "url": "https://www.slocog.org/contact/"
+    },
+    "a81dde74-f452-46c7-aba9-f57b100681a5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://al-anon.org/newcomers/teen-corner-alateen/"
+    },
+    "a8486042-377b-4706-9f3e-b64b5e161a23": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.myfreetaxes.org/es/file-with-virtual-help/"
     },
     "a84a8831-f3c0-47aa-aa53-d12762d8175b": {
       "filter_text_added": true,
@@ -8675,6 +12455,15 @@
       "processor": "text_json_diff",
       "url": "https://cambria-ca.toysfortots.org/local-coordinator-sites/lco-sites/local-contact-us.aspx"
     },
+    "a884cfa2-dee1-4bfe-8cce-2a98ac741c27": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.childrensresourcenetwork.org"
+    },
     "a89ffab1-9850-47bf-9c12-6dc5338d2fe0": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8687,6 +12476,15 @@
       "processor": "text_json_diff",
       "url": "https://www.cccslo.org/what-we-do.php"
     },
+    "a8cc0f2f-a7c1-4c0f-a078-11d50983a0bc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://anc.apm.activecommunities.com/prcityrecreation/activity/search?onlineSiteId=0&locale=es-US&activity_select_param=2&activity_category_ids=8&activity_category_ids=13&viewMode=list"
+    },
     "a8daeefc-e9ef-4a7d-a136-eae292b7afc0": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8698,6 +12496,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://friendsof40prado.org/about/"
+    },
+    "a9110473-ae14-4ea7-89da-f422b6f58c61": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "http://www.scyouthcoalition.org/"
     },
     "a91191e3-f4ba-4306-b5af-d6949e4c8b0a": {
       "filter_text_added": true,
@@ -8753,6 +12560,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocountyfarmers.org/snap"
     },
+    "a9cb0b68-b417-4c28-9257-6f28ed91826f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slofoodbank.org/en/food-locator/#neighborhood-food-distributions"
+    },
     "aa1cb722-0d6a-48aa-844d-a6dba890e920": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8807,6 +12623,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocity.org/services/how-do-i/ask-slo-copy/report-request"
     },
+    "ab737465-3584-4e24-9f77-c976fe08779c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www4.courts.ca.gov/documents/California-Tenants-Guide.pdf"
+    },
     "abb6fa63-286e-4f87-a510-5eb0fed1c248": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8815,6 +12640,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.theupsstore.com/tools/find-a-store"
+    },
+    "abc08a30-059a-4431-94f0-4f1c7eeb6480": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccgoodwill.org/locations/atascadero-goodwill-thrift-store/"
+    },
+    "abfa42c3-0096-4b32-89b3-82b02e43c097": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://dhcs.ca.gov/services/ccs"
     },
     "ac2cfa97-5b94-4adf-93a2-012214e88b94": {
       "filter_text_added": true,
@@ -8834,6 +12677,33 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=NL"
     },
+    "ac85bd75-1cc6-4be3-aecd-4fde14d0cb09": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/teen-programs-2/"
+    },
+    "ac9020a5-9702-473e-a652-6e4ea29fe812": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://joniandfriends.org/wp-content/uploads/2024/10/Statement-of-Faith.pdf"
+    },
+    "ac979e04-8d09-4ee8-bbe8-30821a238834": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ssa.gov/es/prepare/check-eligibility-for-benefits"
+    },
     "ac9b6db6-593d-4c55-ab04-9152a69f3ddc": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8848,6 +12718,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.genmobile.com/pages/lifeline-program"
+    },
+    "aca584b2-631c-49be-aa39-e6d55960fa5c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://pasoroblesha.org/affordable-housing/oak-park-1-2/"
+    },
+    "acb398b6-30f4-41da-939c-ec9b960b4867": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.atsu.edu/"
     },
     "accb7538-5186-4627-9c73-e5b5b6db447d": {
       "filter_text_added": true,
@@ -8893,12 +12781,153 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "BESbswy",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -8906,7 +12935,13 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper",
+        ".cky-banner-bottom",
+        ".cky-consent-bar",
+        ".cky-notice-content-wrapper",
+        ".cky-notice",
+        ".cky-notice-group"
       ],
       "url": "https://www.communityhealthcenters.org/locations/los-robles/"
     },
@@ -8938,6 +12973,15 @@
       "processor": "text_json_diff",
       "url": "https://fcni.org/partner-with-us/fam/"
     },
+    "add46d97-c699-4c87-a179-0772cc6c77f3": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://alison.com/es"
+    },
     "ae30331c-dbd2-4597-beee-5b1b6ec12e05": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -8946,6 +12990,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slohelpmegrow.org/contact"
+    },
+    "ae44e682-de0c-4499-be5a-be3ee75a8a3f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://nationalhomeless.org/"
     },
     "ae85f3ea-ba76-409b-bf19-ef9d85db221d": {
       "filter_text_added": true,
@@ -8960,6 +13013,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/social-services/projects/welcome-home-village"
+    },
+    "ae91484a-2c70-4a83-b19c-e8cbb5bf78ee": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://calendly.com/smallclaims-slolaf/30min"
     },
     "aef67f54-209a-4d26-a6cf-13db64199bc0": {
       "filter_text_added": true,
@@ -8992,6 +13054,15 @@
       "processor": "text_json_diff",
       "url": "https://sloautism.org/about-us/"
     },
+    "af4c87d2-b7c4-4dd0-bc61-0f82d992c28d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://benefitscal.com/"
+    },
     "af7eba79-d2c7-4ca1-aa7c-ef9112f570ea": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9009,6 +13080,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slohealthaccess.org/advocacy.html"
+    },
+    "afbb4564-0d05-4c7d-9779-5efa4c9aab03": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://healthconsumer.org/"
     },
     "b00691ca-fba4-40ff-b304-92fb386a04d0": {
       "filter_text_added": true,
@@ -9030,6 +13110,33 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slo.courts.ca.gov/self-help/family-law"
+    },
+    "b040acf7-5d8f-45bb-aefe-806905a9f744": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.nipomopresbyterian.org"
+    },
+    "b04e598c-0537-4c01-8e28-876aa7d23c50": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://benefits.calitp.org/eligibility/start"
+    },
+    "b0616c26-6a5e-43bc-8478-823bc4c3566d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.esteem.health/"
     },
     "b08bbade-bdf3-45dc-a642-31437e79a000": {
       "filter_text_added": true,
@@ -9090,6 +13197,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slopeopleskitchen.org/contact-us"
+    },
+    "b1f24495-8011-493c-b454-e2e72567a8a1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cencalhealth.org/wp-content/uploads/2025/08/25-165_Universal-CS-Referral-Form_R4_Fillable_082025_tagged.pdf"
     },
     "b229a43a-0687-436a-b559-cf7251983d45": {
       "filter_text_added": true,
@@ -9191,6 +13307,15 @@
       "processor": "text_json_diff",
       "url": "https://slopartners.org/programs/"
     },
+    "b3f20a68-6b9a-44ff-81ea-c188651c6cc2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.humangood.org/judson-terrace-homes/apply"
+    },
     "b41b3550-ac62-4817-89eb-87cec3d00e85": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9207,15 +13332,6 @@
         "nav"
       ],
       "url": "https://www.commonspirit.org/patient-resources/dignity-health-central-coast-financial-assistance"
-    },
-    "b4239e33-f424-4d29-b3a1-8af709985114": {
-      "filter_text_added": true,
-      "filter_text_removed": true,
-      "filter_text_replaced": true,
-      "method": "GET",
-      "notification_format": "System default",
-      "processor": "text_json_diff",
-      "url": "https://www.slocog.org/programs/public-transportation/transit/transit-free-fare-pass-pilot-program"
     },
     "b42ae299-66b7-4bdf-a3ef-8cdfb155a670": {
       "filter_text_added": true,
@@ -9269,6 +13385,15 @@
       "processor": "text_json_diff",
       "url": "https://www.pasocares.org/"
     },
+    "b4f2146c-a28e-4aed-93c2-5903554dcf7e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dental.dhcs.ca.gov/Members/Medi_Cal_Dental/Find_A_Dentist/FindADentist"
+    },
     "b53648ae-9d93-4591-953a-2b2b2531f438": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9277,6 +13402,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://lesageriviera.com/contact-us/"
+    },
+    "b5460508-ed5c-4b7e-97f2-0e47461eefcf": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://slobar.org/legal-resources/listing/creative-mediation/"
     },
     "b5729440-5893-462e-8e8b-802e809d6ecc": {
       "filter_text_added": true,
@@ -9308,6 +13442,15 @@
       "processor": "text_json_diff",
       "url": "https://uuslo.org/"
     },
+    "b5dc7b73-798d-4bde-952b-17cffa9bf8a6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ca.gov/departments/147/services/1239/"
+    },
     "b5effd91-c445-4f29-b6b4-890628856427": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9319,6 +13462,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://report.citizenserviceportal.com/home/agency?agencycode=sloso"
+    },
+    "b5ffadef-a5b9-4e5e-8b3e-5d61884bf1d5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocity.org/Home/Components/News/News/11624/"
     },
     "b6072ff7-b85e-4e50-a82c-3c516979d63d": {
       "filter_text_added": true,
@@ -9370,12 +13522,18 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -9383,7 +13541,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/templeton-wh/"
     },
@@ -9398,6 +13557,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cancer.org/support-programs-and-services/road-to-recovery.html"
+    },
+    "b6c8be49-ab40-4b9a-ac23-0528b48e839d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cencalhealth.org/providers/calaim/housing-homelessness-incentive-program/"
     },
     "b6d383e5-ee0b-4361-9dbf-9729d4b42718": {
       "filter_text_added": true,
@@ -9420,6 +13588,15 @@
       "processor": "text_json_diff",
       "url": "https://www.captivehearts.org/our-program.html"
     },
+    "b7249c5e-f430-449e-a5b7-a135e859aa1f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dhcs.ca.gov/es/services/ccs"
+    },
     "b73a7c56-d8fa-4c47-b5c9-381af98f6cc6": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9431,6 +13608,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.atascadero.org/service/teen-center"
+    },
+    "b742e05c-ff68-45a7-8da4-5961adf7e47f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccgoodwill.org/locations/paso-robles-goodwill-thrift-store/"
+    },
+    "b75bafaf-deb7-4745-945f-b6b97c02268d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://crla.org/articles/san-luis-obispo-county-residents-clear-criminal-records-help-crla-and-local-partners"
     },
     "b7976f31-d78a-435f-9807-044fa3f59063": {
       "filter_text_added": true,
@@ -9444,6 +13639,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.phpslo.org/"
+    },
+    "b7b68687-936a-4fa7-bb58-b1ee9ac75bf0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://24petconnect.com/BreedRequest/Lost?shelterlist=SLOC&zip=93405"
     },
     "b7b6ed21-4e10-4d75-9550-2163759ab658": {
       "filter_text_added": true,
@@ -9468,6 +13672,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.esteem.health/ecm-signup"
+    },
+    "b8181e11-71c4-47dc-869a-e9ed6fff5681": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.nfcc.org/"
+    },
+    "b822582e-9357-4ee6-b3cb-66ac19d837bb": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.irs.gov/es/filing/irs-free-file-do-your-taxes-for-free"
     },
     "b8533c45-1551-42fe-91c7-8aeeb882cadf": {
       "filter_text_added": true,
@@ -9498,6 +13720,15 @@
       "processor": "text_json_diff",
       "url": "https://slocasa.org/"
     },
+    "b879cce6-d5f7-4aae-987b-6957f5461402": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.centralcoastna.org/directory/"
+    },
     "b88c03dc-f99b-43be-aed1-c40cde1846bd": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9509,6 +13740,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/community-services/housing"
+    },
+    "b8a6b4dd-42d7-423b-90e7-105698ee057b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://translifeline.org/es/"
     },
     "b8ce6e4f-94ef-4b77-aa26-44967f270170": {
       "filter_text_added": true,
@@ -9523,6 +13763,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cuesta.edu/"
+    },
+    "b8d95a31-0a8b-4ddc-960c-e03d175bf854": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ourlegacy.church/"
     },
     "b8f4156b-5a5f-46d2-bde1-5a4b9b2ebfc8": {
       "filter_text_added": true,
@@ -9571,6 +13820,60 @@
       "processor": "text_json_diff",
       "url": "https://www.slo.courts.ca.gov/self-help/family-law/domestic-violence"
     },
+    "b9fe0b74-b0fe-435f-aa99-711673ad3103": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/getmedia/3eb220e5-a230-4c31-9a87-e2bc24e648be/2024_pitcount_communityreport"
+    },
+    "ba1bda07-ffb3-4b15-8e96-5bd2c41735c2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/46prado/"
+    },
+    "ba6d8c6d-c08f-47e2-b22a-598fa0c9dd43": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council/forms-documents/2022/slocountywideplantoaddresshomelessness"
+    },
+    "ba9f0fc4-6c8c-4235-9459-b0b67f9c6c7d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://sonriecalifornia.org/encuentra-un-dentista/"
+    },
+    "baa39c3f-c9f2-42fc-a354-eff858b9e5f9": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cuesta.edu/student-support/basic-needs-center/index.html"
+    },
+    "bae57090-e36c-49cd-85d6-215dfbb0f5a2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.assistanceleague.org/san-luis-obispo-county/"
+    },
     "baf11af0-93e5-4c6d-9732-c175d1c7314f": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9585,6 +13888,33 @@
       "processor": "text_json_diff",
       "url": "https://caconnect.org/"
     },
+    "bb555361-e37a-4391-a6ca-458af6d9f822": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ciymca.org/active-older-adults"
+    },
+    "bbb2fcad-2a20-45a6-b18c-41bcedb4bc83": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://assets.glasscow.tech/pasohouse/wp-content/uploads/2025/05/OP1-OP2-APP-INSTRUCTION-SHT.pdf"
+    },
+    "bbd2037f-2371-4616-bfa6-42c05ac0d31d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ksby.com/san-luis-obispo/atascadero-homeless-organization-celebrates-new-construction-project-for-families"
+    },
     "bbd9b267-47a4-4cca-8bfb-7c846a55460d": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9596,6 +13926,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://fcni.org/"
+    },
+    "bbe2df17-9678-4537-9097-dc18c305aedb": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://theconversationproject.org/"
     },
     "bc30a450-b3f7-4a16-a22b-7bb4af6a6f1b": {
       "filter_text_added": true,
@@ -9675,6 +14014,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BH-3900"
+    },
+    "bea21977-1a8e-4f71-9a66-fa081969fe3b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://iframe.publicstuff.com/#?client_id=1428"
     },
     "bf032d3a-4689-4080-b395-d5f4dd7ceb84": {
       "filter_text_added": true,
@@ -9811,7 +14159,8 @@
         "nav",
         ".experiencefragment",
         ".csh-aem-maincontent",
-        ".jump-nav"
+        ".jump-nav",
+        ".csh-aem-card-dropdown__toggle-button"
       ],
       "url": "https://www.commonspirit.org/find-a-location/hearst-cancer-resource-center-dignity-health-french-hospital-medical-center-1309"
     },
@@ -9874,6 +14223,15 @@
       ],
       "url": "https://www.smartsharehousingsolutions.org/co-living-collaborative"
     },
+    "c280c4c5-6beb-4711-8b3b-e1e0d6166051": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.robodeidentidad.gov/"
+    },
     "c2891f7e-134a-4d77-8d1c-1dc39507283a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9931,6 +14289,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=3&search_history_id=262842494&unit_list=0&akaSort=0&query=%20&simple_query=&code=TJ-3000&limit=&name="
     },
+    "c3476b83-0188-46ff-a32f-311ff27300f4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.echoshelter.org/"
+    },
     "c3e11dac-ead9-49e4-a2fb-0c82cacee241": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9955,6 +14322,15 @@
       "processor": "text_json_diff",
       "url": "https://www.cdph.ca.gov/Programs/CHSI/Pages/Assembly-Bill-(AB)-1733.aspx"
     },
+    "c4166c9c-2a84-4d97-af8f-9dce836984e5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ucjeps.berkeley.edu/eflora/eflora_display.php?tid=46791"
+    },
     "c457339a-bf75-49ab-b235-eeff4e97d16f": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9974,6 +14350,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slocity.org/government/department-directory/public-works/slo-transit/fare-information"
     },
+    "c4619547-7952-4c78-941c-638db09d3066": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.grover.org/252/Citizen-Feedback---Compliments-or-Compla"
+    },
     "c47f06b2-7459-4088-b81d-f44fb599d293": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -9985,6 +14370,33 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BM"
+    },
+    "c4a35f3f-9a97-407d-8f1b-231a5315f4d7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.tri-counties.org"
+    },
+    "c4c76841-3a14-43f5-bf11-2b939f26f53b": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.modestneeds.org/"
+    },
+    "c57444f9-2440-4118-9e3c-9828576a8288": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://thecenterslo.com/schedule"
     },
     "c5aaf3cb-df99-4c55-b7ef-e101b23ee3bd": {
       "filter_text_added": true,
@@ -10003,6 +14415,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.assistanceleague.org/san-luis-obispo-county/operation-school-bell/"
+    },
+    "c5d585b8-b55e-415a-8f51-5431b58058ea": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdph.ca.gov/Pages/Documentos.aspx"
     },
     "c5fb706c-0ff2-47e3-96d9-25652d34d6f6": {
       "filter_text_added": true,
@@ -10036,6 +14457,9 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -10068,6 +14492,33 @@
       "processor": "text_json_diff",
       "url": "https://slobar.org/legal-resources/listing/court-appointed-special-advocates-casa/"
     },
+    "c6d62f0b-c4a6-470e-bba3-bed3f84ae318": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ccgoodwill.org/"
+    },
+    "c6dc6000-3d74-4c7f-acb6-600a5a5d2346": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://woodshumanesociety.org/resources/lost-pet-help/"
+    },
+    "c768b6d9-9a09-4305-888b-5678fbc74169": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/central-coast/locations/frenchhospital/patients-and-visitors/for-patients/billing-information/financial-assistance"
+    },
     "c78cb7f1-bbb8-45f8-967a-b1c42a1c0fe1": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10081,6 +14532,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/veterans-services/contact-us"
+    },
+    "c81079f5-ccda-4fcf-adb5-d7d0b6933454": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://smilecalifornia.org/find-a-dentist/"
     },
     "c8202087-baed-426f-9612-da32d5be487b": {
       "filter_text_added": true,
@@ -10136,6 +14596,15 @@
       "processor": "text_json_diff",
       "url": "https://www.ciymca.org/summer-camp"
     },
+    "c95eb0b0-5f9a-4c3e-b894-e7e1b9dcec2e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://bounce.com/"
+    },
     "c969a12d-33f3-46bb-bde1-819bded550da": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10182,6 +14651,24 @@
       "processor": "text_json_diff",
       "url": "https://fivecitieschristianwomenfoodpantry.org/"
     },
+    "c9bdf288-20d8-49fc-9f2d-0c54f3de7b81": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://casasolanainc.org/"
+    },
+    "ca91e7c8-bbb3-42e8-8643-2ce9d8a9c6e1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.statesidelegal.org/sites/default/files/Homeless%20Veteran%20Resource%20Guide_0.pdf"
+    },
     "ca9d09c8-550d-48c5-8feb-3410eabf0b56": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10190,6 +14677,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.cdfa.ca.gov/SeniorFarmersMrktNutritionPrgm/docs/SFMNP-List_of_WIC-markets.pdf"
+    },
+    "caaf0cb7-8398-4fa6-8c4d-e1b824a24635": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pshhc.org/supportive-housing/"
     },
     "cb406edf-94aa-4d52-a69e-0a886d382d3f": {
       "filter_text_added": true,
@@ -10204,6 +14700,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://5chc.org/contact-us"
+    },
+    "cb9e035d-fb37-41e5-91c3-b1e38c0c8712": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://helphopelive.org/"
     },
     "cbde57a7-4b5a-491e-bb43-7f0564f95f41": {
       "filter_text_added": true,
@@ -10256,6 +14761,15 @@
       "processor": "text_json_diff",
       "url": "https://805streetoutreach.org/about-us"
     },
+    "cc330cfe-140f-4770-a27b-9e594e8d2101": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.aclusocal.org/"
+    },
     "cc363c87-6b93-4d2d-a7b9-9fc43b7d40a3": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10286,6 +14800,24 @@
       "processor": "text_json_diff",
       "url": "https://habitatslo.org/remaker-space/"
     },
+    "cc63d2c4-5659-40dc-b4f6-169421cc3321": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://trailways.com/"
+    },
+    "ccc65f5e-0513-4202-ba5b-df17ac97b1d0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://edd.ca.gov/es/jobs-and-training/Job_Seeker_Information_Espanol/"
+    },
     "ccf2fb4e-2d37-463e-bf50-421ef81c27a7": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10294,6 +14826,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://hopesvillageofslo.com/helping"
+    },
+    "cd3158a3-9873-49d2-b02c-7d233a84e23a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center/restitution"
     },
     "cd3dda36-b600-43d6-b842-fcd214cade81": {
       "filter_text_added": true,
@@ -10330,7 +14871,7 @@
         },
         {
           "operation": "Wait for seconds",
-          "optional_value": "2",
+          "optional_value": "4",
           "selector": ""
         }
       ],
@@ -10395,6 +14936,15 @@
       "processor": "text_json_diff",
       "url": "https://agapeslo.church/contact"
     },
+    "cef5d57d-ed47-488e-9ce3-b6ef269e7cb5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://prepareforyourcare.org/es/prepare/bienvenido"
+    },
     "ceffc0de-213f-4a9b-9fcb-bc3cce427780": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10443,6 +14993,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/real-id/real-id-checklist/"
+    },
+    "cfb0025e-4cbd-4d22-9d2e-1348b38eeeb7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/probation/forms-documents/education-and-training-materials-documents/procedures/5-support-services-procedures/evidence/5-6-property-evidence-manual"
     },
     "cfc959d2-1c7e-4fea-a318-fc0cf57e3ff5": {
       "filter_text_added": true,
@@ -10504,6 +15063,15 @@
       "processor": "text_json_diff",
       "url": "https://www.housekeys.org/applicationprocess"
     },
+    "d078d44f-9b2a-48ff-82fa-3f7f7fc1baea": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.t-mha.org/program-details.php?id=45"
+    },
     "d0cda82f-846f-4ea6-8625-07c163c4e6de": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10512,6 +15080,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "http://middlehouse.org/"
+    },
+    "d0e8d68d-cc8e-4e88-a472-a1ffd9a1b464": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-management-information-system/forms-documents/2025/san-luis-obispo-coc-hmis-consent-for-release-of-information-2024-final-%28sp%29"
     },
     "d12e2cee-c4ef-49d5-be77-aee9bad4ce35": {
       "filter_text_added": true,
@@ -10531,6 +15108,24 @@
       "processor": "text_json_diff",
       "url": "https://removery.com/tattoo-removal/"
     },
+    "d13967e1-5898-4c92-9f72-31ba1e2c6f4a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.childrensresource.org/food-program"
+    },
+    "d1521a58-d7b5-4527-8dd0-01a2eaf12879": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.sloseniorgo.org/new-page"
+    },
     "d1aab2bf-5e14-4a69-94bf-baa9db0422bd": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10542,6 +15137,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://channel.recliquecore.com/programs/1269/kid-s-night-out/?locations=140"
+    },
+    "d1b24d19-867a-493e-9f5c-5912b38fd049": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://cencalhealth.org/"
     },
     "d21680b9-9122-4ade-b2ad-159f54a2e4a1": {
       "filter_text_added": true,
@@ -10585,18 +15189,168 @@
       "processor": "text_json_diff",
       "url": "https://apameds.org/contact-us/"
     },
+    "d250e1ba-e254-4f6c-9a43-586bc43d5f46": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/drug-and-alcohol-services/adult-outpatient-substance-use-disorder-treatment"
+    },
     "d27b1417-df05-45ae-9943-6a651f9dd946": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "BESbswy",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -10604,7 +15358,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/cambria/"
     },
@@ -10616,6 +15371,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=5&search_history_id=262841874&unit_list=0&akaSort=0&query=%20&simple_query=&code=PL&limit=&name="
+    },
+    "d2bca614-f650-4db5-9994-f22ef4db7033": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cencalhealth.org/members/provider-directory-for-members/"
     },
     "d301e360-c220-4f7f-a263-8b7a056a4ed1": {
       "filter_text_added": true,
@@ -10638,6 +15402,15 @@
       "processor": "text_json_diff",
       "url": "https://marijuana-anonymous.org/"
     },
+    "d3a0a121-d665-42f0-a7eb-fd0ee5da0800": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://docs.google.com/spreadsheets/d/1cJFBbDUZQF6fGYOzpi790Tkb0Orlb-b5GFHmpFDm61c/edit?gid=374953232#gid=374953232"
+    },
     "d3ba620f-d783-4b8b-950f-087564499d21": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10650,18 +15423,163 @@
       "processor": "text_json_diff",
       "url": "https://www.haslo.org/housing-options-copy"
     },
+    "d3d9ffa9-17cf-49f1-9c38-f99d700002a3": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://1af473-cd.myshopify.com/pages/tcc-tuesdays-adult-support-group"
+    },
     "d3f074cc-33dc-4fe9-ba45-b442d428ef12": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Powered by",
+        "Please accept cookies to access this content",
+        "BESbswy",
+        "BESbswy"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -10669,7 +15587,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/oceano-del-mar/"
     },
@@ -10755,6 +15674,15 @@
       "processor": "text_json_diff",
       "url": "https://catholiccharitiesdom.org/family-supportive-services/"
     },
+    "d52ca60e-a451-4b4a-990b-ae643bca2802": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://capslo.org/"
+    },
     "d55d37b3-465e-401c-a1a1-43e43bc326f4": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10777,7 +15705,7 @@
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://hospiceslo.org/support-groups/general-grief-support-and-education-group-%E2%80%93-meets-weekly-for-6-weeks-in-slo"
+      "url": "https://hospiceslo.org/support-groups/general-grief-support-and-education-group"
     },
     "d5985e58-c5a8-4458-8fdc-581de1192a63": {
       "filter_text_added": true,
@@ -10787,6 +15715,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://galacc.org/events/#calendar"
+    },
+    "d5c9dcf9-55c1-4760-8304-3cfd04f827d8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://centralcoastseniors.myresourcedirectory.com/"
+    },
+    "d5cae196-8183-4937-affa-858667d2df09": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ppsslo.org/"
     },
     "d5e498dc-30a1-45cc-be48-627df7075a38": {
       "filter_text_added": true,
@@ -10908,21 +15854,198 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        ".footer-address"
+        ".wp-block-jetpack-address"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://www.slocog.org/"
+      "url": "https://slocog.org/"
     },
     "d7c386e2-199f-4301-bae8-346d652fa7f7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "ignore_text": [
+        "Select LanguageFilipinoSpanish",
+        "Powered by Translate",
+        "Privacy and Cookie Policy",
+        "Please accept cookies to access this content",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Privacy and Cookie Policy",
+        "To provide the best experiences, we use technologies like cookies to store and/or access device information. Consenting to these technologies will allow us to process data such as browsing behavior or unique IDs on this site. Not consenting or withdrawing consent, may adversely affect certain features and functions.",
+        "Functional Functional Always active",
+        "The technical storage or access is strictly necessary for the legitimate purpose of enabling the use of a specific service explicitly requested by the subscriber or user, or for the sole purpose of carrying out the transmission of a communication over an electronic communications network.",
+        "Preferences Preferences",
+        "The technical storage or access is necessary for the legitimate purpose of storing preferences that are not requested by the subscriber or user.",
+        "Statistics Statistics",
+        "The technical storage or access that is used exclusively for statistical purposes. The technical storage or access that is used exclusively for anonymous statistical purposes. Without a subpoena, voluntary compliance on the part of your Internet Service Provider, or additional records from a third party, information stored or retrieved for this purpose alone cannot usually be used to identify you.",
+        "Marketing Marketing",
+        "The technical storage or access is required to create user profiles to send advertising, or to track the user on a website or across several websites for similar marketing purposes.",
+        "* Manage options",
+        "* Manage services",
+        "* Manage {vendor_count} vendors",
+        "* Read more about these purposes",
+        "Accept Deny View preferences Save preferences View preferences",
+        "* Notice of Privacy Practices",
+        "* {title}",
+        "* {title}",
+        "We value your privacy",
+        "We use cookies to enhance your browsing experience, serve personalized content or content, and analyze our traffic. By clicking \"Accept All\", you consent to our use of cookies.",
+        "Customise Reject All Accept All",
+        "Powered by",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "* Cookie",
+        "wpEmojiSettingsSupports",
+        "* Duration",
+        "session",
+        "* Description",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "* Cookie",
+        "cookieyes-*",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "CookieYes sets this cookie for consent solution management.",
+        "* Cookie",
+        "ts",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "* Cookie",
+        "ts_c",
+        "* Duration",
+        "1 year",
+        "* Description",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "* Cookie",
+        "rc::a",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "* Cookie",
+        "rc::c",
+        "* Duration",
+        "session",
+        "* Description",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "* Cookie",
+        "YSC",
+        "* Duration",
+        "session",
+        "* Description",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "* Cookie",
+        "_ga_*",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to store and count page views.",
+        "* Cookie",
+        "_ga",
+        "* Duration",
+        "1 year 1 month 4 days",
+        "* Description",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "* Cookie",
+        "VISITOR_INFO1_LIVE",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "* Cookie",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "* Duration",
+        "Never Expires",
+        "* Description",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "* Cookie",
+        "__Secure-YENID",
+        "* Duration",
+        "1 year 1 month",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "__Secure-YNID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "* Cookie",
+        "__Secure-ROLLOUT_TOKEN",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "* Cookie",
+        "__Secure-YEC",
+        "* Duration",
+        "past",
+        "* Description",
+        "Description is currently not available.",
+        "* Cookie",
+        "NID",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "* Cookie",
+        "iutk",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Powered by",
+        "menu trigger menu trigger"
+      ],
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".pum-overlay",
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge"
+      ],
+      "url": "https://www.communityhealthcenters.org/about/contact-us/"
+    },
+    "d7d18026-c163-4d32-a2a0-144838ca897f": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://www.communityhealthcenters.org/about/contact-us/"
+      "url": "https://www.salvationarmyusa.org/usa-western-territory/"
     },
     "d8284b98-7aeb-4147-bdfe-30618b35b0cb": {
       "filter_text_added": true,
@@ -10932,6 +16055,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://sacramentohomelessunion.org/"
+    },
+    "d8296b45-0db7-4dcc-96cd-9282b639b5a4": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/Departments/Social-Services/Forms-Documents/Adult-Services/IHSS-Forms/Online-IHSS-Application-Form.aspx"
+    },
+    "d8927dab-2ef6-4b45-8f09-441689257725": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://cdss.ca.gov/inforesources/cdss-programs/enhanced-care-management-and-community-supports-referral-pathways"
     },
     "d8929415-af2a-4ea4-8d04-c88e58b179e0": {
       "filter_text_added": true,
@@ -10945,6 +16086,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BD-5000.1500"
     },
+    "d8d0f1fe-77e5-4b1c-bdbc-234cc29c881a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://support.carbonhealth.com/billing-and-insurance/paying-bills"
+    },
     "d8ea4409-4e31-45fb-a699-74b536c8d51f": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -10956,6 +16106,42 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.adventisthealth.org/central-coast/locations/sierra-vista-regional-medical-center"
+    },
+    "d8fee49d-8e08-4688-a01f-61f4f3f9dc46": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://homelessnesshousingproblem.com/"
+    },
+    "d9031d3a-95be-4a82-9e63-100292c32bd9": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://dmvinvestigations.my.site.com/INVCMS/s/"
+    },
+    "d90b05d9-6c00-4dba-81e7-f758b4c718f7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://frcnca.org/"
+    },
+    "d90c5599-ee7b-4ce8-8c52-e19d3fef7853": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ild.org/"
     },
     "d92e2e6c-a207-4841-8f29-258d876d5861": {
       "filter_text_added": true,
@@ -11042,6 +16228,24 @@
       "processor": "text_json_diff",
       "url": "https://www.sesloc.org/member-services/locations/"
     },
+    "da5d022a-7f2b-48d4-bba5-34f4ca851b3a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdc.gov/nchs/w2w/index.htm"
+    },
+    "daa623ef-33ce-4e8e-acec-743f50b02f0a": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://lifepointcentralcoast.com/"
+    },
     "dabba136-7ff6-492f-b161-175eda499b9e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11117,6 +16321,15 @@
       "processor": "text_json_diff",
       "url": "https://slobangers.com/contact.html"
     },
+    "dbdf7725-a089-42c1-81a8-180cf2a8178c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.jccslo.com/jewish-family-services.html"
+    },
     "dbea70ed-cd29-47cf-aab8-20a50809057e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11133,10 +16346,22 @@
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        "#fsPageBody"
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://ae.slcusd.org/parent-part/parent-part-clone"
+    },
+    "dc80c723-f882-47dd-a521-1ae9512da25e": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ciymca.org/san-luis-obispo-group-exercise-schedule#/results"
     },
     "dcdacbbf-9189-4edd-9461-477315027302": {
       "filter_text_added": true,
@@ -11149,6 +16374,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-2400"
+    },
+    "dcffdcf9-ffc1-45f4-9997-27170e75a127": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.toastmasters.org/"
     },
     "dd3bc4c3-ae53-474d-ba00-baf87c71ba02": {
       "filter_text_added": true,
@@ -11168,12 +16402,21 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "BESbswy",
+        "BESbswy",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -11181,7 +16424,14 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper",
+        ".cmplz-links",
+        ".cmplz-buttons",
+        ".cky-hide",
+        ".cky-revisit-hide",
+        ".cky-consent-container",
+        ".cky-modal"
       ],
       "url": "https://www.communityhealthcenters.org/locations/slo-wh/"
     },
@@ -11234,6 +16484,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=PH-0800"
     },
+    "de1e8188-0146-44e6-95a9-73b11e912537": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://woodshumanesociety.org/"
+    },
     "de537c34-ac49-47e1-8e50-2337554f2d48": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11274,13 +16533,27 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "/html/body/div[2]/div[1]/div/div/div/section[3]/div/div/div/div/div/div[1]/div/div[1]",
-        "/html/body/div[2]/div[1]/div/div/div/section[3]/div/div/div/div/div/div[1]/div/div[3]/div[2]"
+        ".bt_bb_wrapper"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
+      "subtractive_selectors": [
+        ".bt_bb_hidden_xs",
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge"
+      ],
       "url": "https://www.communityhealthcenters.org/health-services/optometry/"
+    },
+    "dea8ad75-1ad1-438c-b3ea-64fcc60000b7": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://edd.ca.gov/"
     },
     "decf48b1-18a9-4bed-9307-dc7bf85a7fa2": {
       "filter_text_added": true,
@@ -11327,7 +16600,7 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "div.section-control:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > p:nth-child(3)"
+        "main"
       ],
       "method": "GET",
       "notification_format": "System default",
@@ -11346,6 +16619,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/child-support/contact-us"
+    },
+    "df926a93-b752-4f92-abd8-11b4ea162bf9": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.infantsee.org/"
     },
     "df954824-4dbe-4136-873c-8ed04ee7592d": {
       "filter_text_added": true,
@@ -11385,6 +16667,24 @@
       "processor": "text_json_diff",
       "url": "https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayers"
     },
+    "dfd01302-e984-49d9-a112-df895425be8d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.tranzcentralcoast.org/"
+    },
+    "dff5a133-9eea-4aff-b85e-45a63f5814ad": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://1af473-cd.myshopify.com/pages/tcc-youth-support-group"
+    },
     "e02505b1-6930-4bbe-a81b-a616e757fd58": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11407,6 +16707,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/social-services/cash-assistance-programs/services/calworks-cash-aid"
+    },
+    "e0696fcf-02f8-49ff-a8b2-0486d6430395": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://pbac.com/membership/"
+    },
+    "e0c5b0c7-4ba8-4336-b82e-2ebd80fb211f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.frontporchslo.org/wednesday-night-dinners"
     },
     "e0c7b1c0-a6b4-4778-93fb-17c24d3d4a4e": {
       "filter_text_added": true,
@@ -11450,6 +16768,15 @@
       "processor": "text_json_diff",
       "url": "https://www.va.gov/education/other-va-education-benefits/ibm-skillsbuild-program/"
     },
+    "e17b5b76-17c1-4c57-95f3-72a718445ced": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://anc.apm.activecommunities.com/prcityrecreation/activity/search?onlineSiteId=0&locale=en-US&activity_select_param=2&activity_category_ids=8&activity_category_ids=13&viewMode=list"
+    },
     "e1f635de-14fb-4a38-9578-a4619beb6f5e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11472,6 +16799,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://accesscentralcoast.org/"
+    },
+    "e265f078-82b1-4f85-9ece-adf627518329": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://alison.com"
     },
     "e28bbf99-e2ee-4617-8929-2896de7ffa3f": {
       "filter_text_added": true,
@@ -11551,7 +16887,7 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "h1.notranslate"
+        "#main-content"
       ],
       "method": "GET",
       "notification_format": "System default",
@@ -11595,12 +16931,89 @@
       "filter_text_replaced": true,
       "ignore_text": [
         "This page can't load Google Maps correctly.",
-        "Do you own this website?  OK"
+        "Do you own this website?  OK",
+        "Map",
+        "Satellite",
+        "BESbswy",
+        "Opt-out Preferences",
+        "We use third-party cookies that help us analyse how you use this website, store your preferences, and provide the content and advertisements that are relevant to you. However, you can opt out of these cookies by checking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button. Once you opt out, you can opt in again at any time by unchecking \"Do Not Sell or Share My Personal Information\" and clicking the \"Save My Preferences\" button.",
+        "Do Not Sell or Share My Personal Information",
+        "Cancel Save My Preferences",
+        "Your opt-out preference has been honored.",
+        "Banner closes automatically in s...",
+        "Powered by",
+        "Customise Consent Preferences",
+        "We use cookies to help you navigate efficiently and perform certain functions. You will find detailed information about all cookies under each consent category below.",
+        "The cookies that are categorised as \"Necessary\" are stored on your browser as they are essential for enabling the basic functionalities of the site. ... Show more",
+        "For more information on how Google's third-party cookies operate and handle your data, see: Google Privacy Policy",
+        "Necessary Always Active",
+        "Necessary cookies are required to enable the basic features of this site, such as providing secure log-in or adjusting your consent preferences. These cookies do not store any personally identifiable data.",
+        "* Cookie",
+        "VISITOR_PRIVACY_METADATA",
+        "* Duration",
+        "6 months",
+        "* Description",
+        "YouTube sets this cookie to store the user's cookie consent state for the current domain.",
+        "wpEmojiSettingsSupports",
+        "session",
+        "WordPress sets this cookie when a user interacts with emojis on a WordPress site. It helps determine if the user's browser can display emojis properly.",
+        "cookieyes-*",
+        "1 year",
+        "CookieYes sets this cookie for consent solution management.",
+        "ts",
+        "PayPal sets this cookie to mitigate risks and ensure transaction integrity.",
+        "ts_c",
+        "PayPal sets this cookie to ensure the security of transactions and verify user authentication.",
+        "Functional",
+        "Functional cookies help perform certain functionalities like sharing the content of the website on social media platforms, collecting feedback, and other third-party features.",
+        "rc::a",
+        "Never Expires",
+        "This cookie is set by the Google recaptcha service to identify bots to protect the website against malicious spam attacks.",
+        "rc::c",
+        "Analytics",
+        "Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics such as the number of visitors, bounce rate, traffic source, etc.",
+        "YSC",
+        "YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.",
+        "_ga_*",
+        "1 year 1 month 4 days",
+        "Google Analytics sets this cookie to store and count page views.",
+        "_ga",
+        "Google Analytics sets this cookie to calculate visitor, session and campaign data and track site usage for the site's analytics report. The cookie stores information anonymously and assigns a randomly generated number to recognise unique visitors.",
+        "Performance",
+        "Performance cookies are used to understand and analyse the key performance indexes of the website which helps in delivering a better user experience for the visitors.",
+        "VISITOR_INFO1_LIVE",
+        "A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.",
+        "ytidb::LAST_RESULT_ENTRY_KEY",
+        "The cookie ytidb::LAST_RESULT_ENTRY_KEY is used by YouTube to store the last search result entry that was clicked by the user. This information is used to improve the user experience by providing more relevant search results in the future.",
+        "Advertisement",
+        "Advertisement cookies are used to provide visitors with customised advertisements based on the pages you visited previously and to analyse the effectiveness of the ad campaigns.",
+        "__Secure-YENID",
+        "1 year 1 month",
+        "Description is currently not available.",
+        "__Secure-YNID",
+        "YouTube cookie used to protect user security and prevent fraud, especially during the login process.",
+        "__Secure-ROLLOUT_TOKEN",
+        "YouTube sets this cookie to manage feature rollout and experimentation. It helps Google control which new features or interface changes are shown to users as part of testing and staged rollouts, ensuring consistent experience for a given user during an experiment.",
+        "__Secure-YEC",
+        "past",
+        "NID",
+        "Google sets the cookie for advertising purposes; to limit the number of times the user sees an ad, to unwanted mute ads, and to measure the effectiveness of ads.",
+        "iutk",
+        "Issuu sets this cookie to recognise the user's device and what Issuu documents have been read.",
+        "Uncategorised",
+        "Other uncategorised cookies are those that are being analysed and have not been classified into a category as yet.",
+        "No cookies to display.",
+        "Reject All Save My Preferences Accept All",
+        "Please accept cookies to access this content"
       ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
       "subtractive_selectors": [
+        ".cky-consent-container",
+        ".cky-modal",
+        ".grecaptcha-badge",
+        ".pum-overlay",
         "#cmplz-cookiebanner-container",
         "header",
         ".bt_bb_hidden_xs",
@@ -11608,7 +17021,8 @@
         "#glt-footer",
         "#flags",
         "#glt-translate-trigger",
-        "#cmplz-manage-consent"
+        "#cmplz-manage-consent",
+        "div.btGoogleMapsWrapper"
       ],
       "url": "https://www.communityhealthcenters.org/locations/nipomo/"
     },
@@ -11726,6 +17140,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcallegal.org/health/#hfaq-post-0"
     },
+    "e644fe99-bea6-4337-83bb-54d542dad3f6": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.phpslo.org/en/referral/"
+    },
     "e651a2af-5dd8-459e-bfba-956e7bc5d87a": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11746,6 +17169,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.disabilityrightsca.org/get-help"
+    },
+    "e7804305-9729-4b74-bcc3-5f0c51afc4e8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://ccrs.calcivilrights.ca.gov/s/"
     },
     "e795964f-94e2-4004-b423-6176299ca2b1": {
       "filter_text_added": true,
@@ -11795,6 +17227,24 @@
       "processor": "text_json_diff",
       "url": "https://www.cuesta.edu/student-support/support-programs/basic-needs-center/homeless-food-resources.html"
     },
+    "e7f60b1e-a0a1-48a0-a738-852f41cadbd5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.newtimesslo.com/c-a-r-e-4paws-will-offer-boarding-for-pets-living-with-struggling-families/"
+    },
+    "e7f78868-0182-45cb-9e63-1b9235242702": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.childrensresource.org/classrooms"
+    },
     "e8080a7d-6254-43b7-8c08-9e5262b6a347": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11804,10 +17254,22 @@
       "processor": "text_json_diff",
       "url": "https://www.echoshelter.org/buildinghopeandhome"
     },
+    "e8650263-76ea-4bbd-9376-b75f794042ac": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://alertslo.org"
+    },
     "e8665908-a718-4d98-a36a-018c6c193444": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
+      "include_filters": [
+        ".primary-container-internal "
+      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
@@ -11822,6 +17284,15 @@
       "processor": "text_json_diff",
       "url": "https://www.ccgoodwill.org/services/resources/"
     },
+    "e87368b1-514f-4cd9-96b4-e02d2be803a8": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/es/pasaportes/tramite-mi-pasaporte/renuever-en-linea.html"
+    },
     "e87e38b4-19d3-47f1-9419-d9d22d6c9fa6": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11830,6 +17301,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://locations.dignityhealth.org/dignity-health-arroyo-grande-community-hospital"
+    },
+    "e8830979-fc35-4359-88e2-a4baf75d6031": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://oa.org/"
     },
     "e8c715c4-e538-49d2-bea1-f6dad80730aa": {
       "filter_text_added": true,
@@ -11897,6 +17377,15 @@
       "processor": "text_json_diff",
       "url": "https://www.learningexpresshub.com/ProductEngine/LELIndex.html#/center/learningexpresslibrary/hsequivalencycenter/home/are-you-prepared"
     },
+    "e9cc7a41-da41-40b9-a337-bc1fb6ccba3c": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://careforsenioranddisabledanimals.org/"
+    },
     "ea4f0093-97f5-4e34-94a3-d610e22ce360": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -11943,6 +17432,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.usa.gov/identity-theft"
+    },
+    "ebb441b0-54f1-495b-8c58-c708b97be8f5": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.statesidelegal.org/helpnavigate?clear=true"
     },
     "ebdc2f55-375c-4350-98a9-fbe6c6664a87": {
       "filter_text_added": true,
@@ -12064,22 +17562,6 @@
       "processor": "text_json_diff",
       "url": "https://medstopurgentcare.com/"
     },
-    "ede5fb4b-f521-40df-8e37-ec0d75a4090c": {
-      "filter_text_added": true,
-      "filter_text_removed": true,
-      "filter_text_replaced": true,
-      "include_filters": [
-        "/html/body/header/div[2]/div/div[1]/a",
-        "/html/body/div[9]/section[1]/div[2]/div/div/div/div",
-        "/html/body/div[9]/section[2]/div/div/div[1]/h4[1]",
-        "/html/body/div[9]/section[3]/div/div/div[2]/div[2]/p[1]/span",
-        "/html/body/div[9]/section[3]/div/div/div[2]/div[2]/p[2]"
-      ],
-      "method": "GET",
-      "notification_format": "System default",
-      "processor": "text_json_diff",
-      "url": "https://removery.com/services/ink-nitiative/"
-    },
     "ede9ff06-6a44-437c-bfbe-5ca58a441d03": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12100,6 +17582,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.org/senior-connection/ask-a-question/"
+    },
+    "ee6657e1-817e-4458-ade6-23f9161b2937": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dignityhealth.org/central-coast/locations/frenchhospital/services/hearst-cancer-resource-center"
     },
     "ee6bb820-3231-41d8-991d-e847e21f79d2": {
       "filter_text_added": true,
@@ -12128,6 +17619,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://pbac.com/"
+    },
+    "ee979757-b3d6-47b0-8a80-c3d4a095ce1f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://dot.ca.gov/-/media/dot-media/programs/maintenance/documents/3-chpt-1-july-2015-rev-1-02-a11y.pdf"
     },
     "eecd6c8c-191f-4fc1-9a58-5af3dfda2d8b": {
       "filter_text_added": true,
@@ -12169,11 +17669,7 @@
       "filter_text_removed": true,
       "filter_text_replaced": true,
       "include_filters": [
-        "#customColor-cell696",
-        "#customColor-cell701 > h2",
-        "#customColor-cell701",
-        "#customColor-cell718",
-        "#customColor-row484"
+        "#main-content"
       ],
       "method": "GET",
       "notification_format": "System default",
@@ -12234,6 +17730,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://capslo.org/toylendinglibrary/"
+    },
+    "f1136cba-cfa8-4441-baa0-fd8f468a3bdc": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/district-attorney/victim-witness-assistance-center/victim-services-information"
     },
     "f152c690-b3f1-4cba-89ba-b88c88957f29": {
       "filter_text_added": true,
@@ -12381,6 +17886,15 @@
       "processor": "text_json_diff",
       "url": "https://www.slolaf.org/programs"
     },
+    "f2e474ae-6eda-47d8-8133-3aaf086594c0": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pge.com/es/account/billing-and-assistance/financial-assistance/california-alternate-rates-for-energy-program.html"
+    },
     "f3071a25-0b21-4f29-bd8a-0390de8cf508": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12443,7 +17957,7 @@
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://removery.com/services/ink-nitiative"
+      "url": "https://removery.com/services/ink-nitiative/"
     },
     "f35da7d5-0e64-4728-b59c-e238f58123d4": {
       "filter_text_added": true,
@@ -12470,6 +17984,15 @@
         "#serverMark"
       ],
       "url": "https://www.vitalchek.com/v/vital-records/california/san-luis-obispo-county-recorder"
+    },
+    "f3767af1-32a7-49a2-aaad-4637f9a63d43": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://adulted.luciamarschools.org/"
     },
     "f37ce469-e136-409c-a137-a7da256bad71": {
       "filter_text_added": true,
@@ -12541,6 +18064,15 @@
       "processor": "text_json_diff",
       "url": "https://buynothingproject.org/find-a-group"
     },
+    "f41f8cb7-2727-4fff-8721-3c5385256799": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slomakerspace.com/get-making"
+    },
     "f4228118-1cca-4d80-8ff2-b65554b3ed1e": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12549,6 +18081,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.assistanceleague.org/san-luis-obispo-county/contact-us/"
+    },
+    "f42a6f07-0199-484c-887d-78efc3350e72": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.ilrc.org/community-resources"
     },
     "f42a8fc8-12c2-4147-b84e-2a7e9ca727ce": {
       "filter_text_added": true,
@@ -12561,6 +18102,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.va.gov/education/about-gi-bill-benefits/"
+    },
+    "f45a97b1-c640-4ae7-ab16-4fc1415fbeb1": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html"
     },
     "f470bda9-a61c-4e6f-825b-d37e8c550529": {
       "filter_text_added": true,
@@ -12638,6 +18188,15 @@
       "processor": "text_json_diff",
       "url": "https://cfsslo.org/wp-content/uploads/2025/02/MFH-Program-FAQ_2025.pdf"
     },
+    "f57936ea-a592-490c-b56d-f1d80fa4fa66": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdfa.ca.gov/SeniorFarmersMrktNutritionPrgm/docs/SFMNP_eligibility_requirements.pdf"
+    },
     "f57b2287-6957-4f77-9740-872e49595ce2": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12670,6 +18229,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slonoorfoundation.org/mhc"
+    },
+    "f669f098-af39-4541-ae79-b8216af432d9": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://gryphonsociety.weebly.com/"
+    },
+    "f691a892-7249-48f7-8fcb-bbb5c2a67182": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://pptform.state.gov/"
     },
     "f6e627e9-d5e7-461a-a0ab-b741b0e8ea2a": {
       "filter_text_added": true,
@@ -12705,6 +18282,15 @@
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php/component/cpx/?task=search.query&view=&page=4&search_history_id=262842494&unit_list=0&akaSort=0&query=%20&simple_query=&code=TJ-3000&limit=&name="
     },
+    "f73be74c-1b18-4c6b-bf5a-4ad978c06547": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.aclusocal.org/en/know-your-rights"
+    },
     "f74b667e-f512-4de8-b4f1-d06437d75f7f": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12716,6 +18302,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.morrobayca.gov/983/Service-Request"
+    },
+    "f7672139-697d-449f-bde7-bc75d67ec189": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocity.org/government/department-directory/parks-and-recreation/activity-guide"
     },
     "f7d6e5d9-999f-4355-9d7c-7865353b928a": {
       "filter_text_added": true,
@@ -12796,6 +18391,15 @@
       "processor": "text_json_diff",
       "url": "https://www.caljobs.ca.gov/vosnet/ContactUs.aspx"
     },
+    "f907f8ff-7d6b-47af-8ba1-418abb8b6223": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/social-services/forms-documents/homeless-services/homeless-management-information-system-(hmis)/2025/san-luis-obispo-coc-hmis-consent-for-release-of-information-2024-final-(sp)"
+    },
     "f963b250-5277-4491-ae71-fbf946b38cd8": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12865,6 +18469,15 @@
       "processor": "text_json_diff",
       "url": "https://www.sloundocusupport.org/immigrantservicesguide"
     },
+    "fa346d3e-8edf-4b33-aeba-afb4265e7193": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocll.org/library-resources/reference-materials/"
+    },
     "fa38df0e-45f6-4b6b-8bbf-a5f35fccf046": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -12877,17 +18490,14 @@
       "processor": "text_json_diff",
       "url": "https://www.slocounty.ca.gov/departments/social-services/homeless-services-division/homeless-services-oversight-council"
     },
-    "fa840c27-83c8-4306-8f25-69d0ca1c4b8f": {
+    "fa537bd7-598d-4de2-8475-992b02c23af8": {
       "filter_text_added": true,
       "filter_text_removed": true,
       "filter_text_replaced": true,
-      "include_filters": [
-        "main"
-      ],
       "method": "GET",
       "notification_format": "System default",
       "processor": "text_json_diff",
-      "url": "https://www.adventisthealth.org/patients-and-visitors/help-paying-your-bill"
+      "url": "https://www.tri-counties.org/our-services/apply/"
     },
     "fb39d75f-e617-4192-a09c-3fe8eac555af": {
       "filter_text_added": true,
@@ -12909,6 +18519,15 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.adventisthealth.org/central-coast/locations/twin-cities-community-hospital"
+    },
+    "fc2a3ebb-d628-4256-b1c6-e8a358286346": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.pge.com/es/save-energy-and-money/energy-saving-programs/energy-savings-assistance-program.html"
     },
     "fc8d4954-3223-4f8a-b49f-2a26181c74e1": {
       "filter_text_added": true,
@@ -12996,6 +18615,15 @@
       "processor": "text_json_diff",
       "url": "https://www.smartsharehousingsolutions.org/homeshare-slo"
     },
+    "fde8a7ad-c459-408e-b7f7-13199735049d": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://forms.office.com/Pages/ResponsePage.aspx?id=dMfDhN9_4kClkCey5w-BJlj1OgktxXpPh0AbBedZg-ZUQzRSQUVOWUZIT1ZZNkdMQjQyMUk5NDJDMi4u"
+    },
     "fdfc9b04-2e97-405d-9126-c9134662df39": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -13033,6 +18661,15 @@
       "processor": "text_json_diff",
       "url": "https://www.prcity.com/1177/Teen-Center"
     },
+    "fe2fd1cd-84a2-4813-8673-dc3455c95871": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records.aspx"
+    },
     "fe3cb1ac-02e3-468e-add4-07fa8049745b": {
       "filter_text_added": true,
       "filter_text_removed": true,
@@ -13068,6 +18705,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://centralcoastseniors.myresourcedirectory.com/index.php?option=com_cpx&task=search.query&code=BV"
+    },
+    "fe7c8c7a-abaa-46f8-91a5-d50093977bae": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.dhcs.ca.gov/services/every-woman-counts/"
+    },
+    "fef2f6c5-9d88-4e04-843c-eb8e372f538f": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.naranoncentralca.org/"
     },
     "fef3cd85-aff7-468a-8960-07f1cd5de663": {
       "filter_text_added": true,
@@ -13116,6 +18771,24 @@
       "notification_format": "System default",
       "processor": "text_json_diff",
       "url": "https://www.slorta.org/schedules-fares/route-24/"
+    },
+    "ff3751cf-d561-4f6a-92f0-bb5d2a5be8f2": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://www.slocounty.ca.gov/departments/health-agency/behavioral-health/all-behavioral-health-services/mental-health-youth-services/services-affirming-family-empowerment-(safe)"
+    },
+    "ff533d86-8978-4e96-9b05-5c45f75d8024": {
+      "filter_text_added": true,
+      "filter_text_removed": true,
+      "filter_text_replaced": true,
+      "method": "GET",
+      "notification_format": "System default",
+      "processor": "text_json_diff",
+      "url": "https://cambriavineyardchurch.org/"
     },
     "fff49ce3-73f8-4856-9485-cffffd774c1a": {
       "filter_text_added": true,


### PR DESCRIPTION
Audits every URL referenced in `About.md`, `Directory.md`, `Resource guide.md` and their Spanish equivalents against the Changedetection.io watchlist, imports what was missing, de-duplicates, and re-exports the snapshot.

## Monitoring: 1098 → 1531 watches

Extracted 1,454 distinct URLs from the six content files — markdown links, bare URLs, and `<!-- Source: … -->` comments — and compared them against the **live** instance rather than the previous (stale, Jul 14) snapshot.

**Added: 449.**

Deliberately not added:

| Skipped | Count | Why |
|---|---|---|
| Wikipedia | 34 | Mostly edible-plant and definition links; not resource data |
| Facebook / Instagram | 24 | Not fetchable without login — would be permanent errors |
| github.com | 4 | Software-dependency links from `About.md` |
| Google custom map | 2 | Same `mid=` as a tracked map, differing only in viewport |
| Confirmed 404 | 6 | See #374 |
| `About.md` attribution | 6 | Font/software/licensing links (incl. a stray `https://example.com`) |

URLs returning 403/429 or timing out were treated as bot-blocking rather than dead and *were* added.

## De-duplication

Six watches differing only by protocol, trailing slash, or `www.` were merged. Four had byte-identical configs. For the two that didn't, the survivor keeps the better configuration:

- **Lucia Mar** — kept the `https://www.` watch, whose filters (`#item1433254`, `#item1433250`) were a strict superset of the `http://` one's.
- **Removery** — kept the CSS-selector watch with its `ignore_text` tuning over one using brittle absolute XPath (`/html/body/div[9]/…`), then repointed it to `…/ink-nitiative/`, its actual redirect target.

**Fragment-only duplicates were left alone** — those pages can serve different content per anchor, and several have deliberately section-scoped filters.

Two exact-URL duplicates remain unmerged because their configs encode genuinely different intent and need a human decision: `communityhealthcenters.org/locations/slo-prado/` (cookie-banner `ignore_text` vs `.btContentWrap` scoping) and `pshhc.org/rental-faq/#…` (whole FAQ accordion vs a single panel).

The snapshot also captures hand-tuning done in the web UI — cookie-banner filters across the communityhealthcenters.org locations, and several brittle absolute-XPath selectors replaced with stable CSS.

## Content fixes

- **Lucia Mar Bright Futures** — four link references used `http://luciamarschools.org/251185_2`, which 301-redirects to `https://www.luciamarschools.org/251185_2`. Pointed at the redirect target, matching the adjacent `Source:` annotations. EN and ES.
- **SLOCOG** — `https://www.slocog.org/contact-page` now 404s; the page moved to `https://slocog.org/contact/`. Updated the `{ Source: … }` annotations in `Directory.md` and `Directory_es.md`. Verified the phone (`805-781-4219`), email (`slocog@slocog.org`) and address (1114 Marsh Street) are all still on the new page, so the cited facts are unchanged. The SLOCOG entry itself remains commented out.

## Related

**Addresses item 2 of #374.** That issue lists six source URLs that 404; this PR resolves the SLOCOG one. **#374 should stay open** — the remaining five still need working replacements:

- `irs.gov/…-individual-taxpayerspreparers` (slug looks like two run together)
- `tcglad.org/human-services/`
- `citizenserve.com/arroyogrande`
- `tri-counties.org/…/slo-county-social-svs-resource-sheet.pdf` (2017)
- `catholiccharitiesdom.org/…/hope-in-home/` (already annotated and commented out; low priority)
