### PR TITLE
fix: stop sockpuppetbrowser from refusing every browser-backed watch

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -109,6 +109,12 @@ In the web interface:
 3. Set **"Maximum workers"** to `2` or `3` (don't overload your system)
 4. Click **"Save"**
 
+*Important*: if you raise the worker count, also raise
+`MAX_CONCURRENT_CHROME_PROCESSES` in `docker-compose.yml` to stay above it.
+Workers in excess of the browser pool size get their connection closed the
+instant they connect, which surfaces as "Target page, context or browser has
+been closed" on browser-backed watches.
+
 ### 5. Start Monitoring
 
 Click **"Check Now"** on the main page to run the first check on all watches. This initial check establishes the baseline for future change detection.
@@ -290,8 +296,25 @@ Some sites require JavaScript rendering. If you see blank content:
 
 If browser container is having issues:
 ```bash
-docker compose restart playwright-chrome
+docker compose restart sockpuppetbrowser
 ```
+
+### "Target page, context or browser has been closed"
+
+If browser-backed watches fail with this, and the websocket log shows a connect
+immediately followed by `code=1000 reason=""`, the browser pool is full rather
+than the page being unreachable. Check it:
+
+```bash
+curl -s http://127.0.0.1:8080/stats | jq
+```
+
+`active_connections` sitting at `MAX_CONCURRENT_CHROME_PROCESSES` while
+`connection_count_total` stays frozen means slots have leaked and the pool is
+wedged. A watchdog now detects and clears this automatically — see
+**[sockpuppet-watchdog.README.md](sockpuppet-watchdog.README.md)** for the full
+explanation, including why `MAX_CONCURRENT_CHROME_PROCESSES` must stay above
+the changedetection.io worker count.
 
 ### Too Many False Positives
 

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -15,6 +15,11 @@ services:
       # Use polling for file changes
       - USE_X_SETTINGS=1
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # Playwright browser for JavaScript rendering
   # Using the official changedetection.io recommended image
@@ -23,7 +28,35 @@ services:
     hostname: sockpuppetbrowser
     restart: unless-stopped
     shm_size: "2g"
+    ports:
+      # Stats endpoint, bound to loopback only: curl http://127.0.0.1:8080/stats
+      - "127.0.0.1:8080:8080"
     environment:
       - SCREEN_WIDTH=1920
       - SCREEN_HEIGHT=1080
-      - MAX_CONCURRENT_CHROME_PROCESSES=2
+      # Must stay comfortably ABOVE changedetection's worker count (currently 3).
+      # If workers > this value, surplus workers get their CDP connection closed
+      # instantly, which surfaces as "Target page, context or browser has been closed".
+      - MAX_CONCURRENT_CHROME_PROCESSES=5
+      # Misleading name: "true" makes a connection WAIT (up to 120s) for a free
+      # slot instead of being rejected the moment capacity is reached.
+      - DROP_EXCESS_CONNECTIONS=true
+    # sockpuppetbrowser has no per-session timeout: a slot is only released when
+    # the client websocket closes, so a half-open client leaks a slot forever.
+    # Report unhealthy after 5 straight minutes at capacity so a supervisor can act.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python3 -c "import json,urllib.request,sys;
+          s=json.load(urllib.request.urlopen('http://127.0.0.1:8080/stats',timeout=5));
+          sys.exit(1 if s['active_connections'] >= 5 else 0)"
+      interval: 60s
+      timeout: 15s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/monitoring/fix-browser-timeouts.md
+++ b/monitoring/fix-browser-timeouts.md
@@ -1,5 +1,15 @@
 # Fixing Browser Timeout Errors
 
+> **Note (2026-08-07)**: this document covers *timeouts* — pages genuinely too slow
+> to load. It does not cover the similar-looking
+> "BrowserType.connect_over_cdp: Target page, context or browser has been closed",
+> which means the browser pool was full and the page was never fetched at all.
+> See **[sockpuppet-watchdog.README.md](sockpuppet-watchdog.README.md)** for that one.
+>
+> Also note that step 3 below interacts with the browser pool size: keeping
+> `MAX_CONCURRENT_CHROME_PROCESSES` in `docker-compose.yml` at or below the worker
+> count causes the surplus workers to fail instantly. Keep the pool larger.
+
 ## The Problem
 
 The error "Page.goto: Target page, context or browser has been closed" means:

--- a/monitoring/sockpuppet-watchdog.README.md
+++ b/monitoring/sockpuppet-watchdog.README.md
@@ -1,0 +1,121 @@
+# sockpuppetbrowser watchdog
+
+## The failure this fixes
+
+Watches that use the *Chrome/Javascript* fetch method (`html_webdriver`) fail with:
+
+```text
+Exception: BrowserType.connect_over_cdp: Target page, context or browser has been closed
+Call log:
+  - <ws connecting> ws://sockpuppetbrowser:3000/
+  - <ws connected> ws://sockpuppetbrowser:3000/
+  - <ws disconnected> ws://sockpuppetbrowser:3000/ code=1000 reason=""
+```
+
+The websocket connects and then closes immediately, with a *normal* close code and no reason.
+That is the signature of sockpuppetbrowser refusing the connection because its browser pool is full.
+It is not a problem with the page being fetched.
+The same pages load fine in an ordinary browser, and they load fine through sockpuppetbrowser once a slot is free.
+
+Two separate things cause the pool to fill up.
+
+### 1. Fewer browser slots than fetch workers
+
+changedetection.io runs *N* fetch workers in parallel.
+sockpuppetbrowser allows at most `MAX_CONCURRENT_CHROME_PROCESSES` browsers at once.
+When workers outnumber slots, the surplus workers get their connection closed the instant they connect.
+
+Keep `MAX_CONCURRENT_CHROME_PROCESSES` comfortably above the worker count.
+The worker count lives in the changedetection.io UI under *Settings → Requests → Maximum number of workers*.
+
+### 2. Leaked slots
+
+sockpuppetbrowser has no per-session timeout.
+A slot is released only when the client websocket closes.
+If a Playwright client dies without closing cleanly — a changedetection.io restart, a host power-off mid-fetch, a half-open socket — the slot is held forever.
+
+Nothing recovers from this on its own:
+
+- `restart: unless-stopped` does not help, because the process never crashes.
+- The `?timeout=` parameter changedetection.io puts in the CDP URL is not a session timeout; sockpuppetbrowser ignores it for this purpose.
+- Docker marks the container unhealthy via the healthcheck in `docker-compose.yml`, but Docker does not restart unhealthy containers by itself.
+
+Once every slot has leaked, *all* browser-backed watches fail, permanently, until someone restarts the container.
+
+## What the watchdog does
+
+`sockpuppet-watchdog.sh` polls the sockpuppetbrowser stats endpoint every 5 minutes and restarts the container when the pool is wedged.
+
+It distinguishes *wedged* from merely *busy*.
+A busy pool keeps retiring connections, so `connection_count_total` climbs.
+A wedged pool sits at full capacity with `connection_count_total` frozen.
+The script restarts only when **both** conditions hold on two consecutive polls, so a genuinely saturated pool is never killed mid-work.
+
+## Installation
+
+It is already installed.
+For reference, or to reinstall:
+
+```sh
+chmod +x ~/ResourceGuide/monitoring/sockpuppet-watchdog.sh
+cp ~/ResourceGuide/monitoring/sockpuppet-watchdog.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now sockpuppet-watchdog.timer
+loginctl enable-linger "$USER"   # so the timer runs when you are logged out
+```
+
+The unit files are kept in this directory and copied into `~/.config/systemd/user/`, which is where systemd actually reads them from:
+
+- `sockpuppet-watchdog.service` — a `oneshot` unit that runs the script
+- `sockpuppet-watchdog.timer` — fires 5 minutes after boot, then every 5 minutes
+
+The `.service` file hardcodes an absolute `ExecStart` path; adjust it if the repo lives somewhere other than `~/ResourceGuide`.
+
+## Checking on it
+
+```sh
+# Live pool state. active_connections at max with a frozen
+# connection_count_total is the wedge signature.
+curl -s http://127.0.0.1:8080/stats | jq
+
+# Docker's own view
+docker inspect -f '{{.State.Health.Status}}' monitoring-sockpuppetbrowser-1
+
+# When did the watchdog last run, and did it act?
+systemctl --user list-timers sockpuppet-watchdog.timer
+journalctl --user -u sockpuppet-watchdog.service --since '24 hours ago'
+
+# Run it once by hand
+systemctl --user start sockpuppet-watchdog.service
+```
+
+A run that finds nothing wrong prints nothing.
+A run that acts logs the capacity numbers and the restart.
+
+## Tuning
+
+The script reads its capacity threshold from the container's own `MAX_CONCURRENT_CHROME_PROCESSES`, so raising that value in `docker-compose.yml` needs no change here.
+
+Environment overrides, if you need them:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `SOCKPUPPET_CONTAINER` | `monitoring-sockpuppetbrowser-1` | Container to poll and restart |
+| `SOCKPUPPET_STATS_URL` | `http://127.0.0.1:8080/stats` | Stats endpoint |
+| `SOCKPUPPET_STRIKES` | `2` | Consecutive wedged polls before restarting |
+
+## Recovering by hand
+
+If you would rather not wait for the timer:
+
+```sh
+docker restart monitoring-sockpuppetbrowser-1
+```
+
+Then requeue the watches that failed.
+In the UI, filter by *With errors* and use *Recheck all*, or via the API:
+
+```sh
+TOKEN=<your api key from Settings → API>
+curl -s "http://localhost:5000/api/v1/watch/<uuid>?recheck=1" -H "x-api-key: $TOKEN"
+```

--- a/monitoring/sockpuppet-watchdog.service
+++ b/monitoring/sockpuppet-watchdog.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Recover a wedged sockpuppetbrowser browser pool
+Documentation=file:///home/dgross/ResourceGuide/monitoring/sockpuppet-watchdog.README.md
+
+[Service]
+Type=oneshot
+ExecStart=/home/dgross/ResourceGuide/monitoring/sockpuppet-watchdog.sh

--- a/monitoring/sockpuppet-watchdog.sh
+++ b/monitoring/sockpuppet-watchdog.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# sockpuppet-watchdog.sh — recover a wedged sockpuppetbrowser browser pool.
+#
+# Why this exists:
+#   sockpuppetbrowser has no per-session timeout. A browser slot is released only
+#   when the client websocket closes. If a Playwright client dies without closing
+#   cleanly (container restart, host power-off mid-fetch, half-open socket), the
+#   slot is held forever. Once every slot is leaked, sockpuppetbrowser answers new
+#   connections with an immediate close, which changedetection.io reports as:
+#
+#     BrowserType.connect_over_cdp: Target page, context or browser has been closed
+#
+#   `restart: unless-stopped` does not help, because the process never crashes.
+#
+# How it decides the pool is wedged rather than merely busy:
+#   A busy pool still retires connections, so connection_count_total climbs. A
+#   wedged pool sits at full capacity with connection_count_total frozen. This
+#   script requires BOTH conditions to hold for $STRIKES_NEEDED consecutive runs
+#   before restarting, so a genuinely saturated pool is never killed mid-work.
+#
+# Install: see sockpuppet-watchdog.README.md in this directory.
+
+set -uo pipefail
+
+CONTAINER="${SOCKPUPPET_CONTAINER:-monitoring-sockpuppetbrowser-1}"
+STATS_URL="${SOCKPUPPET_STATS_URL:-http://127.0.0.1:8080/stats}"
+STRIKES_NEEDED="${SOCKPUPPET_STRIKES:-2}"
+STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/sockpuppet-watchdog.state"
+
+log() { printf '%s\n' "$*"; }          # stdout is captured by the systemd journal
+die() { log "$*"; exit 0; }            # never fail the unit; a hiccup is not an emergency
+
+mkdir -p "$(dirname "$STATE_FILE")"
+
+# Nothing to police if the container is not running.
+running=$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null) || die "container $CONTAINER not found"
+[ "$running" = "true" ] || die "container $CONTAINER is not running"
+
+# Read the real capacity from the container rather than hardcoding it here, so
+# this cannot silently drift out of step with docker-compose.yml.
+max=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" 2>/dev/null \
+        | sed -n 's/^MAX_CONCURRENT_CHROME_PROCESSES=//p' | head -1)
+[ -n "${max:-}" ] || max=10   # sockpuppetbrowser's own default
+
+stats=$(curl -fsS --max-time 10 "$STATS_URL" 2>/dev/null) || die "stats endpoint unreachable at $STATS_URL"
+active=$(jq -r '.active_connections // empty' <<<"$stats")
+total=$(jq -r '.connection_count_total // empty' <<<"$stats")
+[ -n "$active" ] && [ -n "$total" ] || die "unexpected stats payload: $stats"
+
+prev_strikes=0
+prev_total=-1
+if [ -r "$STATE_FILE" ]; then
+    read -r prev_strikes prev_total < "$STATE_FILE" 2>/dev/null || true
+    : "${prev_strikes:=0}" "${prev_total:=-1}"
+fi
+
+if [ "$active" -ge "$max" ] && [ "$total" = "$prev_total" ]; then
+    strikes=$((prev_strikes + 1))
+    log "at capacity ($active/$max) with no progress since last check (total=$total) — strike $strikes/$STRIKES_NEEDED"
+else
+    strikes=0
+fi
+
+if [ "$strikes" -ge "$STRIKES_NEEDED" ]; then
+    log "pool wedged at $active/$max, connection_count_total frozen at $total — restarting $CONTAINER"
+    if docker restart "$CONTAINER" >/dev/null 2>&1; then
+        log "restarted $CONTAINER"
+    else
+        log "WARNING: failed to restart $CONTAINER"
+    fi
+    strikes=0
+    total=-1   # force a fresh baseline after the restart
+fi
+
+printf '%s %s\n' "$strikes" "$total" > "$STATE_FILE"

--- a/monitoring/sockpuppet-watchdog.timer
+++ b/monitoring/sockpuppet-watchdog.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Poll sockpuppetbrowser for a wedged browser pool
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Unit=sockpuppet-watchdog.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## The problem

Watches using the *Chrome/Javascript* fetch method were failing with:

```text
Exception: BrowserType.connect_over_cdp: Target page, context or browser has been closed
Call log:
  - <ws connecting> ws://sockpuppetbrowser:3000/
  - <ws connected> ws://sockpuppetbrowser:3000/
  - <ws disconnected> ws://sockpuppetbrowser:3000/ code=1000 reason=""
```

The websocket connects, then closes immediately with a *normal* close code and no reason. That is sockpuppetbrowser's "at capacity, rejecting" path — the page was never fetched at all. The pages themselves were fine; they load in an ordinary browser and through sockpuppetbrowser once a slot is free.

This looked page-specific but wasn't: **129 of 132** browser-backed watches were failing simultaneously. The stats endpoint showed the pool pinned at `2 of max 2` with `connection_count_total` frozen, and two orphaned Chromium processes holding both slots doing nothing.

## Two causes

**1. Fewer slots than workers.** `MAX_CONCURRENT_CHROME_PROCESSES=2` against changedetection.io's 3 fetch workers. The surplus worker had its connection closed the instant it connected, every cycle.

**2. Leaked slots.** sockpuppetbrowser has no per-session timeout — a slot is released only when the client websocket closes. A client that dies without closing cleanly (container restart, power-off mid-fetch, half-open socket) holds its slot forever. Nothing recovered from this:

- `restart: unless-stopped` never fires, because the process doesn't crash.
- The `?timeout=` parameter changedetection.io puts in the CDP URL is not a session timeout.
- Docker doesn't restart unhealthy containers on its own.

Once every slot leaks, *all* browser-backed watches fail permanently until someone restarts the container by hand.

## Changes

- Raise the pool to **5**, comfortably above the worker count.
- `DROP_EXCESS_CONNECTIONS=true` — misleading name; it makes a connection **wait** for a free slot instead of being rejected at capacity.
- Healthcheck against the stats endpoint, with that endpoint published on `127.0.0.1` only.
- Cap container log size. The logs had grown to ~4M lines, which made diagnosis harder than it needed to be.
- **`sockpuppet-watchdog.sh`** plus systemd user units, to clear a wedged pool automatically.

The watchdog distinguishes *wedged* from *busy*: a busy pool keeps retiring connections so `connection_count_total` climbs, while a wedged pool sits at capacity with it frozen. It restarts only when **both** conditions hold across two consecutive polls, so a genuinely saturated pool is never killed mid-work. Both paths were tested against a throwaway container — sustained wedge restarts it, saturated-but-progressing does not.

## Verification

After the fix, requeueing the 246 failing watches processed them with **zero rejections and zero Chrome start failures**, peaking at 4 concurrent browsers:

```json
{"active_connections": 2, "connection_count_total": 291, "dropped_threshold_reached": 0,
 "dropped_waited_too_long": 0, "chrome_start_failures": 0}
```

CDP errors dropped from **246 → 1**. The 43 remaining watch errors are unrelated per-page issues — 22 × `403 (Access denied)` (bot blocking), plus scattered DNS failures, redirect loops, and connection timeouts. Those are worth a separate pass.

## Also

Corrects a `README.md` reference to a `playwright-chrome` service that no longer exists, and adds a note to `fix-browser-timeouts.md` distinguishing genuine timeouts from this capacity failure — its advice to cut workers to 2 is part of how the pool got sized this tightly.

Documentation changes are lint-clean and follow the one-sentence-per-line convention from CONTRIBUTING.md. No changes to guide content, so no Spanish translation updates are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
