### PR TITLE
fix: update three broken source URLs

### DIFF
--- a/Resource guide.md
+++ b/Resource guide.md
@@ -1821,7 +1821,7 @@ The [**Life Steps Foundation**](Directory.md#Life-Steps-Foundation) has resource
 [**PathPoint**](Directory.md#PathPoint) also has services for people with developmental disabilities. <!-- Source: https://www.pathpoint.org/locations/san-luis-obispo/ -->
 
 If you use American Sign Language, [**Lifesigns**](Directory.md#Lifesigns) can provide an interpreter to accompany you at your medical appointments. <!-- Source: https://lifesignsinc.org/ -->
-[**Tri-County GLAD**](Directory.md#Tri-County-GLAD) can help with telephone call interpreting. <!-- Sources: https://tcglad.org/human-services/ -->
+[**Tri-County GLAD**](Directory.md#Tri-County-GLAD) can help with telephone call interpreting. <!-- Sources: https://tcglad.org/our-services/ -->
 
 #### People with HIV or Hepatitis-C
 
@@ -2802,7 +2802,7 @@ Avoid using commercial tax preparers that charge high fees, or that offer refund
 Some of these preparers give poor-quality tax advice, and most of them are bad bargains compared to the free services.
 
 If you are due a tax refund, you will get that refund more quickly if you have a bank account that accepts direct deposit.
-The U.S. Internal Revenue Service stopped issuing paper tax refund checks in 2025. <!-- Source: https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayerspreparers -->
+The U.S. Internal Revenue Service stopped issuing paper tax refund checks in 2025. <!-- Source: https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayers -->
 
 > See the [Banking and Money Management](#banking-and-money-management) section of this guide for help in establishing a bank account.
 

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -1837,7 +1837,7 @@ La [**Life Steps Foundation**](Directory.md#Life-Steps-Foundation) tiene recurso
 [**PathPoint**](Directory.md#PathPoint) también tiene servicios para personas con discapacidades del desarrollo. <!-- Source: https://www.pathpoint.org/locations/san-luis-obispo/ -->
 
 Si usa lenguaje de señas americano, [**Lifesigns**](Directory.md#Lifesigns) puede proporcionar un intérprete para acompañarle en sus citas médicas. <!-- Source: https://lifesignsinc.org/ -->
-[**Tri-County GLAD**](Directory.md#Tri-County-GLAD) puede ayudar con interpretación de llamadas telefónicas. <!-- Sources: https://tcglad.org/human-services/ -->
+[**Tri-County GLAD**](Directory.md#Tri-County-GLAD) puede ayudar con interpretación de llamadas telefónicas. <!-- Sources: https://tcglad.org/our-services/ -->
 
 #### Personas con VIH o Hepatitis C
 
@@ -2802,7 +2802,7 @@ Evite usar preparadores de impuestos comerciales que cobran tarifas altas, o que
 Algunos de estos preparadores dan asesoramiento tributario de mala calidad, y la mayoría de ellos son malas ofertas comparadas con los servicios gratuitos.
 
 Si se le debe un reembolso de impuestos, obtendrá ese reembolso más rápidamente si tiene una cuenta bancaria que acepta depósito directo.
-El Servicio de Impuestos Internos de EE.UU. dejó de emitir cheques en papel de reembolso de impuestos en 2025. <!-- Source: https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayerspreparers -->
+El Servicio de Impuestos Internos de EE.UU. dejó de emitir cheques en papel de reembolso de impuestos en 2025. <!-- Source: https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayers -->
 
 > Vea la sección de [Banca y Manejo de Dinero](#banking-and-money-management) de esta guía para ayuda al establecer una cuenta bancaria.
 

--- a/monitoring/source-urls.txt
+++ b/monitoring/source-urls.txt
@@ -539,7 +539,7 @@ https://www.instagram.com/countyofslo/
 https://www.instagram.com/countyofslo/p/DRDll_MD2FV/
 https://www.instagram.com/p/CjQ7qDCvbhf/
 https://www.irs.gov/credits-deductions/individuals/refundable-tax-credits
-https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayerspreparers
+https://www.irs.gov/newsroom/irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayers
 https://www.jccslo.com/microgrants.html
 https://www.joslynrec.org/CAN/index.html
 https://www.kickitca.org/
@@ -639,7 +639,7 @@ https://www.slocm.org/
 https://www.slocm.org/visit
 https://www.slocoe.org/about/programs/homeless-and-foster-youth-services-coordinating-program/
 https://www.slocog.org/
-https://www.slocog.org/contact-page
+https://www.slocog.org/contact
 https://www.slocounty.ca.gov/departments/administrative-office/office-of-emergency-services/contact-us
 https://www.slocounty.ca.gov/departments/child-support
 https://www.slocounty.ca.gov/departments/child-support/contact-us


### PR DESCRIPTION
Addresses three of the six broken URLs in #374.

## Fixed

**1. IRS** — `Resource guide.md:2805`, `Resource guide_es.md:2805`, `monitoring/source-urls.txt`

Your hunch was right: the slug had two paths concatenated. The page is live at `.../irs-to-phase-out-paper-tax-refund-checks-starting-with-individual-taxpayers`.

Worth a second look while you're in there — the release says paper checks *began* phasing out on Sept 30, 2025, and limited exceptions still exist. "Stopped issuing paper tax refund checks in 2025" may overstate it. I haven't touched the wording since that's a content call, not a link fix.

**2. SLOCOG** — `monitoring/source-urls.txt` only

The content files already point at `slocog.org/contact/`, so only the watchlist entry was stale. Site reorganised; `/contact-page` → `/contact`, same content.

**3. TCGLAD** — `Resource guide.md:1824`, `Resource guide_es.md:1840`

Site was rebuilt in 2026. No `/human-services/` path in the new structure; closest equivalent is `/our-services/`. They also now have dedicated `/housing-resources/`, `/food-resources/` and `/211-guide-and-job-center/` pages, which may be better targets depending on what the surrounding text supports.

## Not changed

**4. citizenserve.com/arroyogrande** — I started to replace this, then found `scripts/check-links.js:50`, where it's already in `KNOWN_GOOD_URLS` with a comment explaining that citizenserve returns a 404 with a client-side JS redirect, so it works in browsers but looks broken to a checker. Reverted my change and left it alone — but it may be worth either dropping it from the issue list, or removing it from `KNOWN_GOOD_URLS` if that behaviour has genuinely changed.

**5. tri-counties 2017 PDF** and **6. Catholic Charities hope-in-home** — not attempted. The PDF likely needs a different document entirely, and Hope in Home needs someone to establish whether the program still exists.