### PR TITLE
Add Ticket to Work email; use official Spanish program name

### DIFF
--- a/Resource guide.md
+++ b/Resource guide.md
@@ -3050,7 +3050,7 @@ They may also be able to assign you a “Benefits Arch Advocate” who can help 
 The government encourages you to seek work and to return to work without losing disability benefits.
 The [Ticket to Work Program](https://choosework.ssa.gov/) is a free, voluntary program for people aged 18–64 who are receiving SSDI or SSI benefits. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
 It gives you free career counseling, vocational rehabilitation, and job placement and training. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
-Call [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) to learn how to apply. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
+Call [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) or email [TicketToWork@ssa.gov](mailto:TicketToWork@ssa.gov) to learn how to apply. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
 
 If you are a U.S. military veteran, you may also qualify for other benefits.
 You can get help learning about, applying for, and receiving government benefits you are entitled to from the [**County Veterans Services Offices**](Directory.md#Veterans-Services).
@@ -3109,7 +3109,7 @@ They also conduct workshops on topics like job searching, building your resume, 
 #### For People with Disabilities
 
 If you are currently receiving SSDI or SSI benefits and you are between the ages of 18 and 64, the [Ticket to Work Program](https://choosework.ssa.gov/) can give you free career counseling, vocational rehabilitation, and job placement and training, and can help you return to work without losing your benefits. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
-Call [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) to learn how to apply. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
+Call [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) or email [TicketToWork@ssa.gov](mailto:TicketToWork@ssa.gov) to learn how to apply. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
 
 [**PathPoint**](Directory.md#PathPoint) helps people with intellectual or developmental disabilities to find jobs that are good matches for them, trains them in job skills, and helps them to maintain employment. <!-- Source: https://www.pathpoint.org/locations/san-luis-obispo/ -->
 

--- a/Resource guide_es.md
+++ b/Resource guide_es.md
@@ -3048,9 +3048,9 @@ También pueden asignarle un “Defensor de Beneficios” (Benefits Arch Advocat
 -->
 
 El gobierno le anima a buscar trabajo y a regresar al trabajo sin perder los beneficios por discapacidad.
-El [Programa Ticket to Work](https://choosework.ssa.gov/) es un programa gratuito y voluntario para personas de 18–64 años que están recibiendo beneficios de SSDI o SSI. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
+El [programa del Boleto para trabajar](https://choosework.ssa.gov/) (Ticket to Work) es un programa gratuito y voluntario para personas de 18–64 años que están recibiendo beneficios de SSDI o SSI. <!-- Source: https://choosework.ssa.gov/about/how-it-works --> <!-- Spanish program name per SSA: https://www.ssa.gov/faqs/es/questions/KA-01849.html -->
 Puede darle asesoramiento profesional gratuito, rehabilitación vocacional y colocación y capacitación laboral. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
-Llame al [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) para aprender cómo solicitar. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
+Llame al [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) o envíe un correo electrónico a [TicketToWork@ssa.gov](mailto:TicketToWork@ssa.gov) para aprender cómo solicitar. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
 
 Si es veterano militar de los Estados Unidos, también puede calificar para una variedad de otros beneficios.
 Puede obtener ayuda para informarse sobre, solicitar y recibir beneficios del gobierno a los que tiene derecho en las [**Oficinas de Servicios para Veteranos del Condado**](Directory.md#Veterans-Services) (County Veterans Services Offices).
@@ -3108,8 +3108,8 @@ También realizan talleres sobre temas como búsqueda de empleo, construcción d
 
 #### Para Personas con Discapacidades
 
-Si actualmente está recibiendo beneficios de SSDI o SSI y tiene entre 18 y 64 años, el [Programa Ticket to Work](https://choosework.ssa.gov/) puede darle asesoramiento profesional gratuito, rehabilitación vocacional, colocación y capacitación laboral, y puede ayudarle a regresar al trabajo sin perder sus beneficios. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
-Llame al [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) para aprender cómo solicitar. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
+Si actualmente está recibiendo beneficios de SSDI o SSI y tiene entre 18 y 64 años, el [programa del Boleto para trabajar](https://choosework.ssa.gov/) (Ticket to Work) puede darle asesoramiento profesional gratuito, rehabilitación vocacional, colocación y capacitación laboral, y puede ayudarle a regresar al trabajo sin perder sus beneficios. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
+Llame al [866-968-7842](tel:+1-866-968-7842) (TTY: [866-833-2967](tel:+1-866-833-2967)) o envíe un correo electrónico a [TicketToWork@ssa.gov](mailto:TicketToWork@ssa.gov) para aprender cómo solicitar. <!-- Source: https://choosework.ssa.gov/about/how-it-works -->
 
 [**PathPoint**](Directory.md#PathPoint) ayuda a personas con discapacidades intelectuales o del desarrollo a encontrar trabajos que sean buenas opciones para ellas, las capacita en habilidades laborales y les ayuda a mantener el empleo. <!-- Source: https://www.pathpoint.org/locations/san-luis-obispo/ -->
 


### PR DESCRIPTION
Adds the `TicketToWork@ssa.gov` contact address alongside the help line phone and TTY numbers, in both the SSDI/SSI benefits section and the employment section of the guide. The English edit was made by hand; this PR carries the matching change into the Spanish guide.

In `Resource guide_es.md`, the program is also renamed to SSA's official Spanish name, "el programa del Boleto para trabajar", with "Ticket to Work" kept in parentheses so readers can match it to the website and the phone menu. Source for the name: SSA's [Spanish FAQ](https://www.ssa.gov/faqs/es/questions/KA-01849.html) and their [Spanish brochure](https://yourtickettowork.ssa.gov/Assets/docs/about-ticket-to-work/ticket-mailings/2015-04-29_SpanishBrochure.pdf).

Notes:

- `https://choosework.ssa.gov/es/` returns 404 — SSA publishes no Spanish version of the Ticket to Work site, so the Spanish pages continue to link to the English URL.
- SSA's Spanish FAQ suggests callers can press 7 for Spanish, but that is not documented on the current choosework.ssa.gov contact page and is unverified. Deliberately left out: phone-tree menu positions change silently and aren't covered by the changedetection watches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)