### PR TITLE
docs: add Library Van service info

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -3405,6 +3405,9 @@ If you see one listed here that is no longer in service, please use the feedback
 | Shandon: <a href="#" class="map-link" data-lat="35.656573" data-lon="-120.376358" data-zoom="17" data-label="SLO County Public Library">195 N. 2nd St.</a> | [805-237-3009](tel:+1-805-237-3009) | Tu/W 10am–6pm (closed 12:30–1pm), Sa 9am–5pm (closed 12:30–1pm) |
 | Shell Beach: <a href="#" class="map-link" data-lat="35.154648" data-lon="-120.669678" data-zoom="17" data-label="SLO County Public Library">230 Leeward Ave.</a> | [805-773-2263](tel:+1-805-773-2263) | Tu/W 10am–1pm and 2–6pm, Sa 9am–5pm |
 
+- **Library Van:** <a href="#" class="map-link" data-lat="35.254738" data-lon="-120.69423" data-zoom="17" data-label="Branch Out Library Van">DeVaul Park, 1651 Spooner Dr., SLO</a>, second and third Saturday afternoons 1–2:30pm <!-- Source: https://catalog.slolibrary.org/branch-out-library-van -->
+   - **Website:** [catalog.slolibrary.org/branch-out-library-van](https://catalog.slolibrary.org/branch-out-library-van)
+
 - Note: [**Transitions Mental Health Association (TMHA)**](#TMHA) has a “Library Outreach Team” that connects library patrons who are experiencing homelessness with a social worker and case manager to help them overcome barriers to accessing crucial social services. You can meet the Library Outreach Team at the following library branches (this schedule is subject to change; contact [mvargas@t-mha.org](mailto:mvargas@t-mha.org) for the most up-to-date schedule):
    - Atascadero: W 10:30am–Noon
    - Arroyo Grande: Th 9:30–11am

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -3427,6 +3427,9 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 | Shandon: <a href="#" class="map-link" data-lat="35.656573" data-lon="-120.376358" data-zoom="17" data-label="SLO County Public Library">195 N. 2nd St.</a> | [805-237-3009](tel:+1-805-237-3009) | Ma/Mi 10am–6pm (cerrado 12:30–1pm), S9am–5pm (cerrado 12:30–1pm) |
 | Shell Beach: <a href="#" class="map-link" data-lat="35.154648" data-lon="-120.669678" data-zoom="17" data-label="SLO County Public Library">230 Leeward Ave.</a> | [805-773-2263](tel:+1-805-773-2263) | Ma/Mi 10am–1pm y 2–6pm, S9am–5pm |
 
+- **Branch Out Library Van:** <a href="#" class="map-link" data-lat="35.254738" data-lon="-120.69423" data-zoom="17" data-label="Branch Out Library Van">DeVaul Park, 1651 Spooner Dr., SLO</a>, los segundos y terceros sábados por la tarde de 1–2:30pm <!-- Source: https://catalog.slolibrary.org/branch-out-library-van -->
+   - **Sitio web:** [catalog.slolibrary.org/branch-out-library-van](https://catalog.slolibrary.org/branch-out-library-van)
+
 - Nota: [**Transitions Mental Health Association (TMHA)**](#TMHA) tiene un “Equipo de Alcance de Biblioteca” que conecta a los usuarios de la biblioteca que están experimentando la falta de vivienda con un trabajador social y administrador de casos para ayudarles a superar las barreras para acceder a servicios sociales cruciales. Puede reunirse con el Equipo de Alcance de Biblioteca en las siguientes sucursales de biblioteca (este horario está sujeto a cambios; contacte a [mvargas@t-mha.org](mailto:mvargas@t-mha.org) para el horario más actualizado):
    - Atascadero: Mi 10:30am–mediodía
    - Arroyo Grande: J 9:30–11am

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -3248,6 +3248,8 @@ Contact them at [digitalliteracy@ccgoodwill.org](mailto:digitalliteracy@ccgoodwi
 [**SLO County Public Libraries**](Directory.md#SLO-County-Public-Libraries) have not only books, but online research databases, computers with internet access, English conversation practice sessions, and several [online learning](https://catalog.slolibrary.org/online-learning) programs.
 <!-- Sources: https://catalog.slolibrary.org/tlc and https://catalog.slolibrary.org/online-learning -->
 
+The [Library Van](https://catalog.slolibrary.org/branch-out-library-van) brings SLO County Public Libraries materials to DeVaul Park in SLO on the second and third Saturday afternoons, 1–2:30pm. <!-- Source: https://catalog.slolibrary.org/branch-out-library-van -->
+
 Cal Poly’s [Robert E. Kennedy Library](https://library.calpoly.edu/) is a resource not just for Cal Poly students and faculty but for the inhabitants of the Central Coast in general. <!-- Source: https://library.calpoly.edu/about/policies -->
 The library supports the principle of open access to its collections by the community and region. <!-- Source: https://library.calpoly.edu/about/policies -->
 Members of the community can come to the library during main library opening hours and can access most databases while on the premises by bringing their own device and signing onto Cal Poly guest wireless. <!-- Source: https://library.calpoly.edu/about/policies -->

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -3248,6 +3248,8 @@ El [**Paso Robles Senior Center**](Directory.md#Paso-Robles-Senior-Center) tiene
 Las [**SLO County Public Libraries**](Directory.md#SLO-County-Public-Libraries) tienen no solo libros, sino bases de datos de investigación en línea, computadoras con acceso a internet, sesiones de práctica de conversación en inglés y varios programas de [aprendizaje en línea](https://catalog.slolibrary.org/online-learning).
 <!-- Sources: https://catalog.slolibrary.org/tlc and https://catalog.slolibrary.org/online-learning -->
 
+El programa [Branch Out Library Van](https://catalog.slolibrary.org/branch-out-library-van) de las [**SLO County Public Libraries**](Directory.md#SLO-County-Public-Libraries) lleva materiales a DeVaul Park en SLO los segundos y terceros sábados por la tarde, de 1–2:30pm. <!-- Source: https://catalog.slolibrary.org/branch-out-library-van -->
+
 La [Robert E. Kennedy Library](https://library.calpoly.edu/) de Cal Poly es un recurso no solo para estudiantes y profesores de Cal Poly sino para los habitantes de la Costa Central en general. <!-- Source: https://library.calpoly.edu/about/policies -->
 La biblioteca apoya el principio de acceso abierto a sus colecciones por la comunidad y la región. <!-- Source: https://library.calpoly.edu/about/policies -->
 Los miembros de la comunidad pueden venir a la biblioteca durante las horas de apertura de la biblioteca principal y pueden acceder a la mayoría de las bases de datos mientras estén en las instalaciones trayendo su propio dispositivo y conectándose a la red inalámbrica para invitados de Cal Poly. <!-- Source: https://library.calpoly.edu/about/policies -->

--- a/spell-check.cjs
+++ b/spell-check.cjs
@@ -61,7 +61,7 @@ const WHITELIST = new Set([
   'Beurden',
 
   // Personal Names
-  'Anna', 'Judson', 'DeVaul', 'Macadero', 'Cleaver', 'Clark', 'Halcyon', 'Willow', 'Madonna',
+  'Anna', 'Judson', 'DeVaul', 'Spooner', 'Macadero', 'Cleaver', 'Clark', 'Halcyon', 'Willow', 'Madonna',
   'Marvin', 'Lizzie', 'Betty', 'Bettys', 'Woodson', 'Grayson', 'Ariana', 'Nielson', 'Lamore',
   'Vania', 'Agama', 'Layne', 'Rupe', 'Jauregui', 'Bruse', 'Rossi', 'Villalobos', 'Dowler',
   'Rocio', 'Anaya', 'Butz', 'Scurich', 'Beres', 'LeGrande',


### PR DESCRIPTION
Closes #376

## Summary

Adds the Branch Out Library Van service to the SLO County Public Libraries Directory entry and to the Libraries section of the Resource Guide, in English and Spanish.

Details included:

- Location: DeVaul Park, 1651 Spooner Dr., SLO
- Schedule: second and third Saturday afternoons, 1–2:30pm
- Source: catalog.slolibrary.org/branch-out-library-van

Also adds `Spooner` to the spell-check dictionary.

## Verification

```bash
npm run lint:sources
```

Remark lint completes with no warnings.

Signed off with DCO.
