### PR TITLE
fix: detect a deadlocked worker pool, not just a full browser pool

### DIFF
--- a/monitoring/sockpuppet-watchdog.README.md
+++ b/monitoring/sockpuppet-watchdog.README.md
@@ -1,6 +1,14 @@
-# sockpuppetbrowser watchdog
+# monitoring stack watchdog
 
-## The failure this fixes
+The watchdog covers two independent ways the monitoring stack stops checking watches.
+Neither recovers on its own, and neither crashes anything, so `restart: unless-stopped` never fires.
+
+- **[A wedged browser pool](#failure-a-a-wedged-browser-pool)** — browser-backed watches fail instantly with a CDP error.
+- **[A deadlocked worker pool](#failure-b-a-deadlocked-worker-pool)** — *every* watch silently stops being checked, including plain-HTTP ones.
+
+Failure B is the more damaging of the two, and it can occur while the browser pool still looks healthy.
+
+## Failure A: a wedged browser pool
 
 Watches that use the *Chrome/Javascript* fetch method (`html_webdriver`) fail with:
 
@@ -19,7 +27,7 @@ The same pages load fine in an ordinary browser, and they load fine through sock
 
 Two separate things cause the pool to fill up.
 
-### 1. Fewer browser slots than fetch workers
+### Fewer browser slots than fetch workers
 
 changedetection.io runs *N* fetch workers in parallel.
 sockpuppetbrowser allows at most `MAX_CONCURRENT_CHROME_PROCESSES` browsers at once.
@@ -28,7 +36,7 @@ When workers outnumber slots, the surplus workers get their connection closed th
 Keep `MAX_CONCURRENT_CHROME_PROCESSES` comfortably above the worker count.
 The worker count lives in the changedetection.io UI under *Settings → Requests → Maximum number of workers*.
 
-### 2. Leaked slots
+### Leaked slots
 
 sockpuppetbrowser has no per-session timeout.
 A slot is released only when the client websocket closes.
@@ -42,14 +50,37 @@ Nothing recovers from this on its own:
 
 Once every slot has leaked, *all* browser-backed watches fail, permanently, until someone restarts the container.
 
+## Failure B: a deadlocked worker pool
+
+A browser-backed watch can hang inside Playwright past any timeout configured in the UI.
+The worker that claimed it never finishes and never picks up another job.
+Once every worker is stuck, the queue stops draining entirely — including plain-HTTP watches that never touch the browser at all.
+
+The symptom is a *Queued size* that only ever grows, with no watch being checked.
+In the changedetection.io log it looks like a wall of `Queued watch UUID ...` lines with no matching `Worker N completed ...`.
+
+This mode does **not** require the browser pool to be full.
+Some slots leak, the rest stay free, and a pure capacity check reports everything healthy while nothing is actually being monitored.
+
+Document-style URLs are repeat offenders — Chrome's PDF viewer is a common place to hang.
+See [Watches that hang the browser](#watches-that-hang-the-browser) below.
+
 ## What the watchdog does
 
-`sockpuppet-watchdog.sh` polls the sockpuppetbrowser stats endpoint every 5 minutes and restarts the container when the pool is wedged.
+`sockpuppet-watchdog.sh` runs every 5 minutes and makes two independent checks.
 
-It distinguishes *wedged* from merely *busy*.
+**Check A — is the browser pool wedged?**
 A busy pool keeps retiring connections, so `connection_count_total` climbs.
 A wedged pool sits at full capacity with `connection_count_total` frozen.
-The script restarts only when **both** conditions hold on two consecutive polls, so a genuinely saturated pool is never killed mid-work.
+When both hold on 2 consecutive polls, it restarts sockpuppetbrowser.
+
+**Check B — is the queue draining?**
+A draining queue shrinks.
+When the queue is non-empty and has not shrunk across 3 consecutive polls, the script confirms with the decisive signal: the most recent `last_checked` across all watches.
+If no watch at all has been checked in the last 20 minutes, the workers really are stuck, and it restarts changedetection.io along with sockpuppetbrowser.
+If some watch *was* checked recently, the queue is merely busy and nothing is restarted.
+
+Both checks require their symptom to persist across several polls, so a merely loaded system is never restarted mid-work.
 
 ## Installation
 
@@ -75,8 +106,19 @@ The `.service` file hardcodes an absolute `ExecStart` path; adjust it if the rep
 
 ```sh
 # Live pool state. active_connections at max with a frozen
-# connection_count_total is the wedge signature.
+# connection_count_total is the wedge signature (failure A).
 curl -s http://127.0.0.1:8080/stats | jq
+
+# Queue state. A queue_size that only ever grows is the
+# deadlock signature (failure B).
+TOKEN=$(jq -r .settings.application.api_access_token \
+          ~/ResourceGuide/monitoring/changedetection-data/url-watches.json)
+curl -s http://localhost:5000/api/v1/systeminfo -H "x-api-key: $TOKEN" | jq .queue_size
+
+# Is anything actually being checked? Minutes since the most
+# recent check across all watches; a large number means stuck.
+curl -s http://localhost:5000/api/v1/watch -H "x-api-key: $TOKEN" \
+  | jq "(now - ([.[].last_checked // 0] | max)) / 60 | floor"
 
 # Docker's own view
 docker inspect -f '{{.State.Health.Status}}' monitoring-sockpuppetbrowser-1
@@ -90,7 +132,24 @@ systemctl --user start sockpuppet-watchdog.service
 ```
 
 A run that finds nothing wrong prints nothing.
-A run that acts logs the capacity numbers and the restart.
+A run that acts logs the numbers it saw and what it restarted.
+
+## Watches that hang the browser
+
+Failure B is usually triggered by a specific watch rather than by load.
+Document-style URLs on the *Chrome/Javascript* backend are the usual cause, because Chrome's PDF viewer can hang indefinitely.
+
+To list them:
+
+```sh
+TOKEN=$(jq -r .settings.application.api_access_token \
+          ~/ResourceGuide/monitoring/changedetection-data/url-watches.json)
+curl -s http://localhost:5000/api/v1/watch -H "x-api-key: $TOKEN" \
+  | jq -r 'to_entries[] | select(.value.url | test("showpublisheddocument|\\.pdf$|/documentcenter/view/"; "i")) | "\(.key) \(.value.url)"'
+```
+
+PDFs do not need JavaScript rendering.
+Switching these watches to *Basic fast Plaintext/HTTP Client* both avoids the hang and lets changedetection.io extract the PDF text directly.
 
 ## Tuning
 
@@ -100,20 +159,35 @@ Environment overrides, if you need them:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `SOCKPUPPET_CONTAINER` | `monitoring-sockpuppetbrowser-1` | Container to poll and restart |
-| `SOCKPUPPET_STATS_URL` | `http://127.0.0.1:8080/stats` | Stats endpoint |
-| `SOCKPUPPET_STRIKES` | `2` | Consecutive wedged polls before restarting |
+| `SOCKPUPPET_CONTAINER` | `monitoring-sockpuppetbrowser-1` | Browser container to poll and restart |
+| `CHANGEDETECTION_CONTAINER` | `changedetection` | App container to restart on a worker deadlock |
+| `SOCKPUPPET_STATS_URL` | `http://127.0.0.1:8080/stats` | Browser pool stats endpoint |
+| `CHANGEDETECTION_URL` | `http://localhost:5000` | changedetection.io base URL |
+| `CHANGEDETECTION_DATASTORE` | `.../changedetection-data/url-watches.json` | Where the script reads the API token |
+| `SOCKPUPPET_STRIKES` | `2` | Consecutive wedged-pool polls before restarting |
+| `QUEUE_STRIKES` | `3` | Consecutive non-draining-queue polls before confirming |
+| `STALL_MINUTES` | `20` | No watch checked in this long confirms a deadlock |
 
 ## Recovering by hand
 
 If you would rather not wait for the timer:
 
+For a wedged browser pool (failure A), restarting the browser is enough:
+
 ```sh
 docker restart monitoring-sockpuppetbrowser-1
 ```
 
-Then requeue the watches that failed.
-In the UI, filter by *With errors* and use *Recheck all*, or via the API:
+For a deadlocked worker pool (failure B), restart both, browser first so the app comes up against a clean pool:
+
+```sh
+docker restart monitoring-sockpuppetbrowser-1
+docker restart changedetection
+```
+
+The queue drains on its own afterwards; there is no need to requeue anything, because the overdue watches are still queued.
+
+To requeue watches that failed with an error rather than a stall, filter by *With errors* in the UI and use *Recheck all*, or via the API:
 
 ```sh
 TOKEN=<your api key from Settings → API>

--- a/monitoring/sockpuppet-watchdog.service
+++ b/monitoring/sockpuppet-watchdog.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Recover a wedged sockpuppetbrowser browser pool
+Description=Recover a stalled changedetection.io monitoring stack
 Documentation=file:///home/dgross/ResourceGuide/monitoring/sockpuppet-watchdog.README.md
 
 [Service]

--- a/monitoring/sockpuppet-watchdog.sh
+++ b/monitoring/sockpuppet-watchdog.sh
@@ -1,76 +1,151 @@
 #!/usr/bin/env bash
 #
-# sockpuppet-watchdog.sh — recover a wedged sockpuppetbrowser browser pool.
+# sockpuppet-watchdog.sh — recover a stalled changedetection.io monitoring stack.
 #
-# Why this exists:
-#   sockpuppetbrowser has no per-session timeout. A browser slot is released only
-#   when the client websocket closes. If a Playwright client dies without closing
-#   cleanly (container restart, host power-off mid-fetch, half-open socket), the
-#   slot is held forever. Once every slot is leaked, sockpuppetbrowser answers new
-#   connections with an immediate close, which changedetection.io reports as:
+# It watches for two independent failure modes. Both end with watches silently
+# not being checked, and neither recovers on its own.
 #
-#     BrowserType.connect_over_cdp: Target page, context or browser has been closed
+# A. Wedged browser pool.
+#    sockpuppetbrowser has no per-session timeout. A browser slot is released
+#    only when the client websocket closes, so a client that dies without
+#    closing cleanly holds its slot forever. Once every slot is leaked,
+#    sockpuppetbrowser answers new connections with an immediate close, which
+#    changedetection.io reports as:
+#      BrowserType.connect_over_cdp: Target page, context or browser has been closed
 #
-#   `restart: unless-stopped` does not help, because the process never crashes.
+# B. Deadlocked worker pool.
+#    A browser-backed watch can hang inside Playwright past any configured
+#    timeout (PDF-ish URLs and some SPAs are repeat offenders). The worker that
+#    claimed it never finishes, and never picks up another job. Once every
+#    worker is stuck, the whole queue stops draining — including plain-HTTP
+#    watches that never touch the browser at all. This is the more damaging
+#    mode, and it can happen while the browser pool still looks healthy: only
+#    some slots leak, so a pure capacity check reports everything is fine.
 #
-# How it decides the pool is wedged rather than merely busy:
-#   A busy pool still retires connections, so connection_count_total climbs. A
-#   wedged pool sits at full capacity with connection_count_total frozen. This
-#   script requires BOTH conditions to hold for $STRIKES_NEEDED consecutive runs
-#   before restarting, so a genuinely saturated pool is never killed mid-work.
+# `restart: unless-stopped` helps with neither, because nothing ever crashes.
+#
+# Distinguishing stuck from busy:
+#   A busy pool keeps retiring connections, so connection_count_total climbs.
+#   A busy queue keeps shrinking as work completes. Each check therefore needs
+#   its symptom to persist across several consecutive polls before acting, so
+#   a merely loaded system is never restarted mid-work.
 #
 # Install: see sockpuppet-watchdog.README.md in this directory.
 
 set -uo pipefail
 
-CONTAINER="${SOCKPUPPET_CONTAINER:-monitoring-sockpuppetbrowser-1}"
+SP_CONTAINER="${SOCKPUPPET_CONTAINER:-monitoring-sockpuppetbrowser-1}"
+CD_CONTAINER="${CHANGEDETECTION_CONTAINER:-changedetection}"
 STATS_URL="${SOCKPUPPET_STATS_URL:-http://127.0.0.1:8080/stats}"
-STRIKES_NEEDED="${SOCKPUPPET_STRIKES:-2}"
-STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/sockpuppet-watchdog.state"
+CD_URL="${CHANGEDETECTION_URL:-http://localhost:5000}"
+DATASTORE="${CHANGEDETECTION_DATASTORE:-/home/dgross/ResourceGuide/monitoring/changedetection-data/url-watches.json}"
+POOL_STRIKES_NEEDED="${SOCKPUPPET_STRIKES:-2}"      # x5min: pool wedged
+QUEUE_STRIKES_NEEDED="${QUEUE_STRIKES:-3}"          # x5min: queue not draining
+STALL_MINUTES="${STALL_MINUTES:-20}"                # no watch checked in this long = stalled
+STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/sockpuppet-watchdog.state.json"
 
-log() { printf '%s\n' "$*"; }          # stdout is captured by the systemd journal
-die() { log "$*"; exit 0; }            # never fail the unit; a hiccup is not an emergency
+log() { printf '%s\n' "$*"; }   # stdout is captured by the systemd journal
 
 mkdir -p "$(dirname "$STATE_FILE")"
+[ -s "$STATE_FILE" ] || printf '{}' > "$STATE_FILE"
+state=$(cat "$STATE_FILE" 2>/dev/null); [ -n "$state" ] || state='{}'
+getstate() { jq -r --arg k "$1" --arg d "$2" '.[$k] // $d' <<<"$state"; }
 
-# Nothing to police if the container is not running.
-running=$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null) || die "container $CONTAINER not found"
-[ "$running" = "true" ] || die "container $CONTAINER is not running"
+pool_strikes=$(getstate pool_strikes 0)
+pool_total=$(getstate pool_total -1)
+queue_strikes=$(getstate queue_strikes 0)
+queue_size_prev=$(getstate queue_size -1)
 
-# Read the real capacity from the container rather than hardcoding it here, so
-# this cannot silently drift out of step with docker-compose.yml.
-max=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$CONTAINER" 2>/dev/null \
-        | sed -n 's/^MAX_CONCURRENT_CHROME_PROCESSES=//p' | head -1)
-[ -n "${max:-}" ] || max=10   # sockpuppetbrowser's own default
+save_state() {
+    jq -n --argjson ps "${1:-0}" --argjson pt "${2:--1}" \
+          --argjson qs "${3:-0}" --argjson qz "${4:--1}" \
+      '{pool_strikes:$ps, pool_total:$pt, queue_strikes:$qs, queue_size:$qz}' > "$STATE_FILE"
+}
 
-stats=$(curl -fsS --max-time 10 "$STATS_URL" 2>/dev/null) || die "stats endpoint unreachable at $STATS_URL"
-active=$(jq -r '.active_connections // empty' <<<"$stats")
-total=$(jq -r '.connection_count_total // empty' <<<"$stats")
-[ -n "$active" ] && [ -n "$total" ] || die "unexpected stats payload: $stats"
+running() { [ "$(docker inspect -f '{{.State.Running}}' "$1" 2>/dev/null)" = "true" ]; }
 
-prev_strikes=0
-prev_total=-1
-if [ -r "$STATE_FILE" ]; then
-    read -r prev_strikes prev_total < "$STATE_FILE" 2>/dev/null || true
-    : "${prev_strikes:=0}" "${prev_total:=-1}"
-fi
+# ---------------------------------------------------------------------------
+# Check A: is the browser pool wedged?
+# ---------------------------------------------------------------------------
+if running "$SP_CONTAINER"; then
+    # Read capacity from the container so this cannot drift out of step with
+    # docker-compose.yml.
+    max=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$SP_CONTAINER" 2>/dev/null \
+            | sed -n 's/^MAX_CONCURRENT_CHROME_PROCESSES=//p' | head -1)
+    [ -n "${max:-}" ] || max=10   # sockpuppetbrowser's own default
 
-if [ "$active" -ge "$max" ] && [ "$total" = "$prev_total" ]; then
-    strikes=$((prev_strikes + 1))
-    log "at capacity ($active/$max) with no progress since last check (total=$total) — strike $strikes/$STRIKES_NEEDED"
-else
-    strikes=0
-fi
+    if stats=$(curl -fsS --max-time 10 "$STATS_URL" 2>/dev/null); then
+        active=$(jq -r '.active_connections // empty' <<<"$stats")
+        total=$(jq -r '.connection_count_total // empty' <<<"$stats")
+        if [ -n "$active" ] && [ -n "$total" ]; then
+            if [ "$active" -ge "$max" ] && [ "$total" = "$pool_total" ]; then
+                pool_strikes=$((pool_strikes + 1))
+                log "pool at capacity ($active/$max), no progress since last check (total=$total) — strike $pool_strikes/$POOL_STRIKES_NEEDED"
+            else
+                pool_strikes=0
+            fi
+            pool_total="$total"
 
-if [ "$strikes" -ge "$STRIKES_NEEDED" ]; then
-    log "pool wedged at $active/$max, connection_count_total frozen at $total — restarting $CONTAINER"
-    if docker restart "$CONTAINER" >/dev/null 2>&1; then
-        log "restarted $CONTAINER"
-    else
-        log "WARNING: failed to restart $CONTAINER"
+            if [ "$pool_strikes" -ge "$POOL_STRIKES_NEEDED" ]; then
+                log "browser pool wedged at $active/$max, connection_count_total frozen at $total — restarting $SP_CONTAINER"
+                docker restart "$SP_CONTAINER" >/dev/null 2>&1 \
+                    && log "restarted $SP_CONTAINER" || log "WARNING: failed to restart $SP_CONTAINER"
+                pool_strikes=0
+                pool_total=-1
+            fi
+        fi
     fi
-    strikes=0
-    total=-1   # force a fresh baseline after the restart
 fi
 
-printf '%s %s\n' "$strikes" "$total" > "$STATE_FILE"
+# ---------------------------------------------------------------------------
+# Check B: is the queue draining?
+#
+# A leaked-but-not-full browser pool still deadlocks every worker, so this must
+# not be gated on Check A having fired.
+# ---------------------------------------------------------------------------
+if running "$CD_CONTAINER" && [ -r "$DATASTORE" ]; then
+    token=$(jq -r '.settings.application.api_access_token // empty' "$DATASTORE" 2>/dev/null)
+
+    if [ -n "$token" ] && info=$(curl -fsS --max-time 15 "$CD_URL/api/v1/systeminfo" -H "x-api-key: $token" 2>/dev/null); then
+        queue_size=$(jq -r '.queue_size // empty' <<<"$info")
+
+        if [ -n "$queue_size" ]; then
+            # A draining queue shrinks. Only a queue that is non-empty AND never
+            # shrinking is a candidate for being stalled.
+            if [ "$queue_size" -gt 0 ] && [ "$queue_size_prev" -ge 0 ] && [ "$queue_size" -ge "$queue_size_prev" ]; then
+                queue_strikes=$((queue_strikes + 1))
+                log "queue not draining ($queue_size_prev -> $queue_size) — strike $queue_strikes/$QUEUE_STRIKES_NEEDED"
+            else
+                queue_strikes=0
+            fi
+            queue_size_prev="$queue_size"
+
+            if [ "$queue_strikes" -ge "$QUEUE_STRIKES_NEEDED" ]; then
+                # Confirm with the decisive signal before acting: if no watch at
+                # all has been checked recently, the workers really are stuck.
+                # floor: last_checked is a float, and bash compares integers only
+                newest=$(curl -fsS --max-time 30 "$CD_URL/api/v1/watch" -H "x-api-key: $token" 2>/dev/null \
+                           | jq -r '([.[].last_checked // 0] | max // 0) | floor')
+                now=$(date +%s)
+                if [ -n "$newest" ] && [ "$newest" -gt 0 ]; then
+                    idle_min=$(( (now - newest) / 60 ))
+                    if [ "$idle_min" -ge "$STALL_MINUTES" ]; then
+                        log "workers deadlocked: queue=$queue_size, no watch checked in ${idle_min}m — restarting $CD_CONTAINER and $SP_CONTAINER"
+                        # Restart the browser first so changedetection comes up
+                        # against a clean pool.
+                        running "$SP_CONTAINER" && docker restart "$SP_CONTAINER" >/dev/null 2>&1
+                        docker restart "$CD_CONTAINER" >/dev/null 2>&1 \
+                            && log "restarted $CD_CONTAINER" || log "WARNING: failed to restart $CD_CONTAINER"
+                        pool_strikes=0; pool_total=-1
+                        queue_strikes=0; queue_size_prev=-1
+                    else
+                        log "queue static but a watch was checked ${idle_min}m ago — treating as busy, not stalled"
+                        queue_strikes=0
+                    fi
+                fi
+            fi
+        fi
+    fi
+fi
+
+save_state "$pool_strikes" "$pool_total" "$queue_strikes" "$queue_size_prev"


### PR DESCRIPTION
Follow-up to #381. The watchdog it added reported the stack **healthy** while monitoring was completely stopped overnight.

## What happened

*Queued size* had climbed to **615** and nothing was draining. All three changedetection.io fetch workers claimed a browser-backed watch at 21:02 and never completed:

```text
21:02:21  Worker 0 processing watch aac632f2…   → never completed
21:02:23  Worker 2 processing watch 5b11abbf…   → never completed
21:02:28  Worker 1 processing watch 9ec0b9c4…   → never completed
```

After that the log is nothing but `Queued watch UUID …` with no matching `Worker N completed …`. **1502 of 1505 watches had gone unchecked for 6+ hours.**

A watch can hang inside Playwright past any timeout configured in the UI, and the worker that claimed it never picks up another job. With every worker stuck, the queue stops draining entirely — including plain-HTTP watches that never touch the browser at all.

## Why the existing watchdog missed it

Four browser slots had leaked (Chrome processes 15h, 15h, 5h, 5h old), but the pool holds five. The capacity check saw `4/5`, called it healthy, and never fired.

That's the real lesson: **a pure capacity check cannot see this failure.** The damaging condition is workers being stuck, not slots being full — and a partially leaked pool deadlocks every worker while still looking fine on capacity alone. The two conditions need independent checks.

## The fix

A second check, independent of the capacity check:

- A draining queue shrinks. When the queue is non-empty and hasn't shrunk across 3 consecutive polls, confirm with the decisive signal — the most recent `last_checked` across all watches. If nothing has been checked in 20 minutes, restart changedetection.io along with sockpuppetbrowser.
- If some watch *was* checked recently, the queue is merely busy and nothing is restarted. This matters during backlog catch-up, when the ticker legitimately enqueues faster than the workers drain — exactly the state the stack is in right now.

Also fixes an integer-comparison bug the tests caught: `last_checked` is a float, so it needs flooring before bash compares it.

## Verification

Both paths tested against stub endpoints and throwaway containers:

```text
queue not draining (505 -> 510) — strike 2/3
queue not draining (510 -> 515) — strike 3/3
workers deadlocked: queue=515, no watch checked in 60m — restarting cd-test and sp-test
PASS: deadlocked stack was restarted
```

```text
queue not draining (510 -> 515) — strike 3/3
queue static but a watch was checked 1m ago — treating as busy, not stalled
PASS: busy-but-progressing stack was NOT restarted
```

Recovery on the live stack: queue **615 → 248**, throughput steady at ~12 checks/min, most recent check consistently 0m old.

## Known trigger, not addressed here

**8 PDF-style watches are on the browser backend**, and one of them — `cityofsantamaria.org/home/showpublisheddocument/32758/…` — was among the three that deadlocked. Chrome's PDF viewer is a common place to hang.

PDFs don't need JavaScript rendering, and changedetection.io extracts PDF text directly over plain HTTP. Switching those 8 watches to *Basic fast Plaintext/HTTP Client* would likely remove the trigger, but that's a change to watch configuration rather than infrastructure, so it's left as a documented recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
