### PR TITLE
fix: correct dead source URLs found by change monitoring

### DIFF
--- a/Directory.md
+++ b/Directory.md
@@ -937,7 +937,7 @@
 
 ## <a id="Childrens-Resource-Network-of-the-Central-Coast">Children’s Resource Network of the Central Coast</a>
 
-- **Website:** [childrensresourcenetwork.org](https://www.childrensresourcenetwork.org) <!-- Not responsive on 29 Nov 2025 -->
+- **Website:** [childrensresourcenetwork.org](https://www.childrensresourcenetwork.org) <!-- Not responsive on 29 Nov 2025; still not responding on 8 Aug 2026 (connection times out). Consider removing the website line if it stays down. -->
 - **Location:** <a href="#" class="map-link" data-lat="35.111293" data-lon="-120.602116" data-zoom="17" data-label="Children’s Resource Network of the Central Coast">1212 Farroll Ave., Arroyo Grande</a> <!-- Location found at https://5chc.org/community-services/clothing -->
 - **Mailing address:** P.O. Box 454, Pismo Beach, CA 93448-0454
 - **Phone:** [805-709-8673](tel:+1-805-709-8673) <!-- Source: https://www.volunteerslo.org/agency/detail/?agency_id=31613 -->
@@ -1446,10 +1446,10 @@
 
 - **Website:** [https://www.frontporchslo.org/](https://www.frontporchslo.org/)
 - **Location:** <a href="#" class="map-link" data-lat="35.297443" data-lon="-120.660964" data-zoom="17" data-label="Front Porch">1468 E. Foothill, SLO</a> <!-- Source: https://www.frontporchslo.org/ -->
-- **Phone:** [818-731-4984](tel:+1-818-731-4984)
+- **Phone:** [805-316-4266](tel:+1-805-316-4266)
 - **Email:** [hello@frontporchslo.org](mailto:hello@frontporchslo.org) <!-- Source: https://www.frontporchslo.org/ -->
 - **Hours:** M–Th 7am–11pm, F 7am–4pm, Su 7am–6pm (depending on volunteer availability, likely closed during Cal Poly breaks) <!-- Source: visited in person and saw those hours taped to the door -->
-- **How to access:** oriented toward students from Cuesta College or Cal Poly, but “Whoever you are, you are welcome here” and “No matter what, you’re welcome here.” <!-- Source: https://www.frontporchslo.org/what-we-do and https://www.frontporchslo.org/ -->
+- **How to access:** oriented toward students from Cuesta College or Cal Poly, but “Everyone is welcome.” <!-- Source: https://www.frontporchslo.org/ -->
 
 ## <a id="GALA">GALA Pride & Diversity Center</a>
 
@@ -2946,9 +2946,10 @@ If you see one listed here that is no longer in service, please use the feedback
 
 ## <a id="St-Josephs-Church">Saint Joseph’s Church</a>
 
-- **Website:** [stjosephcayucos.org](https://stjosephcayucos.org/)
-- **Location:** <a href="#" class="map-link" data-lat="35.447245" data-lon="-120.897665" data-zoom="17" data-label="Saint Joseph’s Church">360 Park Ave., Cayucos</a> <!-- Source: https://www.dioceseofmonterey.org/parishfinder -->
-- **Phone:** [805-995-3243](tel:+1-805-995-3243) <!-- Source: https://www.dioceseofmonterey.org/parishfinder -->
+- **Website:** [saintjosephcayucos.org](https://www.saintjosephcayucos.org/) <!-- The former stjosephcayucos.org domain stopped resolving; the parish moved to saintjosephcayucos.org. Verified 8 Aug 2026. -->
+- **Location:** <a href="#" class="map-link" data-lat="35.447245" data-lon="-120.897665" data-zoom="17" data-label="Saint Joseph’s Church">360 Park Ave., Cayucos</a> <!-- Source: https://www.saintjosephcayucos.org/ -->
+- **Phone:** [805-995-3243](tel:+1-805-995-3243) <!-- Source: https://www.saintjosephcayucos.org/ -->
+- **Email:** [officeadmin@saintjosephcayucos.org](mailto:officeadmin@saintjosephcayucos.org) <!-- Source: https://www.saintjosephcayucos.org/ -->
 - **Hours** (food pantry): Fridays 10am–Noon, or Thursdays by appointment
 
 ## <a id="St-Patricks-Church">Saint Patrick’s Church</a>
@@ -3677,7 +3678,7 @@ If you see one listed here that is no longer in service, please use the feedback
 
 ## <a id="South-Bay-Seniors-People-Helping-People">South Bay Seniors People Helping People</a>
 
-- **Website:** [southbayseniorspeoplehelpingpeople.com](https://southbayseniorspeoplehelpingpeople.com/)
+- **Website:** [southbayseniorspeoplehelpingpeople.com](https://southbayseniorspeoplehelpingpeople.com/) <!-- Website returns a hosting "suspended page" as of 8 Aug 2026. The group itself is still operating; keep the phone, location, and hours, which come from southbaycommunitycenter.com. Re-check the website periodically. -->
 - **Location:** <a href="#" class="map-link" data-lat="35.312984" data-lon="-120.836284" data-zoom="17" data-label="South Bay Seniors People Helping People">2180 Palisades Ave., Los Osos</a> <!-- Source: https://southbaycommunitycenter.com/ -->
 - **Phone:** [805-528-2626](tel:+1-805-528-2626) <!-- Source: https://southbaycommunitycenter.com/ -->
 - **Hours:** M/W/F 9am–1pm <!-- Source: https://southbaycommunitycenter.com/ -->

--- a/Directory_es.md
+++ b/Directory_es.md
@@ -1203,7 +1203,7 @@
 
 ## <a id="Childrens-Resource-Network-of-the-Central-Coast">Children’s Resource Network of the Central Coast</a>
 
-- **Sitio web:** [childrensresourcenetwork.org](https://www.childrensresourcenetwork.org) <!-- Not responsive on 29 Nov 2025 -->
+- **Sitio web:** [childrensresourcenetwork.org](https://www.childrensresourcenetwork.org) <!-- Not responsive on 29 Nov 2025; still not responding on 8 Aug 2026 (connection times out). Consider removing the website line if it stays down. -->
 - **Ubicación:** <a href="#" class="map-link" data-lat="35.111293" data-lon="-120.602116" data-zoom="17" data-label="Children’s Resource Network of the Central Coast">1212 Farroll Ave., Arroyo Grande</a> <!-- Location found at https://5chc.org/community-services/clothing -->
 - **Dirección postal:** P.O. Box 454, Pismo Beach, CA 93448-0454
 - **Teléfono:** [805-709-8673](tel:+1-805-709-8673) <!-- Source: https://www.volunteerslo.org/agency/detail/?agency_id=31613 -->
@@ -1735,10 +1735,10 @@
 
 - **Sitio web:** [https://www.frontporchslo.org/](https://www.frontporchslo.org/)
 - **Ubicación:** <a href="#" class="map-link" data-lat="35.297443" data-lon="-120.660964" data-zoom="17" data-label="Front Porch">1468 E. Foothill, SLO</a> <!-- Source: https://www.frontporchslo.org/ -->
-- **Teléfono:** [818-731-4984](tel:+1-818-731-4984)
+- **Teléfono:** [805-316-4266](tel:+1-805-316-4266)
 - **Correo electrónico:** [hello@frontporchslo.org](mailto:hello@frontporchslo.org) <!-- Source: https://www.frontporchslo.org/ -->
 - **Horario:** L–J 7am–11pm, V 7am–4pm, D 7am–6pm (dependiendo de la disponibilidad de voluntarios; es probable que esté cerrado durante las vacaciones de Cal Poly.) <!-- Source: visited in person and saw those hours taped to the door -->
-- **Cómo obtener el servicio:** orientado a estudiantes de Cuesta College o Cal Poly, pero “Quienquiera que seas, eres bienvenido aquí” y “No importa qué, eres bienvenido aquí” <!-- Source: https://www.frontporchslo.org/what-we-do and https://www.frontporchslo.org/ -->
+- **Cómo obtener el servicio:** orientado a estudiantes de Cuesta College o Cal Poly, pero “Todos son bienvenidos.” <!-- Source: https://www.frontporchslo.org/ -->
 
 ## <a id="SLO-Noor-Foundation">La Fundación SLO Noor</a>
 
@@ -3019,9 +3019,10 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 
 ## <a id="St-Josephs-Church">Saint Joseph’s Church</a>
 
-- **Sitio web:** [stjosephcayucos.org](https://stjosephcayucos.org/)
-- **Ubicación:** <a href="#" class="map-link" data-lat="35.447245" data-lon="-120.897665" data-zoom="17" data-label="Saint Joseph’s Church">360 Park Ave., Cayucos</a> <!-- Source: https://www.dioceseofmonterey.org/parishfinder -->
-- **Teléfono:** [805-995-3243](tel:+1-805-995-3243) <!-- Source: https://www.dioceseofmonterey.org/parishfinder -->
+- **Sitio web:** [saintjosephcayucos.org](https://www.saintjosephcayucos.org/) <!-- The former stjosephcayucos.org domain stopped resolving; the parish moved to saintjosephcayucos.org. Verified 8 Aug 2026. -->
+- **Ubicación:** <a href="#" class="map-link" data-lat="35.447245" data-lon="-120.897665" data-zoom="17" data-label="Saint Joseph’s Church">360 Park Ave., Cayucos</a> <!-- Source: https://www.saintjosephcayucos.org/ -->
+- **Teléfono:** [805-995-3243](tel:+1-805-995-3243) <!-- Source: https://www.saintjosephcayucos.org/ -->
+- **Correo electrónico:** [officeadmin@saintjosephcayucos.org](mailto:officeadmin@saintjosephcayucos.org) <!-- Source: https://www.saintjosephcayucos.org/ -->
 - **Horario** (despensa de alimentos): los viernes 10am–mediodía, o los jueves con cita previa
 
 ## <a id="St-Patricks-Church">Saint Patrick’s Church</a>
@@ -3678,7 +3679,7 @@ Si ve uno listado aquí que ya no está en servicio, por favor use el botón de 
 
 ## <a id="South-Bay-Seniors-People-Helping-People">South Bay Seniors People Helping People</a>
 
-- **Sitio web:** [southbayseniorspeoplehelpingpeople.com](https://southbayseniorspeoplehelpingpeople.com/)
+- **Sitio web:** [southbayseniorspeoplehelpingpeople.com](https://southbayseniorspeoplehelpingpeople.com/) <!-- Website returns a hosting "suspended page" as of 8 Aug 2026. The group itself is still operating; keep the phone, location, and hours, which come from southbaycommunitycenter.com. Re-check the website periodically. -->
 - **Ubicación:** <a href="#" class="map-link" data-lat="35.312984" data-lon="-120.836284" data-zoom="17" data-label="South Bay Seniors People Helping People">2180 Palisades Ave., Los Osos</a> <!-- Source: https://southbaycommunitycenter.com/ -->
 - **Teléfono:** [805-528-2626](tel:+1-805-528-2626) <!-- Source: https://southbaycommunitycenter.com/ -->
 - **Horario:** L/Mi/V 9am–1pm <!-- Source: https://southbaycommunitycenter.com/ -->

--- a/Resource guide.md
+++ b/Resource guide.md
@@ -798,7 +798,7 @@ Note: Investigated “Westside Neighborhood Center” (805-897-2560) (October 20
 
 <!-- Sources
  ECHO, Refuge Church, PKGB, PKSLO (40 Prado): https://slofoodbank.org/wp-content/uploads/2026/05/ENG_June26_Distribution-ResourceList.pdf
- Front Porch: https://www.frontporchslo.org/wednesday-night-dinners
+ Front Porch: https://www.frontporchslo.org/events
  Los Osos Cares: https://www.losososcares.com/programs
  Morro Bay Lions: https://morrobaylions.org/2025/07/24/community-dinners-at-vets-hall/
  Blessed to Serve: SOURCE NEEDED

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -798,7 +798,7 @@ Note: Investigated “Westside Neighborhood Center” (805-897-2560) (October 20
 
 <!-- Sources
  ECHO, Refuge Church, PKGB, PKSLO (40 Prado): https://slofoodbank.org/wp-content/uploads/2026/05/ENG_June26_Distribution-ResourceList.pdf
- Front Porch: https://www.frontporchslo.org/wednesday-night-dinners
+ Front Porch: https://www.frontporchslo.org/events
  Los Osos Cares: https://www.losososcares.com/programs
  Morro Bay Lions: https://morrobaylions.org/2025/07/24/community-dinners-at-vets-hall/
  Blessed to Serve: SOURCE NEEDED


### PR DESCRIPTION
Auditing the 53 errors the changedetection.io instance was reporting turned up links in the guide that no longer work. This fixes the ones I could verify and dates the ones that need a human.

Kept separate from #383 (monitoring docs) because these are user-facing content changes that deploy on merge, so they deserve content review rather than infra review.

## Fixed

**Saint Joseph's Church, Cayucos** — `stjosephcayucos.org` no longer resolves *at all* (no DNS). The parish moved to `saintjosephcayucos.org`, spelled out. Updates the link, repoints the location and phone source annotations at the new site (which confirms both: 360 Park Ave., 805-995-3243), and adds the office email listed there.

**Front Porch** — `/wednesday-night-dinners` now 404s; `/events` carries the same information. Verified 200. Also updated the phone number and the published "Everyone is welcome" source.

## Annotated rather than changed

**South Bay Seniors People Helping People** — the website returns a hosting *suspended page*. The group is still operating, and the entry's phone, location, and hours all come from the South Bay Community Center site rather than the suspended one, so the entry stands with a note explaining the situation.

**Children's Resource Network** — already annotated as unresponsive in Nov 2025, still unresponsive. Added the current date so the next editor can judge whether the website line is worth keeping.

## Deliberately not touched

- **Modest Needs** — already commented out in the guide as `<!-- Appears to be defunct`, so the monitoring errors are just stale watches on content that isn't live.
- **Generation Build** — serves a parked `window.location.href="/lander"` redirect and appears defunct, but it isn't referenced anywhere in the guide. Stale watch only.

Spanish files updated in parallel. Per CONTRIBUTING, HTML comments are left in English. Pre-commit checks (translation sync, remark lint, spell check) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
