### PR TITLE
docs: record what switching the PDF watches actually fixed

### DIFF
--- a/monitoring/sockpuppet-watchdog.README.md
+++ b/monitoring/sockpuppet-watchdog.README.md
@@ -149,7 +149,18 @@ curl -s http://localhost:5000/api/v1/watch -H "x-api-key: $TOKEN" \
 ```
 
 PDFs do not need JavaScript rendering.
-Switching these watches to *Basic fast Plaintext/HTTP Client* both avoids the hang and lets changedetection.io extract the PDF text directly.
+Switching these watches to *Basic fast Plaintext/HTTP Client* is the right move regardless of whether the fetch then succeeds, because a plain-HTTP fetch fails in about a second instead of hanging a worker indefinitely.
+
+All 8 such watches were switched on 2026-08-08, with no regressions: every watch that worked before still works, and three of them now extract clean PDF text.
+The other five were already failing under the browser backend and still fail, but they can no longer deadlock the queue.
+Their causes were diagnosed as follows, and none is fixable by changing the fetch method:
+
+- **Cloudflare managed challenge** (`www4.courts.ca.gov`) — the response is the "Enable JavaScript and cookies to continue" interstitial.
+  Headless Chrome is flagged too, so no header set or fetch method gets past it.
+- **TLS-fingerprint blocking** (`showpublisheddocument` URLs on CivicPlus-hosted sites) — `curl` receives the PDF, while Python's `requests` gets a 403 with byte-identical headers, from the same machine.
+  The block keys on the HTTP client, not on the request.
+- **Server-side redirect loop** (`slofoodbank.org/.../2025/11/ENG_December_...pdf`) — the URL 301-redirects to itself.
+  A sibling file under a current path returns 200, so this is a stale URL rather than a fetch problem.
 
 ## Tuning
 


### PR DESCRIPTION
Follow-up to #382, which recommended moving document-style URLs off the browser backend. All 8 have now been switched. The recommendation was only half right, so this records the measured outcome rather than the prediction.

## Result: no regressions

| | Before (browser) | After (plain HTTP) |
|---|---|---|
| Working | 3 | 3 |
| Failing | 5 | 5 |

Every watch that worked before still works, and the three that work now extract clean PDF text — e.g. 40,320 characters of readable text from the Senior Connection subsidized-housing list, where the browser backend was rendering Chrome's PDF viewer.

The five that still fail were **already failing under the browser backend**, two of them with the identical error. The gain is not that they now succeed; it is that a plain-HTTP fetch fails in about a second instead of hanging a worker indefinitely. That removes the trigger for the deadlock in #382 — one of these URLs was among the three watches that froze the queue.

## Why the other five cannot be fixed by changing the fetch method

Diagnosed so nobody re-investigates them:

- **Cloudflare managed challenge** — `www4.courts.ca.gov` returns the "Enable JavaScript and cookies to continue" interstitial. Headless Chrome gets flagged too, which is why it was 403 on the browser backend as well.
- **TLS-fingerprint blocking** — the `showpublisheddocument` URLs (CivicPlus-hosted). `curl` receives the PDF; Python's `requests` gets a 403 with byte-identical headers, from the same machine. I bisected the headers first and found `Accept-Encoding` flipped curl from 403 to 200, but adding it to the watch changed nothing — the block keys on the HTTP client, not the request. The ineffective headers were removed rather than left behind implying a fix.
- **Server-side redirect loop** — `slofoodbank.org/.../2025/11/ENG_December_...pdf` 301-redirects to itself. A sibling file under a current path returns 200, so this is a stale URL rather than a fetch problem, and probably wants updating or removing as a source.

## Stack status

Queue **615 → 0**, zero watches overdue, backlog fully cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
